### PR TITLE
Added structured startup validation for runtime dependencies (Issue #3)

### DIFF
--- a/API/Classes/Base/Config.py
+++ b/API/Classes/Base/Config.py
@@ -26,23 +26,6 @@ ALLOWED_EXTENSIONS_XLS = set(['xls', 'xlsx'])
 # This file is in: API/Classes/Base/Config.py
 # So project root is 3 levels up
 BASE_DIR = Path(__file__).resolve().parents[3]
-<<<<<<< HEAD
-=======
-
-WEBAPP_PATH = BASE_DIR / "WebAPP"
-
-UPLOAD_FOLDER = WEBAPP_PATH
-DATA_STORAGE = WEBAPP_PATH / "DataStorage"
-CLASS_FOLDER = WEBAPP_PATH / "Classes"
-SOLVERs_FOLDER = WEBAPP_PATH / "SOLVERs"
-EXTRACT_FOLDER = BASE_DIR
-
-# Ensure DataStorage exists before chmod
-DATA_STORAGE.mkdir(parents=True, exist_ok=True)
-# os.chmod(DATA_STORAGE, 0o777)
-if DATA_STORAGE.exists() and os.environ.get("ENV", "production") == "development":
-    os.chmod(DATA_STORAGE, 0o755)
->>>>>>> 7c80f7b1 (Align startup validation with merged path/solver logic (local-first resolution + Config-based paths))
 
 WEBAPP_PATH = BASE_DIR / "WebAPP"
 
@@ -67,14 +50,6 @@ if not os.access(DATA_STORAGE, os.W_OK):
 # EXTRACT_FOLDER = Path(OSEMOSYS_ROOT, "")
 # SOLVERs_FOLDER = Path(OSEMOSYS_ROOT, 'WebAPP', 'SOLVERs')
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-# os.chmod(DATA_STORAGE, 0o777)
-
->>>>>>> 725648bc (Fix config issues: correct EmissionActivityRatio typo, remove duplicate keys, and refine DATA_STORAGE permission handling)
-=======
->>>>>>> 839a565c (Apply startup validation changes)
 HEROKU_DEPLOY = 0
 AWS_SYNC = 0
 
@@ -87,87 +62,6 @@ EMIS_GROUPS = ('RYE', 'RYTE', 'RYTEM')
 SINGLE_TECH_GROUPS = ['RT']
 SINGLE_EMIS_GROUPS = ['RE']
 
-<<<<<<< HEAD
-=======
-DEFAULT_F ={
-    "R"    : 'default_R',     
-    "RT"   : 'default_RT',     
-    "RY"   : 'default_RY',     
-    "RE"   : 'default_RE',  
-    "RS"   : 'default_RS', 
-    "RYCn" : 'default_RYCn', 
-    "RYTs" : 'default_RYTs', 
-    "RYDtb" : 'default_RYDtb',  
-    "RYSeDt" : 'default_RYSeDt',   
-    "RYT"  : 'default_RYT',
-    "RYS"  : 'default_RYS',
-    "RYTCn": 'default_RYTCn',    
-    "RYTM" : 'default_RYTM',     
-    "RYC"  : 'default_RYC',     
-    "RYE"  : 'default_RYE',     
-    "RYTC" : 'default_RYTC',  
-    "RYTCM": 'default_RYTCM' , 
-    "RTSM": 'default_RTSM' ,   
-    "RYTE" : 'default_RYTE',  
-    "RYTEM": 'default_RYTEM' , 
-    # "RYTM" : 'default_RYTM',     
-    "RYTTs": 'default_RYTTs',     
-    "RYCTs": 'default_RYCTs'
-}
-
-UPDATE_F ={
-    "R"    : 'update_R',     
-    "RT"   : 'update_RT',     
-    "RY"   : 'update_RY',     
-    "RE"   : 'update_RE', 
-    "RS"   : 'update_RS',
-    "RYCn" : 'update_RYCn',
-    "RYTs" : 'update_RYTs', 
-    "RYDtb" : 'update_RYDtb', 
-    "RYSeDt" : 'update_RYSeDt',    
-    "RYT"  : 'update_RYT', 
-    "RYS"  : 'update_RYS',  
-    "RYTCn": 'update_RYTCn',
-    "RYTM" : 'update_RYTM',     
-    "RYC"  : 'update_RYC',     
-    "RYE"  : 'update_RYE',     
-    "RYTC" : 'update_RYTC',  
-    "RYTCM": 'update_RYTCM' ,  
-    "RTSM": 'update_RTSM' ,   
-    "RYTE" : 'update_RYTE',  
-    "RYTEM": 'update_RYTEM' , 
-    # "RYTM" : 'update_RYTM',     
-    "RYTTs": 'update_RYTTs',     
-    "RYCTs": 'update_RYCTs'
-}
-
-GEN_F ={
-    "R"    : 'gen_R',   
-    "RT"   : 'gen_RT',     
-    "RY"   : 'gen_RY',     
-    "RE"   : 'gen_RE', 
-    "RS"   : 'gen_RS',
-    "RYCn" : 'gen_RYCn', 
-    "RYTCn": 'gen_RYTCn',   
-    "RYTs" : 'gen_RYTs',  
-    "RYDtb" : 'gen_RYDtb',  
-    "RYSeDt" : 'gen_RYSeDt',   
-    "RYT"  : 'gen_RYT', 
-    "RYS"  : 'gen_RYS', 
-    "RYTM" : 'gen_RYTM',     
-    "RYC"  : 'gen_RYC',     
-    "RYE"  : 'gen_RYE',     
-    "RYTC" : 'gen_RYTC',  
-    "RYTCM": 'gen_RYTCM' , 
-    "RTSM": 'gen_RTSM' ,  
-    "RYTE" : 'gen_RYTE',  
-    "RYTEM": 'gen_RYTEM' , 
-    # "RYTM" : 'gen_RYTM',     
-    "RYTTs": 'gen_RYTTs',     
-    "RYCTs": 'gen_RYCTs'
-}
-
->>>>>>> 725648bc (Fix config issues: correct EmissionActivityRatio typo, remove duplicate keys, and refine DATA_STORAGE permission handling)
 #full var list 38
 VARIABLES_C = {
         'NewCapacity':['r','t','y'],

--- a/API/app.py
+++ b/API/app.py
@@ -7,6 +7,8 @@ from flask_cors import CORS
 from datetime import timedelta
 from pathlib import Path
 # from pathlib import Path
+from startup_validation import run_startup_checks, StartupValidationError
+
 
 #import json
 from Classes.Base import Config
@@ -123,8 +125,6 @@ if __name__ == '__main__':
     import mimetypes
     mimetypes.add_type('application/javascript', '.js')
     port = int(os.environ.get("PORT", 5002))
-<<<<<<< HEAD
-<<<<<<< HEAD
 
     def print_startup_info(host, current_port, server_name):
         mode = 'local' if Config.HEROKU_DEPLOY == 0 else 'heroku'
@@ -136,20 +136,12 @@ if __name__ == '__main__':
         print(f"Port: {current_port}")
         print(f"Open: http://{access_host}:{current_port}")
 
-=======
-    
-=======
->>>>>>> 7c80f7b1 (Align startup validation with merged path/solver logic (local-first resolution + Config-based paths))
-    from startup_validation import run_startup_checks, StartupValidationError
     try:
         run_startup_checks()
     except StartupValidationError as e:
         print(str(e))
         exit(1)
-<<<<<<< HEAD
-    print("PORTTTTTTTTTTT")
->>>>>>> e4c46816 (Add structured startup validation for solvers and required directories (Issue #3))
-=======
+
 
     def print_startup_info(host, current_port, server_name):
         mode = 'local' if Config.HEROKU_DEPLOY == 0 else 'heroku'
@@ -161,7 +153,6 @@ if __name__ == '__main__':
         print(f"Port: {current_port}")
         print(f"Open: http://{access_host}:{current_port}")
 
->>>>>>> 839a565c (Apply startup validation changes)
     if Config.HEROKU_DEPLOY == 0: 
         #localhost
         #app.run(host='127.0.0.1', port=port, debug=True)


### PR DESCRIPTION
## Summary
Added a structured startup validation for deterministic runtime prerequisites, addressing the “Add startup validation with clear errors when required binaries/paths are missing” portion of Issue #3.
Additionally, during validation testing, it was observed that `Config.py` unconditionally set `DATA_STORAGE` permissions to `0o777`, which masked permission-related behavior. 
This has been refined to avoid overriding environment-level permissions.

This PR introduces a pre-startup validation layer that ensures required directories and solver binaries are available before the server starts, providing clear and actionable feedback instead of runtime crashes.

- What changed:
  1. Added `API/startup_validation.py`
  2. Integrated validation call before server startup in `API/app.py`
  3. Validation now checks:
    - `DATA_STORAGE` existence and write permissions
    - `WebAPP` directory existence
    - GLPK (`glpsol`) availability via PATH
    - CBC availability via PATH
    - Solver executability
    - Basic version detection where possible
    - OS-specific installation hints
  4. Structured validation summary output
  5. Clean exit on failure (no traceback)
  6. Minor Config.py corrections (identified during validation testing):
  - Fixed typo in EmissionActivityRatio parameter definition
  - Removed duplicate dictionary keys causing silent overwrites
  - Refined `DATA_STORAGE` permission handling:
    - Removed unconditional `0o777` permission override
    - Applied environment-specific (development-only) permission adjustment
    - Prevented masking of permission validation behaviour

- Why:
  Previously, missing solver binaries or required directories could cause unclear runtime failures or crashes before meaningful feedback was shown.  
  While validating write-permission behavior, it was discovered that `Config.py` was unconditionally modifying directory permissions at import time. This masked expected validation outcomes and could override externally configured permissions. The logic has been adjusted to ensure predictable behavior while maintaining development usability.
  This change ensures early, deterministic cross-platform failure detection without modifying existing runtime or path resolution logic.


## Related issues

- [x] Issue exists and is linked
- Closes #97 
- Related to #3 

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

Validation Steps:

1. Normal startup (all dependencies installed)
   - From repository root:
     ```bash
     python API/app.py
     ```
   - Expected:
     - Structured startup validation summary
     - All checks report `OK`
     - Server starts normally
   <img width="496" height="134" alt="image" src="https://github.com/user-attachments/assets/40bc2982-fd7d-483a-9a46-ab979d9896e0" />


2. Run from a different working directory
   - From inside `API/`:
     ```bash
     cd API
     python app.py
     ```
   - Expected:
     - A validation output mentioning the error to run from the correct directory
Note: Running the application from a non-root working directory may still trigger existing path-resolution errors in Config.py. This is part of the broader path refactor tracked under Issue #3 and is not modified in this PR.
   <img width="741" height="179" alt="image" src="https://github.com/user-attachments/assets/27da961c-f8db-4659-bdc7-969ed71b9463" />
   <img width="508" height="67" alt="image" src="https://github.com/user-attachments/assets/2fa3ee28-20dc-44e4-a352-22f7202da206" />


3. Missing solver simulation
   - Temporarily clear PATH (macOS/Linux):
     ```bash
     PATH="" .venv/bin/python API/app.py
     ```
   - Expected:
     - GLPK and/or CBC reported as `FAIL`
     - Clear OS-specific installation hint
     - Clean exit (no traceback)
   <img width="585" height="138" alt="image" src="https://github.com/user-attachments/assets/263ac52b-4c96-438b-8131-f04836ffb14f" />


4. Missing WebAPP directory simulation
   - Temporarily rename directory:
     ```bash
     mv WebAPP WebAPP_backup
     python API/app.py
     ```
   - Expected:
     - `WebAPP directory` reported as `FAIL`
     - Structured summary printed
     - Clean exit
   - Restore directory after test:
     ```bash
     mv WebAPP_backup WebAPP
     ```
   <img width="678" height="163" alt="image" src="https://github.com/user-attachments/assets/aa48d41e-66d0-4787-9495-73d63f7c6e4f" />
   <img width="552" height="53" alt="image" src="https://github.com/user-attachments/assets/10bcf9eb-935f-4133-aa07-908c603a653c" />



**Permission behaviour validation**
1. Development environment: 
     ```
     export ENV=development
     chmod 555 WebAPP/DataStorage
     python API/app.py
     ```
     Expected:
      - Folder permissions adjusted to 755
      - Validation succeeds
      - Application starts normally
    <img width="522" height="255" alt="image" src="https://github.com/user-attachments/assets/6695309a-22e7-48ce-aad6-e95faddcfcec" />


2. Production/default environment:
     ```
     unset ENV
     chmod 555 WebAPP/DataStorage
     python API/app.py
     ```
     Expected:
      - Permissions not overridden
      - Validation correctly reports write-permission failure (if applicable)
    - No silent permission modification occurs
    <img width="511" height="271" alt="image" src="https://github.com/user-attachments/assets/4474e70b-a6d7-4f6c-9260-99c0a6ec9b42" />


3. Change path of DataStorage:
    <img width="478" height="168" alt="image" src="https://github.com/user-attachments/assets/55e15578-e13b-4e58-b7cb-d714245354c8" />


## Documentation

- [x] Docs updated in this PR (or not applicable)
- [x] Any setup/workflow changes reflected in repo docs

No external documentation changes required — internal validation layer only

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)
