### PR TITLE
fix: replace hardcoded Windows path separators with os.sep (#34)

### DIFF
--- a/API/Classes/Base/SyncS3.py
+++ b/API/Classes/Base/SyncS3.py
@@ -74,7 +74,7 @@ class SyncS3():
             client.download_file(bucket, k, dest_pathname)
 
     #s3.uploadSync(localDir, case, Config.S3_BUCKET, '*')
-    def uploadSync(self, localDir, awsInitDir, bucketName, tag, prefix='\\'):
+    def uploadSync(self, localDir, awsInitDir, bucketName, tag, prefix=os.sep):
         """
         from current working directory, upload a 'localDir' with all its subcontents (files and subdirectories...)
         to a aws bucket
@@ -103,7 +103,7 @@ class SyncS3():
                 fileName = str(FullfileName).replace(str(localDir), '')
                 if fileName.startswith(prefix):  # only modify the text if it starts with the prefix
                     fileName = fileName.replace(prefix, "", 1) # remove one instance of prefix
-                    fileName = fileName.replace('\\', '/')
+                    fileName = fileName.replace(os.sep, '/')
 
                 awsPath = str(awsInitDir) + '/' + str(fileName)
                 resource.meta.client.upload_file(FullfileName, bucketName, awsPath)
@@ -130,7 +130,7 @@ class SyncS3():
         """
         resource = self.resource
         fileName = localFile.name
-        localFile = str(localFile).replace('\\', '/')
+        localFile = str(localFile).replace(os.sep, '/')
         if awsInitDir != '':
             awsPath = str(awsInitDir) + '/' + str(fileName)
         else:

--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -58,7 +58,7 @@ def download_dir(prefix, local, bucket, client):
             os.makedirs(os.path.dirname(dest_pathname))
         client.download_file(bucket, k, dest_pathname)
 
-def upload_dir(s3, localDir, awsInitDir, bucketName, tag, prefix='\\'):
+def upload_dir(s3, localDir, awsInitDir, bucketName, tag, prefix=os.sep):
     """
     from current working directory, upload a 'localDir' with all its subcontents (files and subdirectories...)
     to a aws bucket
@@ -87,7 +87,7 @@ def upload_dir(s3, localDir, awsInitDir, bucketName, tag, prefix='\\'):
             fileName = str(FullfileName).replace(str(localDir), '')
             if fileName.startswith(prefix):  # only modify the text if it starts with the prefix
                 fileName = fileName.replace(prefix, "", 1) # remove one instance of prefix
-                fileName = fileName.replace('\\', '/')
+                fileName = fileName.replace(os.sep, '/')
 
             awsPath = str(awsInitDir) + '/' + str(fileName)
             # S3.resource.meta.client.upload_file(FullfileName, bucketName, awsPath)


### PR DESCRIPTION
# Closes #34

## Summary

Replaces all hardcoded Windows-style backslash path separators (`'\\'`) with `os.sep` from the Python standard library in the S3 upload logic.

This is a non-breaking fix that advances the project's stated goal of platform-independence.

---

## Changes

### `API/Classes/Base/SyncS3.py`

- `uploadSync()`
  - Default `prefix` parameter changed from `'\\'` to `os.sep`
- `uploadSync()`
  - `fileName.replace('\\', '/')` → `fileName.replace(os.sep, '/')`
- `updateSync()`
  - `localFile.replace('\\', '/')` → `localFile.replace(os.sep, '/')`

---

### `API/Routes/Upload/UploadRoute.py`

- `upload_dir()`
  - Default `prefix` parameter changed from `'\\'` to `os.sep`
- `upload_dir()`
  - `fileName.replace('\\', '/')` → `fileName.replace(os.sep, '/')`

---

## Notes

- `os` is already imported in both files — zero new dependencies introduced.
- `os.sep` evaluates to `'\\'` on Windows, so existing Windows behaviour is completely unchanged.
- On macOS and Linux, `os.sep` correctly evaluates to `'/'`, fixing silent failures in S3 path construction on those platforms.
- Directly addresses the constraint listed in `docs/ARCHITECTURE.md`:

> "Hardcoded or relative path assumptions exist and reduce portability."

---

## Testing

- Verified that `os.sep` resolves to `'\\'` on Windows (behaviour preserved).
- Verified that logic using `startswith(prefix)` and `replace(prefix, "", 1)` behaves identically when `prefix=os.sep`.
- Confirmed correct S3 key generation on macOS/Linux environments.
- Confirmed no regression in existing upload functionality.