### PR TITLE
Fix: guard against None contents in S3 download and upload listing

### DIFF
--- a/API/Classes/Base/SyncS3.py
+++ b/API/Classes/Base/SyncS3.py
@@ -56,12 +56,13 @@ class SyncS3():
                 kwargs.update({'ContinuationToken': next_token})
             results = client.list_objects_v2(**kwargs)
             contents = results.get('Contents')
-            for i in contents:
-                k = i.get('Key')
-                if k[-1] != '/':
-                    keys.append(k)
-                else:
-                    dirs.append(k)
+            if contents:
+                for i in contents:
+                    k = i.get('Key')
+                    if k[-1] != '/':
+                        keys.append(k)
+                    else:
+                        dirs.append(k)
             next_token = results.get('NextContinuationToken')
         for d in dirs:
             dest_pathname = os.path.join(local, d)

--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -41,12 +41,13 @@ def download_dir(prefix, local, bucket, client):
             kwargs.update({'ContinuationToken': next_token})
         results = client.list_objects_v2(**kwargs)
         contents = results.get('Contents')
-        for i in contents:
-            k = i.get('Key')
-            if k[-1] != '/':
-                keys.append(k)
-            else:
-                dirs.append(k)
+        if contents:
+            for i in contents:
+                k = i.get('Key')
+                if k and not k.endswith('/'):
+                    keys.append(k)
+                else:
+                    dirs.append(k)
         next_token = results.get('NextContinuationToken')
     for d in dirs:
         dest_pathname = os.path.join(local, d)


### PR DESCRIPTION
## Summary

- What changed:   Added `if contents:` guard before iterating over S3 `list_objects_v2` response in `SyncS3.downloadSync()` and the duplicated pagination logic in [UploadRoute.py](cci:7://file:///C:/Users/rajan/Desktop/GSOC/UN2/MUIOGO/API/Routes/Upload/UploadRoute.py:0:0-0:0). This prevents a `TypeError` crash when the S3 prefix matches no objects.

- Why:  AWS `list_objects_v2` omits the `Contents` key entirely (rather than returning an empty list) when no objects match. The code iterated directly over `None`, causing `TypeError: 'NoneType' is not iterable`.

## Related issues

- [x] Issue exists and is linked
- Closes #12 


## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

Tested with mock AWS responses simulating both normal and empty S3 results:
    === Testing with NORMAL response ===
      Keys: ['case1/data.json']
      Dirs: ['case1/subfolder/']
      PASSED
    === Testing with EMPTY response (the bug scenario) ===
      Keys: []
      Dirs: []
      PASSED
    === Proving the BUGGY version crashes ===
      Confirmed bug: 'NoneType' object is not iterable

## Documentation

- [x] Docs updated in this PR (or not applicable)
- [x] Any setup/workflow changes reflected in repo docs

No documentation changes needed — this is a bug fix with no API or workflow changes.

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x]Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)
