### PR TITLE
fix: validate case existence in /setSession before writing to session…

### DIFF
--- a/API/app.py
+++ b/API/app.py
@@ -102,11 +102,13 @@ def getSession():
 def setSession():
     try:
         cs = request.json['case']
-        #session.permanent= True
+        from pathlib import Path
+        if not Path(Config.DATA_STORAGE, cs).is_dir():
+            return jsonify({'message': 'Case not found.', 'status_code': 'error'}), 404
         session['osycase'] = cs
         response = {"osycase": session['osycase']}
         return jsonify(response), 200
-    except( KeyError ):
+    except KeyError:
         return jsonify('No selected parameters!'), 404
 
 


### PR DESCRIPTION
## What

Adds an existence check to `/setSession` before writing a case name into
`session['osycase']`.

## Why

Closes #75

`/setSession` previously accepted **any** string as a case name with no
validation — no check that the case directory exists, no authentication.
This allowed an attacker to pre-load their session with an arbitrary case
name and then pass the ownership guard in `/deleteCase` or `/copyCase`,
since both guards compare `session['osycase']` against the request
body — a comparison the attacker controls both sides of.

## Change

**[API/app.py](cci:7://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/app.py:0:0-0:0)**

```diff
 def setSession():
     try:
         cs = request.json['case']
+        from pathlib import Path
+        if not Path(Config.DATA_STORAGE, cs).is_dir():
+            return jsonify({'message': 'Case not found.', 'status_code': 'error'}), 404
         session['osycase'] = cs
         return jsonify({"osycase": cs}), 200
```
<img width="1919" height="197" alt="Screenshot 2026-02-27 134833" src="https://github.com/user-attachments/assets/8888f7c9-227f-4481-9bd4-e069244c99d5" />
