### PR TITLE
Fix cross-platform runtime assumptions in API startup and frontend API resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 build/
 venv/
 venv
+.venv/
 API/__pycache__
 API/Classes/__pycache__
 API/Classes/Base/__pycache__

--- a/API/app.py
+++ b/API/app.py
@@ -1,6 +1,5 @@
 #import sys
 import os
-import sys
 
 from flask import Flask, jsonify, request, session, render_template
 from flask_cors import CORS
@@ -32,12 +31,6 @@ static_dir = os.path.abspath('WebAPP')
 
 # template_dir = 'WebAPP'
 # static_dir = '../WebAPP'
-
-print(template_dir)
-print(static_dir)
-print(sys.executable)
-
-print(__name__)
 
 app = Flask(__name__, static_url_path='', static_folder=static_dir,  template_folder=template_dir)
 
@@ -117,16 +110,30 @@ if __name__ == '__main__':
     import mimetypes
     mimetypes.add_type('application/javascript', '.js')
     port = int(os.environ.get("PORT", 5002))
-    print("PORTTTTTTTTTTT")
+
+    def print_startup_info(host, current_port, server_name):
+        mode = 'local' if Config.HEROKU_DEPLOY == 0 else 'heroku'
+        access_host = '127.0.0.1' if host == '0.0.0.0' else host
+        print("MUIOGO API starting...")
+        print(f"Server: {server_name}")
+        print(f"Mode: {mode}")
+        print(f"Host: {host}")
+        print(f"Port: {current_port}")
+        print(f"Open: http://{access_host}:{current_port}")
+
     if Config.HEROKU_DEPLOY == 0: 
         #localhost
         #app.run(host='127.0.0.1', port=port, debug=True)
         #waitress server
         #prod server
         from waitress import serve
-        serve(app, host='127.0.0.1', port=port)
+        host = '127.0.0.1'
+        print_startup_info(host, port, 'waitress')
+        serve(app, host=host, port=port)
     else:
         #HEROKU
-        app.run(host='0.0.0.0', port=port, debug=True)
+        host = '0.0.0.0'
+        print_startup_info(host, port, 'flask-dev')
+        app.run(host=host, port=port, debug=True)
         #app.run(host='127.0.0.1', port=port, debug=True)
 

--- a/WebAPP/Classes/Base.Class.js
+++ b/WebAPP/Classes/Base.Class.js
@@ -9,15 +9,10 @@ export class Base {
     static INIT_SYNC = 1;
 
     static apiUrl() {
-        let apiUrl
-        if (this.HEROKU == 0) {
-            //localhost
-            apiUrl = "http://127.0.0.1:5002/";
-        } else {
-            //HEROKU
-            apiUrl = "https://osemosys.herokuapp.com/";
+        if (this.HEROKU == 1) {
+            return "https://osemosys.herokuapp.com/";
         }
-        return apiUrl
+        return `${window.location.origin}/`;
     }
 
     static initSyncS3() {

--- a/WebAPP/index.html
+++ b/WebAPP/index.html
@@ -31,7 +31,6 @@
 		
 		 <script src="References/wijmo/controls/wijmo.odata.min.js"></script>
 		 <script src="References/wijmo/controls/wijmo.olap.min.js"></script>
-		<script src="References/wijmo/licence.js"></script>
 		<script src="References/jszip/jszip.min.js"></script>
 
 		<!-- plotly -->


### PR DESCRIPTION
## Summary

- What changed:
  - Updated frontend API base URL resolution to use runtime origin in local/dev mode, improving compatibility in Codespaces and preview URLs.
  - Removed the missing Wijmo license script include from the web entry page to prevent 404 + MIME console failures.
  - Replaced vague backend startup debug prints with clear startup info showing server, mode, host, port, and open URL.
  - Files touched: [app.py], [Base.Class.js], [index.html]

- Why:
  - The previous runtime configuration relied on environment-specific assumptions (e.g., localhost API binding and implicit runtime dependencies), which reduced portability and created onboarding friction.
  - These improvements ensure platform-independent startup behavior, improve runtime observability, and support the cross-platform goals of the MUIO refactoring effort.
  - To reduce platform-dependent runtime assumptions and improve cross-platform contributor experience, aligned with platform-independence goals.


## Related issues

- [x] Issue exists and is linked
- Closes #25 
- Related #3 

## Validation

- [x] Validation steps documented

     1. Start API: python [app.py](https://github.com/user-attachments/files/25526954/app.py)
     2. Confirm startup output includes host/port/open URL.
     3. Open app in browser and verify page loads without missing licence.js console errors.
     4. Verify API calls resolve from current origin (no hardcoded localhost dependency in frontend runtime path).
- [x] Evidence attached (logs/screenshots/output as relevant)
Before:
<img width="1365" height="492" alt="Screenshot 2026-02-23 192214" src="https://github.com/user-attachments/assets/98f620ff-2322-4fa0-b4e0-b2f876430d11" />
<img width="555" height="105" alt="image" src="https://github.com/user-attachments/assets/155f07f3-b67d-41ba-b5fd-ecdd13a0951a" />

After:
<img width="1365" height="632" alt="image" src="https://github.com/user-attachments/assets/0fa5a73e-a716-4fd4-9b8a-8a2b5ef99f67" />
<img width="572" height="117" alt="image" src="https://github.com/user-attachments/assets/5cf3b8f0-dd21-4eec-a584-80107fbf5f3e" />

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

Can you please review these changes and merge it @SeaCelo @autibet @NyeinChan85 ?