### PR TITLE
Fix cleanup failure when non-directory files exist in results path

### DIFF
--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -972,6 +972,12 @@ class DataFile(Osemosys):
 
             for caserunname in os.listdir( self.resultsPath):
                 caserunname_path = os.path.join(self.resultsPath, caserunname)
+                if not os.path.isdir(caserunname_path):
+                    try:
+                        os.remove(caserunname_path)
+                    except Exception as e:
+                        print(f"Greška pri brisanju {caserunname_path}: {e}")
+                    continue
                 for carerunData in os.listdir( caserunname_path):
                     file_path = os.path.join(caserunname_path, carerunData)
                     try:

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,114 @@
+"""Tests for DataFile.cleanUp handling of non-directory files in resultsPath."""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'API'))
+
+from unittest.mock import patch
+from pathlib import Path
+
+from Classes.Case.DataFileClass import DataFile
+
+
+def _make_cleanup_instance(results_path, view_folder_path):
+    """Create a DataFile instance with only the attributes cleanUp() needs,
+    bypassing the heavy Osemosys.__init__ constructor."""
+    instance = object.__new__(DataFile)
+    instance.resultsPath = results_path
+    instance.viewFolderPath = view_folder_path
+    return instance
+
+
+@pytest.fixture
+def cleanup_env(tmp_path):
+    """Set up a minimal directory structure for cleanUp tests."""
+    results = tmp_path / "res"
+    results.mkdir()
+    view = tmp_path / "view"
+    view.mkdir()
+    # cleanUp writes viewDefinitions.json and reads Variables.json
+    variables = {"group": [{"id": "v1"}]}
+    variables_path = tmp_path / "Variables.json"
+    variables_path.write_text(json.dumps(variables), encoding="utf-8")
+    return results, view, variables_path
+
+
+class TestCleanUpWithNonDirFiles:
+    """Verify cleanUp handles non-directory files (e.g. .DS_Store) in resultsPath."""
+
+    def test_ds_store_does_not_break_cleanup(self, cleanup_env):
+        results, view, variables_path = cleanup_env
+
+        # Create a case run directory with a file inside
+        run_dir = results / "run1"
+        run_dir.mkdir()
+        (run_dir / "output.csv").write_text("data", encoding="utf-8")
+
+        # Create .DS_Store at resultsPath root (the problematic file)
+        (results / ".DS_Store").write_text("", encoding="utf-8")
+
+        instance = _make_cleanup_instance(results, view)
+
+        with patch("Classes.Base.Config.DATA_STORAGE", variables_path.parent):
+            response = instance.cleanUp()
+
+        assert response["status_code"] == "success"
+        # .DS_Store should be removed
+        assert not (results / ".DS_Store").exists()
+        # run directory contents should be cleaned
+        assert not (run_dir / "output.csv").exists()
+
+    def test_cleanup_succeeds_with_only_directories(self, cleanup_env):
+        results, view, variables_path = cleanup_env
+
+        run_dir = results / "run1"
+        run_dir.mkdir()
+        (run_dir / "result.txt").write_text("x", encoding="utf-8")
+
+        instance = _make_cleanup_instance(results, view)
+
+        with patch("Classes.Base.Config.DATA_STORAGE", variables_path.parent):
+            response = instance.cleanUp()
+
+        assert response["status_code"] == "success"
+        assert not (run_dir / "result.txt").exists()
+
+    def test_multiple_non_dir_files_cleaned(self, cleanup_env):
+        results, view, variables_path = cleanup_env
+
+        # Create several stray files at resultsPath root
+        for name in [".DS_Store", "Thumbs.db", ".gitkeep"]:
+            (results / name).write_text("", encoding="utf-8")
+
+        # Also create a normal run directory
+        run_dir = results / "run1"
+        run_dir.mkdir()
+
+        instance = _make_cleanup_instance(results, view)
+
+        with patch("Classes.Base.Config.DATA_STORAGE", variables_path.parent):
+            response = instance.cleanUp()
+
+        assert response["status_code"] == "success"
+        for name in [".DS_Store", "Thumbs.db", ".gitkeep"]:
+            assert not (results / name).exists()
+
+    def test_view_folder_preserves_resdata(self, cleanup_env):
+        results, view, variables_path = cleanup_env
+
+        # resData.json should NOT be deleted
+        (view / "resData.json").write_text("{}", encoding="utf-8")
+        (view / "other.json").write_text("{}", encoding="utf-8")
+
+        instance = _make_cleanup_instance(results, view)
+
+        with patch("Classes.Base.Config.DATA_STORAGE", variables_path.parent):
+            response = instance.cleanUp()
+
+        assert response["status_code"] == "success"
+        assert (view / "resData.json").exists()
+        assert not (view / "other.json").exists()


### PR DESCRIPTION
Closes #62

## Problem

On macOS, Finder drops `.DS_Store` files inside `run/result` folders. The `cleanUp()` loop in `DataFileClass.py` iterates entries under `self.resultsPath` and calls `os.listdir()` on each one, assuming they're all directories. When a regular file like `.DS_Store` is present, that call throws `NotADirectoryError` and the whole cleanup aborts.

Same class of issue as upstream OSeMOSYS#7.

## Fix

Before descending into each entry, guard with `os.path.isdir()`. Stray files get removed as part of cleanup instead of crashing it. Error handling follows the same pattern already used in the inner loop.

```diff
 for caserunname in os.listdir(self.resultsPath):
     caserunname_path = os.path.join(self.resultsPath, caserunname)
+    if not os.path.isdir(caserunname_path):
+        try:
+            os.remove(caserunname_path)
+        except Exception as e:
+            print(f"Greška pri brisanju {caserunname_path}: {e}")
+        continue
     for carerunData in os.listdir(caserunname_path):
```

6 lines added, 0 removed. `os.path.isdir()` works the same on macOS, Linux, and Windows, so no platform-specific behavior.

## Tests

Added `tests/test_cleanup.py` with 4 cases:

- `.DS_Store` at results root → cleanup completes, file removed, subdirectory contents cleaned
- Directory-only results → no regression, works as before
- Multiple stray files (`.DS_Store`, `Thumbs.db`, `.gitkeep`) → all removed
- View folder cleanup → `resData.json` preserved, other files deleted

```
$ pytest tests/ -v
29 passed in 1.59s
```


<img width="822" height="440" alt="Screenshot 2026-02-26 at 10 07 21 PM" src="https://github.com/user-attachments/assets/3c3b36a3-0b9c-40f0-a6af-9df17cc309ca" />



