### PR TITLE
fix: resolve solver paths via env var / PATH / bundled fallback (#43)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,6 +44,20 @@ Solver execution is handled by backend subprocess calls (GLPK/CBC).
 These constraints are tracked as implementation issues and should be addressed
 incrementally with tested changes.
 
+### Solver resolution
+
+Solver binaries (GLPK / CBC) are resolved at runtime using a three-tier
+priority chain implemented in `Osemosys._resolve_solver_folder`:
+
+1. **Environment variable** — `SOLVER_GLPK_PATH` or `SOLVER_CBC_PATH`
+2. **System PATH** — via `shutil.which` (supports package-manager installs)
+3. **Bundled fallback** — folder inside `Config.SOLVERs_FOLDER`
+
+If no solver is found through any of these steps, a `RuntimeError` is raised
+at startup with a clear, actionable message. This replaces the previous
+hardcoded, platform-specific path strings which failed silently on
+Linux and Apple Silicon (see issue #43).
+
 ## Upstream/downstream relationship
 
 - Upstream reference: `OSeMOSYS/MUIO`


### PR DESCRIPTION
## Summary
Replaces hardcoded, platform-specific solver binary paths in `OsemosysClass.__init__`
with a portable three-tier resolution chain: environment variable → system PATH → bundled fallback.

## Changes
- [API/Classes/Case/OsemosysClass.py](cci:7://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/Classes/Case/OsemosysClass.py:0:0-0:0): removed `if platform.system()` block, added [_resolve_solver_folder](cci:1://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/Classes/Case/OsemosysClass.py:87:4-109:9) static method
- [docs/ARCHITECTURE.md](cci:7://file:///e:/United%20Nations/MUIOGO/MUIOGO/docs/ARCHITECTURE.md:0:0-0:0): documented the new solver resolution behaviour

## Verification
Tested resolution chain manually — all cases (env override, bundled fallback, RuntimeError) pass.

Closes #43
