### PR TITLE
feat: macOS support - portable paths, solver discovery, and cross-platform runtime fixes

### DIFF
--- a/API/Classes/Base/Config.py
+++ b/API/Classes/Base/Config.py
@@ -20,24 +20,24 @@ S3_SECRET = ""
 ALLOWED_EXTENSIONS = set(['zip', 'application/zip'])
 ALLOWED_EXTENSIONS_XLS = set(['xls', 'xlsx'])
 
-UPLOAD_FOLDER = Path('WebAPP')
-WebAPP_PATH = Path('WebAPP')
-DATA_STORAGE = Path("WebAPP", 'DataStorage')
-CLASS_FOLDER = Path("WebAPP", 'Classes')
-EXTRACT_FOLDER = Path("")
-SOLVERs_FOLDER = Path('WebAPP', 'SOLVERs')
+# Anchor all paths to the project root (two levels up from this file:
+# API/Classes/Base/Config.py -> project root)
+_CONFIG_DIR = Path(__file__).resolve().parent          # .../API/Classes/Base
+PROJECT_ROOT = _CONFIG_DIR.parent.parent.parent        # .../MUIOGO
 
+UPLOAD_FOLDER = PROJECT_ROOT / 'WebAPP'
+WebAPP_PATH = PROJECT_ROOT / 'WebAPP'
+DATA_STORAGE = PROJECT_ROOT / 'WebAPP' / 'DataStorage'
+CLASS_FOLDER = PROJECT_ROOT / 'WebAPP' / 'Classes'
+EXTRACT_FOLDER = PROJECT_ROOT
+SOLVERs_FOLDER = PROJECT_ROOT / 'WebAPP' / 'SOLVERs'
 
-#absolute paths
-# OSEMOSYS_ROOT = os.path.abspath(os.getcwd())
-# UPLOAD_FOLDER = Path(OSEMOSYS_ROOT, 'WebAPP')
-# WebAPP_PATH = Path(OSEMOSYS_ROOT, 'WebAPP')
-# DATA_STORAGE = Path(OSEMOSYS_ROOT, "WebAPP", 'DataStorage')
-# CLASS_FOLDER = Path(OSEMOSYS_ROOT, "WebAPP", 'Classes')
-# EXTRACT_FOLDER = Path(OSEMOSYS_ROOT, "")
-# SOLVERs_FOLDER = Path(OSEMOSYS_ROOT, 'WebAPP', 'SOLVERs')
-
-os.chmod(DATA_STORAGE, 0o777)
+# Ensure DATA_STORAGE exists before setting permissions
+os.makedirs(DATA_STORAGE, exist_ok=True)
+try:
+    os.chmod(DATA_STORAGE, 0o777)
+except OSError:
+    pass  # May fail on macOS due to SIP or permission restrictions
 
 HEROKU_DEPLOY = 0
 AWS_SYNC = 0
@@ -203,7 +203,7 @@ PARAMETERS_C = {
         'DiscountRate': ['r'],
         'OutputActivityRatio':['r','f','t','y','m'],
         'InputActivityRatio':['r','f','t','y','m'],
-        'EmissionActivityRatio':['r','e''t','y','m'],
+        'EmissionActivityRatio':['r','e','t','y','m'],
         'TotalAnnualMaxCapacityInvestment':['r','t','y'],
         'TotalAnnualMinCapacityInvestment':['r','t','y'],
         'TotalTechnologyAnnualActivityUpperLimit':['r','t','y'],

--- a/API/Classes/Base/CustomThreadClass.py
+++ b/API/Classes/Base/CustomThreadClass.py
@@ -1,16 +1,24 @@
 from collections.abc import Callable, Iterable, Mapping
 from threading import Thread
 from typing import Any
+import sys
 
 class CustomThread(Thread):
     def __init__(self, group=None, target=None, name=None, args=(), kwargs={}, Verbose=None):
         Thread.__init__(self, group, target, name, args, kwargs)
         self._return = None
+        self._exc_info = None
 
     def run(self):
-        if self._target is not None:
-            self._return = self._target(*self._args, **self._kwargs)
+        try:
+            if self._target is not None:
+                self._return = self._target(*self._args, **self._kwargs)
+        except Exception:
+            self._exc_info = sys.exc_info()
 
-    def join(self):
-        Thread.join(self)
+    def join(self, timeout=None):
+        Thread.join(self, timeout)
+        # Re-raise any exception that occurred in the thread
+        if self._exc_info is not None:
+            raise self._exc_info[1].with_traceback(self._exc_info[2])
         return self._return

--- a/API/Classes/Base/SyncS3.py
+++ b/API/Classes/Base/SyncS3.py
@@ -56,12 +56,13 @@ class SyncS3():
                 kwargs.update({'ContinuationToken': next_token})
             results = client.list_objects_v2(**kwargs)
             contents = results.get('Contents')
-            for i in contents:
-                k = i.get('Key')
-                if k[-1] != '/':
-                    keys.append(k)
-                else:
-                    dirs.append(k)
+            if contents:
+                for i in contents:
+                    k = i.get('Key')
+                    if k[-1] != '/':
+                        keys.append(k)
+                    else:
+                        dirs.append(k)
             next_token = results.get('NextContinuationToken')
         for d in dirs:
             dest_pathname = os.path.join(local, d)
@@ -74,7 +75,7 @@ class SyncS3():
             client.download_file(bucket, k, dest_pathname)
 
     #s3.uploadSync(localDir, case, Config.S3_BUCKET, '*')
-    def uploadSync(self, localDir, awsInitDir, bucketName, tag, prefix='\\'):
+    def uploadSync(self, localDir, awsInitDir, bucketName, tag, prefix=os.sep):
         """
         from current working directory, upload a 'localDir' with all its subcontents (files and subdirectories...)
         to a aws bucket
@@ -103,7 +104,7 @@ class SyncS3():
                 fileName = str(FullfileName).replace(str(localDir), '')
                 if fileName.startswith(prefix):  # only modify the text if it starts with the prefix
                     fileName = fileName.replace(prefix, "", 1) # remove one instance of prefix
-                    fileName = fileName.replace('\\', '/')
+                    fileName = fileName.replace(os.sep, '/')
 
                 awsPath = str(awsInitDir) + '/' + str(fileName)
                 resource.meta.client.upload_file(FullfileName, bucketName, awsPath)
@@ -130,7 +131,7 @@ class SyncS3():
         """
         resource = self.resource
         fileName = localFile.name
-        localFile = str(localFile).replace('\\', '/')
+        localFile = str(localFile).replace(os.sep, '/')
         if awsInitDir != '':
             awsPath = str(awsInitDir) + '/' + str(fileName)
         else:

--- a/API/Classes/Case/OsemosysClass.py
+++ b/API/Classes/Case/OsemosysClass.py
@@ -1,9 +1,43 @@
 from pathlib import Path
 import platform
+import shutil
 from Classes.Base import Config
 from Classes.Base.FileClass import File
 
 class Osemosys():
+
+    @staticmethod
+    def _resolve_solver_folder(env_var, exe_name, bundled_subpath):
+        """
+        Three-tier solver resolution:
+          1. Environment variable (e.g. GLPK_PATH=/opt/homebrew/bin)
+          2. System PATH lookup via shutil.which()
+          3. Bundled fallback under SOLVERs/
+        Returns the directory containing the solver executable as a Path.
+        """
+        # Tier 1: explicit env var
+        env_path = __import__('os').environ.get(env_var)
+        if env_path:
+            p = Path(env_path)
+            if p.is_dir():
+                return p
+            # If they pointed at the executable itself, use its parent
+            if p.is_file():
+                return p.parent
+
+        # Tier 2: system PATH (Homebrew, apt, etc.)
+        which_result = shutil.which(exe_name)
+        if which_result:
+            return Path(which_result).resolve().parent
+
+        # Tier 3: bundled fallback
+        bundled = Path(Config.SOLVERs_FOLDER, *bundled_subpath)
+        if bundled.exists():
+            return bundled
+
+        # If nothing found, return the bundled path anyway (will fail at runtime with a clear error)
+        return bundled
+
     def __init__(self, case):
         self.case = case
         self.PARAMETERS = File.readParamFile(Path(Config.DATA_STORAGE, 'Parameters.json'))
@@ -14,8 +48,6 @@ class Osemosys():
         #Case.__init__(self, case)
         self.casePath = Path(Config.DATA_STORAGE,case)
         self.zipPath = Path(Config.DATA_STORAGE,case+'.zip')
-
-        #self.genData = Path(Config.DATA_STORAGE,case,'genData.json')
 
         self.rPath = Path(Config.DATA_STORAGE,case,'R.json')
         self.ryPath = Path(Config.DATA_STORAGE,case,'RY.json')
@@ -45,20 +77,13 @@ class Osemosys():
         self.osemosysFile = Path(Config.SOLVERs_FOLDER,'model.v.5.4.txt') 
         self.osemosysFileOriginal = Path(Config.SOLVERs_FOLDER,'osemosys.txt')
         
-        if platform.system() == 'Windows':
-            #self.glpkFolder = Path(Config.SOLVERs_FOLDER, 'GLPK','glpk-4.65', 'w64')
-            # self.cbcFolder = Path(Config.SOLVERs_FOLDER,'COIN-OR', 'Cbc-2.7.5-win64-intel11.1', 'bin')
-            self.glpkFolder = Path(Config.SOLVERs_FOLDER, 'GLPK')
-            self.cbcFolder = Path(Config.SOLVERs_FOLDER,'COIN-OR')
-        
-            #self.cbcFolder = Path(Config.SOLVERs_FOLDER,'COIN-OR', 'Cbc-2.10-win64-msvc16-md', 'bin')
-
-            #Cbc-master-win64-msvc16-mt
-            #self.cbcFolder = Path(Config.SOLVERs_FOLDER,'COIN-OR', 'Cbc-master-win64-msvc16-md', 'bin')
-
-        else:
-            self.glpkFolder = Path(Config.SOLVERs_FOLDER, 'GLPK','glpk-4.65', 'w64')
-            self.cbcFolder = Path(Config.SOLVERs_FOLDER,'COIN-OR', 'Cbc-2.10-osx10.15-x86_64-gcc9', 'bin')
+        # Portable solver resolution: env var → PATH → bundled fallback
+        self.glpkFolder = Osemosys._resolve_solver_folder(
+            'GLPK_PATH', 'glpsol', ('GLPK',)
+        )
+        self.cbcFolder = Osemosys._resolve_solver_folder(
+            'CBC_PATH', 'cbc', ('COIN-OR',)
+        )
 
         self.resultsPath = Path(Config.DATA_STORAGE,case,'res')
         self.viewFolderPath = Path(Config.DATA_STORAGE,case,'view')

--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -41,12 +41,13 @@ def download_dir(prefix, local, bucket, client):
             kwargs.update({'ContinuationToken': next_token})
         results = client.list_objects_v2(**kwargs)
         contents = results.get('Contents')
-        for i in contents:
-            k = i.get('Key')
-            if k[-1] != '/':
-                keys.append(k)
-            else:
-                dirs.append(k)
+        if contents:
+            for i in contents:
+                k = i.get('Key')
+                if k[-1] != '/':
+                    keys.append(k)
+                else:
+                    dirs.append(k)
         next_token = results.get('NextContinuationToken')
     for d in dirs:
         dest_pathname = os.path.join(local, d)
@@ -58,7 +59,7 @@ def download_dir(prefix, local, bucket, client):
             os.makedirs(os.path.dirname(dest_pathname))
         client.download_file(bucket, k, dest_pathname)
 
-def upload_dir(s3, localDir, awsInitDir, bucketName, tag, prefix='\\'):
+def upload_dir(s3, localDir, awsInitDir, bucketName, tag, prefix=os.sep):
     """
     from current working directory, upload a 'localDir' with all its subcontents (files and subdirectories...)
     to a aws bucket

--- a/API/app.py
+++ b/API/app.py
@@ -5,7 +5,7 @@ import sys
 from flask import Flask, jsonify, request, session, render_template
 from flask_cors import CORS
 from datetime import timedelta
-# from pathlib import Path
+from pathlib import Path
 
 #import json
 from Classes.Base import Config
@@ -16,28 +16,9 @@ from Routes.Case.SyncS3Route import syncs3_api
 from Routes.Case.ViewDataRoute import viewdata_api
 from Routes.DataFile.DataFileRoute import datafile_api
 
-#RADI
-template_dir = os.path.abspath('WebAPP')
-static_dir = os.path.abspath('WebAPP')
-
-# template_dir = Config.WebAPP_PATH.resolve()
-# static_dir = Config.WebAPP_PATH.resolve()
-
-# template_dir = os.path.join(sys._MEIPASS, 'WebAPP') 
-# static_dir = os.path.join(sys._MEIPASS, 'WebAPP') 
-
-#gets absolute path
-# template_dir = Path('WebAPP').resolve()
-# static_dir = Path('../WebAPP').resolve()
-
-# template_dir = 'WebAPP'
-# static_dir = '../WebAPP'
-
-print(template_dir)
-print(static_dir)
-print(sys.executable)
-
-print(__name__)
+# Resolve template/static dirs from project root (CWD-independent)
+template_dir = str(Config.WebAPP_PATH.resolve())
+static_dir = str(Config.WebAPP_PATH.resolve())
 
 app = Flask(__name__, static_url_path='', static_folder=static_dir,  template_folder=template_dir)
 
@@ -111,22 +92,22 @@ def setSession():
 
 
 if __name__ == '__main__':
-# if __name__ == 'app':
-    #potrebno radi module js importa u index.html ES6 modules
-    #Flask.__version__
     import mimetypes
     mimetypes.add_type('application/javascript', '.js')
     port = int(os.environ.get("PORT", 5002))
-    print("PORTTTTTTTTTTT")
-    if Config.HEROKU_DEPLOY == 0: 
-        #localhost
-        #app.run(host='127.0.0.1', port=port, debug=True)
-        #waitress server
-        #prod server
-        from waitress import serve
-        serve(app, host='127.0.0.1', port=port)
-    else:
-        #HEROKU
-        app.run(host='0.0.0.0', port=port, debug=True)
-        #app.run(host='127.0.0.1', port=port, debug=True)
+    host = '127.0.0.1'
 
+    print(f"──────────────────────────────────────────")
+    print(f"  MUIOGO starting up")
+    print(f"  Python:    {sys.executable}")
+    print(f"  Templates: {template_dir}")
+    print(f"  Static:    {static_dir}")
+    print(f"  Mode:      {'Heroku' if Config.HEROKU_DEPLOY else 'Local'}")
+    print(f"  URL:       http://{host}:{port}/")
+    print(f"──────────────────────────────────────────")
+
+    if Config.HEROKU_DEPLOY == 0: 
+        from waitress import serve
+        serve(app, host=host, port=port)
+    else:
+        app.run(host='0.0.0.0', port=port, debug=True)

--- a/WebAPP/Classes/Base.Class.js
+++ b/WebAPP/Classes/Base.Class.js
@@ -11,8 +11,8 @@ export class Base {
     static apiUrl() {
         let apiUrl
         if (this.HEROKU == 0) {
-            //localhost
-            apiUrl = "http://127.0.0.1:5002/";
+            // Use runtime origin for local/dev mode (works in Codespaces, preview URLs, etc.)
+            apiUrl = window.location.origin + "/";
         } else {
             //HEROKU
             apiUrl = "https://osemosys.herokuapp.com/";

--- a/WebAPP/Classes/Osemosys.Class.js
+++ b/WebAPP/Classes/Osemosys.Class.js
@@ -361,15 +361,14 @@ export class Osemosys {
     // }
 
     static getData(casename, dataJson) {
-        // return fetch('../../DataStorage/'+casename+'/'+dataJson, {cache: "no-store"})
-        // .then(response => response.json())
-        // .catch(error => error);
+        // Guard: prevent fetch with null/undefined casename (e.g. after model deletion)
+        if (!casename) {
+            return Promise.resolve(null);
+        }
 
         return fetch('../../DataStorage/'+casename+'/'+dataJson, {cache: "no-store"}) 
             .then((response) => {
                 if (response.ok) {
-                    //console.log('response1 ', response)
-                    //console.log('data ', response.json())
                 return response;
                 }
                 throw new Error('No casename selecetd');
@@ -397,22 +396,14 @@ export class Osemosys {
     }
 
     static getResultData(casename, dataJson) {
-        // return new Promise((resolve, reject) => {
-        //     fetch('../../DataStorage/'+casename+'/view/' +dataJson, {cache: "no-store"})
-        //     .then(DATA => {
-        //         DATA = DATA.json();
-        //         resolve(DATA);
-        //     })
-        //     .catch(error => {
-        //         if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-        //         reject(error);
-        //     });
-        // });
+        // Guard: prevent fetch with null/undefined casename
+        if (!casename) {
+            return Promise.resolve(null);
+        }
 
         return fetch('../../DataStorage/'+casename+'/view/' +dataJson, {cache: "no-store"})
             .then((response) => {
                 if (response.ok) {
-                    //console.log('response1 ', response)
                     return response;
                 }
                 throw new Error('No casename selecetd');

--- a/WebAPP/index.html
+++ b/WebAPP/index.html
@@ -31,7 +31,8 @@
 		
 		 <script src="References/wijmo/controls/wijmo.odata.min.js"></script>
 		 <script src="References/wijmo/controls/wijmo.olap.min.js"></script>
-		<script src="References/wijmo/licence.js"></script>
+		<!-- Wijmo licence file not present in repo; uncomment when available -->
+		<!-- <script src="References/wijmo/licence.js"></script> -->
 		<script src="References/jszip/jszip.min.js"></script>
 
 		<!-- plotly -->

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# ============================================================================
+# MUIOGO Setup Script — Cross-platform (macOS / Linux)
+# ============================================================================
+# Usage:
+#   chmod +x setup.sh
+#   ./setup.sh
+#
+# What this script does:
+#   1. Creates a Python virtual environment in .venv/
+#   2. Installs Python dependencies from requirements.txt
+#   3. Installs GLPK and CBC solvers via Homebrew (macOS) or apt (Linux)
+#   4. Verifies solver availability
+#   5. Creates required data directories
+# ============================================================================
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+info()  { echo -e "${GREEN}[✓]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[!]${NC} $*"; }
+error() { echo -e "${RED}[✗]${NC} $*"; }
+
+# ── Detect platform ──────────────────────────────────────────────────────────
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+echo ""
+echo "══════════════════════════════════════════"
+echo "  MUIOGO Setup"
+echo "  Platform: $OS ($ARCH)"
+echo "══════════════════════════════════════════"
+echo ""
+
+# ── Check Python ─────────────────────────────────────────────────────────────
+PYTHON=""
+for cmd in python3 python; do
+    if command -v "$cmd" &>/dev/null; then
+        PYTHON="$cmd"
+        break
+    fi
+done
+
+if [ -z "$PYTHON" ]; then
+    error "Python 3 is required but not found."
+    echo "  macOS:  brew install python3"
+    echo "  Linux:  sudo apt install python3 python3-venv"
+    exit 1
+fi
+
+PY_VERSION=$($PYTHON --version 2>&1)
+info "Found $PY_VERSION ($PYTHON)"
+
+# ── Create virtual environment ───────────────────────────────────────────────
+VENV_DIR=".venv"
+if [ ! -d "$VENV_DIR" ]; then
+    info "Creating virtual environment in $VENV_DIR/"
+    $PYTHON -m venv "$VENV_DIR"
+else
+    info "Virtual environment already exists at $VENV_DIR/"
+fi
+
+# Activate it
+source "$VENV_DIR/bin/activate"
+info "Activated virtual environment"
+
+# ── Install Python dependencies ──────────────────────────────────────────────
+if [ -f "requirements.txt" ]; then
+    info "Installing Python dependencies..."
+    pip install --upgrade pip -q
+    pip install -r requirements.txt -q
+    info "Python dependencies installed"
+else
+    warn "requirements.txt not found — skipping pip install"
+fi
+
+# ── Install solvers ──────────────────────────────────────────────────────────
+install_solvers_macos() {
+    if ! command -v brew &>/dev/null; then
+        error "Homebrew is required on macOS. Install from https://brew.sh"
+        exit 1
+    fi
+
+    info "Installing solvers via Homebrew..."
+
+    if ! command -v glpsol &>/dev/null; then
+        brew install glpk
+        info "GLPK installed"
+    else
+        info "GLPK already installed ($(glpsol --version 2>&1 | head -1))"
+    fi
+
+    if ! command -v cbc &>/dev/null; then
+        brew install cbc
+        info "CBC installed"
+    else
+        info "CBC already installed ($(cbc -quit 2>&1 | head -1))"
+    fi
+}
+
+install_solvers_linux() {
+    if command -v apt-get &>/dev/null; then
+        info "Installing solvers via apt..."
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq glpk-utils coinor-cbc
+    elif command -v dnf &>/dev/null; then
+        info "Installing solvers via dnf..."
+        sudo dnf install -y glpk-utils coin-or-Cbc
+    else
+        warn "Could not detect package manager."
+        warn "Please manually install glpk-utils and coinor-cbc."
+    fi
+}
+
+case "$OS" in
+    Darwin) install_solvers_macos ;;
+    Linux)  install_solvers_linux ;;
+    *)      warn "Unsupported OS ($OS). Please install GLPK and CBC manually." ;;
+esac
+
+# ── Verify solvers ───────────────────────────────────────────────────────────
+echo ""
+SOLVERS_OK=true
+
+if command -v glpsol &>/dev/null; then
+    GLPK_LOC=$(which glpsol)
+    info "glpsol found at $GLPK_LOC"
+else
+    error "glpsol NOT found on PATH"
+    SOLVERS_OK=false
+fi
+
+if command -v cbc &>/dev/null; then
+    CBC_LOC=$(which cbc)
+    info "cbc found at $CBC_LOC"
+else
+    error "cbc NOT found on PATH"
+    SOLVERS_OK=false
+fi
+
+# ── Create required directories ──────────────────────────────────────────────
+mkdir -p WebAPP/DataStorage
+info "WebAPP/DataStorage/ directory ready"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "══════════════════════════════════════════"
+if [ "$SOLVERS_OK" = true ]; then
+    info "Setup complete! To run MUIOGO:"
+else
+    warn "Setup mostly complete, but solver(s) missing."
+    echo "  You can still start the app but model runs will fail."
+    echo "  Install solvers and re-run this script, or set:"
+    echo "    export GLPK_PATH=/path/to/glpsol/bin"
+    echo "    export CBC_PATH=/path/to/cbc/bin"
+    echo ""
+    info "To run MUIOGO:"
+fi
+echo ""
+echo "    source .venv/bin/activate"
+echo "    cd API"
+echo "    python app.py"
+echo ""
+echo "    Then open http://127.0.0.1:5002/ in your browser"
+echo "══════════════════════════════════════════"


### PR DESCRIPTION
## Summary

This PR integrates full macOS support into MUIOGO by resolving all platform-dependent
assumptions across the backend, frontend, and setup flow. It consolidates the work
planned across 9 individual PRs (#11, #13, #28, #31, #32, #35, #40, #44, #46) into
a single, tested change set.

### What changed and why

#### Path Portability (CWD-Independent Startup)
- **`Config.py`**: All `Path('WebAPP')` relative paths replaced with `PROJECT_ROOT / 'WebAPP'`
  computed via `Path(__file__).resolve()`. The app now starts correctly from any working
  directory, not just the project root.
  
- **`app.py`**: Replaced `os.path.abspath('WebAPP')` with `Config.WebAPP_PATH.resolve()`.
  Removed debug `print()` statements, added structured startup banner showing Python path,
  template/static dirs, mode, and server URL.
  
- **`Config.py`**: Added `os.makedirs(DATA_STORAGE, exist_ok=True)` and wrapped `os.chmod`
  in `try/except` to handle macOS SIP permission restrictions gracefully.

####  Solver Discovery (GLPK/CBC)
- **`OsemosysClass.py`**: Removed the `if platform.system() == 'Windows'` block with
  hardcoded Windows/x86 macOS paths. Replaced with `_resolve_solver_folder()` — a portable
  three-tier resolution chain:
  
  1. **Environment variable** (`$GLPK_PATH` / `$CBC_PATH`)
  2. **System PATH** via `shutil.which()` (finds Homebrew-installed solvers automatically)
  3. **Bundled fallback** under `WebAPP/SOLVERs/`

  Verified on Apple Silicon: GLPK resolves to `/opt/homebrew/Cellar/glpk/5.0/bin`,
  CBC to `/opt/homebrew/Cellar/cbc/2.10.12/bin`.

#### Frontend & Runtime
- **`Base.Class.js`**: Replaced hardcoded `http://127.0.0.1:5002/` with
  `window.location.origin + "/"` for local/dev mode, enabling compatibility with
  Codespaces and preview URLs.
- **`Osemosys.Class.js`**: Added `if (!casename)` guards in `getData()` and
  `getResultData()` to prevent `fetch('/DataStorage/null/...')` calls after model
  deletion.
- **`index.html`**: Commented out missing `References/wijmo/licence.js` script include
  to prevent 404 + MIME console errors.

####  Backend Robustness
- **`SyncS3.py` + `UploadRoute.py`**: Replaced all hardcoded `'\\'` path separators
  with `os.sep`. Added `if contents:` guard before iterating over `list_objects_v2`
  response to prevent `TypeError: 'NoneType' is not iterable`.
- **`CustomThreadClass.py`**: Background thread exceptions are now captured via
  `sys.exc_info()` in `run()` and re-raised with original traceback in `join()`.
  Previously exceptions were silently swallowed.

####  Bug Fix
- **`Config.py`**: Fixed `EmissionActivityRatio` dimension list — `'e''t'` (Python
  string concatenation = `'et'`) corrected to `'e','t'` (two separate elements).

####  Setup & Documentation
- **`setup.sh`**: New cross-platform setup script that creates a Python venv, installs
  pip dependencies, installs GLPK/CBC via Homebrew (macOS) or apt (Linux), verifies
  solver availability, and creates required directories.

### Files changed (10)

| File | Change |
|---|---|
| `API/Classes/Base/Config.py` | CWD-independent paths, chmod guard, typo fix |
| `API/app.py` | CWD-independent template/static, startup banner |
| `API/Classes/Case/OsemosysClass.py` | 3-tier solver resolution |
| `API/Classes/Base/SyncS3.py` | os.sep, None guard |
| `API/Routes/Upload/UploadRoute.py` | os.sep, None guard |
| `API/Classes/Base/CustomThreadClass.py` | Exception propagation |
| `WebAPP/Classes/Base.Class.js` | Runtime origin API URL |
| `WebAPP/Classes/Osemosys.Class.js` | Null casename guards |
| `WebAPP/index.html` | Comment out missing licence.js |
| `setup.sh` | New cross-platform setup script |

### Validation

- ✅ App starts on macOS (Apple Silicon) with `python3 app.py`
- ✅ All paths resolve correctly from any CWD
- ✅ GLPK found at `/opt/homebrew/Cellar/glpk/5.0/bin` via `shutil.which()`
- ✅ CBC found at `/opt/homebrew/Cellar/cbc/2.10.12/bin` via `shutil.which()`
- ✅ UI loads at `http://127.0.0.1:5002/`
- ✅ No Windows-only path assumptions remain

### Related issues

Closes #51 

---