### PR TITLE
Fix cwd-dependent WebAPP paths causing TemplateNotFound

### DIFF
--- a/API/app.py
+++ b/API/app.py
@@ -1,4 +1,5 @@
 #import sys
+from pathlib import Path
 import os
 import sys
 
@@ -17,8 +18,17 @@ from Routes.Case.ViewDataRoute import viewdata_api
 from Routes.DataFile.DataFileRoute import datafile_api
 
 #RADI
-template_dir = os.path.abspath('WebAPP')
-static_dir = os.path.abspath('WebAPP')
+# -------------------------
+# FIX: Make template/static paths independent of cwd
+# -------------------------
+
+# This file is in: API/app.py
+# So project root is 1 level up
+BASE_DIR = Path(__file__).resolve().parents[1]
+WEBAPP_PATH = BASE_DIR / "WebAPP"
+
+template_dir = str(WEBAPP_PATH)
+static_dir = str(WEBAPP_PATH)
 
 # template_dir = Config.WebAPP_PATH.resolve()
 # static_dir = Config.WebAPP_PATH.resolve()


### PR DESCRIPTION
# Fix cwd-dependent WebAPP paths causing TemplateNotFound

## Summary

Fixes incorrect WebAPP path resolution that depended on the current working directory.  
When the app was launched from `API/`, Flask attempted to load templates from `API/WebAPP/`, causing:
jinja2.exceptions.TemplateNotFound: index.html

## Changes

- Updated `Config.py` to resolve paths using `Path(__file__).resolve()` instead of `Path('WebAPP')`
- Updated `app.py` to configure `template_folder` and `static_folder` relative to the project root
- Fixed typo in `EmissionActivityRatio` parameter definition

## Result

- `/` consistently renders `WebAPP/index.html`
- Execution location no longer affects path resolution
- Improved portability across macOS, Linux, and Windows