### PR TITLE
Improve server startup message for local development

### DIFF
--- a/API/app.py
+++ b/API/app.py
@@ -111,22 +111,18 @@ def setSession():
 
 
 if __name__ == '__main__':
-# if __name__ == 'app':
-    #potrebno radi module js importa u index.html ES6 modules
-    #Flask.__version__
     import mimetypes
     mimetypes.add_type('application/javascript', '.js')
+
     port = int(os.environ.get("PORT", 5002))
-    print("PORTTTTTTTTTTT")
-    if Config.HEROKU_DEPLOY == 0: 
-        #localhost
-        #app.run(host='127.0.0.1', port=port, debug=True)
-        #waitress server
-        #prod server
+
+    print(f"\nStarting MUIOGO server on http://127.0.0.1:{port}")
+    print("Press CTRL+C to stop the server\n")
+
+    if Config.HEROKU_DEPLOY == 0:
+        # Local development (Waitress)
         from waitress import serve
         serve(app, host='127.0.0.1', port=port)
     else:
-        #HEROKU
+        # Heroku deployment
         app.run(host='0.0.0.0', port=port, debug=True)
-        #app.run(host='127.0.0.1', port=port, debug=True)
-


### PR DESCRIPTION
This PR improves the local development startup experience.
Previously, running python API/app.py only printed PORTTTTTTTT, which made it unclear whether the server had started successfully. Since the application uses Waitress for local execution, no default Flask startup message was shown, causing confusion for new contributors.
This change replaces the debug output with a clear startup message displaying the server URL and keeps the existing behavior unchanged for both local and Heroku environments.

Changes made:
Removed confusing debug print statements
Added informative startup message indicating server address
Preserved existing Waitress and Heroku deployment logic
This helps contributors quickly confirm that the application is running correctly without affecting functionality.
<img width="557" height="213" alt="image" src="https://github.com/user-attachments/assets/8f44af94-6d1d-40e6-8d31-1fdb6cbe9ace" />
