### PR TITLE
fix: propagate exceptions from CustomThread to caller on join() (#45)

### DIFF
--- a/API/Classes/Base/CustomThreadClass.py
+++ b/API/Classes/Base/CustomThreadClass.py
@@ -1,16 +1,24 @@
+import sys
 from collections.abc import Callable, Iterable, Mapping
 from threading import Thread
 from typing import Any
+
 
 class CustomThread(Thread):
     def __init__(self, group=None, target=None, name=None, args=(), kwargs={}, Verbose=None):
         Thread.__init__(self, group, target, name, args, kwargs)
         self._return = None
+        self._exc_info = None  # captures exception if thread crashes
 
     def run(self):
         if self._target is not None:
-            self._return = self._target(*self._args, **self._kwargs)
+            try:
+                self._return = self._target(*self._args, **self._kwargs)
+            except Exception:
+                self._exc_info = sys.exc_info()
 
     def join(self):
         Thread.join(self)
+        if self._exc_info is not None:
+            raise self._exc_info[1].with_traceback(self._exc_info[2])
         return self._return


### PR DESCRIPTION
Fixes CustomThread silently discarding exceptions from background threads.

- Captures exception in `run()` using `sys.exc_info()`
- Re-raises with original traceback in `join()`
- Successful return values unaffected

Closes #45
