### PR TITLE
Fix: Prevent null casename fetch calls after model deletion or selection (Closes #39)

### DIFF
--- a/WebAPP/Classes/Osemosys.Class.js
+++ b/WebAPP/Classes/Osemosys.Class.js
@@ -360,19 +360,35 @@ export class Osemosys {
     //     .catch(error => error);
     // }
 
-    static getData(casename, dataJson) {
-        // return fetch('../../DataStorage/'+casename+'/'+dataJson, {cache: "no-store"})
-        // .then(response => response.json())
-        // .catch(error => error);
+    // static getData(casename, dataJson) {
+    //     // return fetch('../../DataStorage/'+casename+'/'+dataJson, {cache: "no-store"})
+    //     // .then(response => response.json())
+    //     // .catch(error => error);
 
+    //     return fetch('../../DataStorage/'+casename+'/'+dataJson, {cache: "no-store"}) 
+    //         .then((response) => {
+    //             if (response.ok) {
+    //                 //console.log('response1 ', response)
+    //                 //console.log('data ', response.json())
+    //             return response;
+    //             }
+    //             throw new Error('No casename selecetd');
+    //         })
+    //         .then(response => response.json())
+    //         .catch(error => null);
+    // }
+
+    static getData(casename, dataJson) {
+        if (!casename || casename === "null") {
+            console.warn("getData called without valid casename");
+            return Promise.resolve(null);
+        }
         return fetch('../../DataStorage/'+casename+'/'+dataJson, {cache: "no-store"}) 
             .then((response) => {
                 if (response.ok) {
-                    //console.log('response1 ', response)
-                    //console.log('data ', response.json())
-                return response;
+                    return response;
                 }
-                throw new Error('No casename selecetd');
+                throw new Error('Invalid casename');
             })
             .then(response => response.json())
             .catch(error => null);
@@ -396,28 +412,44 @@ export class Osemosys {
         });
     }
 
-    static getResultData(casename, dataJson) {
-        // return new Promise((resolve, reject) => {
-        //     fetch('../../DataStorage/'+casename+'/view/' +dataJson, {cache: "no-store"})
-        //     .then(DATA => {
-        //         DATA = DATA.json();
-        //         resolve(DATA);
-        //     })
-        //     .catch(error => {
-        //         if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-        //         reject(error);
-        //     });
-        // });
+    // static getResultData(casename, dataJson) {
+    //     // return new Promise((resolve, reject) => {
+    //     //     fetch('../../DataStorage/'+casename+'/view/' +dataJson, {cache: "no-store"})
+    //     //     .then(DATA => {
+    //     //         DATA = DATA.json();
+    //     //         resolve(DATA);
+    //     //     })
+    //     //     .catch(error => {
+    //     //         if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
+    //     //         reject(error);
+    //     //     });
+    //     // });
 
+    //     return fetch('../../DataStorage/'+casename+'/view/' +dataJson, {cache: "no-store"})
+    //         .then((response) => {
+    //             if (response.ok) {
+    //                 //console.log('response1 ', response)
+    //                 return response;
+    //             }
+    //             throw new Error('No casename selecetd');
+    //         })
+    //         .then(response =>  response.json())
+    //         .catch(error => null);
+    // }
+
+    static getResultData(casename, dataJson) {
+        if (!casename || casename === "null") {
+            console.warn("getResultData called without valid casename");
+            return Promise.resolve(null);
+        }
         return fetch('../../DataStorage/'+casename+'/view/' +dataJson, {cache: "no-store"})
             .then((response) => {
                 if (response.ok) {
-                    //console.log('response1 ', response)
                     return response;
                 }
-                throw new Error('No casename selecetd');
+                throw new Error('Invalid casename');
             })
-            .then(response =>  response.json())
+            .then(response => response.json())
             .catch(error => null);
     }
 


### PR DESCRIPTION
## Summary

- What changed:
Added validation to prevent frontend from fetching genData.json and resData.json when no valid model (casename) is selected or when a model is deleted.
Specifically:
Added guard clause in:
  - Osemosys.Class.js → getData()
  - Osemosys.Class.js → getResultData()
Prevents fetch execution when casename is null or undefined.

- Why:
When no model is selected (e.g., immediately after deleting a model) or a model is deleted, the frontend attempted to fetch:
`/DataStorage/null/genData.json
/DataStorage/null/view/resData.json`
This resulted in:
  - 404 NOT FOUND errors
  - Silent null responses
  - Inconsistent UI state
  - Network tab errors
The root cause was lack of validation before constructing fetch paths using casename.
This PR ensures deterministic behavior and prevents invalid network requests.

## Related issues

- [x] Issue exists and is linked
- Closes #39 
- Related #

## Validation

- [ ] Tests added/updated (or not applicable)- Not applicable (frontend guard fix)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

**Validation steps:**

1. Create model → Navigate to Configure →
  - genData.json loads (200)
  - resData.json loads (200)

2. Delete model → Navigate to Configure →
  - No request made to /DataStorage/null/...
  - No 404 errors in Network tab
  - UI remains stable

3. Open app without selecting model →
  - No invalid fetch requests executed
 
a. On creating a new model:
<img width="1309" height="701" alt="image" src="https://github.com/user-attachments/assets/a6674296-f0ff-4ed0-bdda-e743f066bad5" />
b. On deleting an existing model:
<img width="1307" height="690" alt="image" src="https://github.com/user-attachments/assets/9b97ea37-0c6a-413a-9474-37fce22bffc4" />
c. On selecting different model:
<img width="1345" height="705" alt="image" src="https://github.com/user-attachments/assets/ca9a62a1-6910-43cd-8dc8-09860d3e06a5" />




## Documentation

- [ ] Docs updated in this PR (or not applicable)- Not applicable
- [ ] Any setup/workflow changes reflected in repo docs- No

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)
