### PR TITLE
Fix cleanup when non-directory files exist in results path (#62)

### DIFF
--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -972,6 +972,9 @@ class DataFile(Osemosys):
 
             for caserunname in os.listdir( self.resultsPath):
                 caserunname_path = os.path.join(self.resultsPath, caserunname)
+                # Skip files such as .DS_Store that can appear on macOS.
+                if not os.path.isdir(caserunname_path):
+                    continue
                 for carerunData in os.listdir( caserunname_path):
                     file_path = os.path.join(caserunname_path, carerunData)
                     try:


### PR DESCRIPTION
Adds directory guard in `[DataFileClass.py](app://-/index.html#) cleanUp()`
Skips non-directory entries (for example `.DS_Store`) before `[os.listdir(...)](app://-/index.html#)`
Fixes macOS cleanup/delete failures
Closes #62 