### PR TITLE
cleanup: remove remaining broad 0o777 permission usage

### DIFF
--- a/API/Classes/Base/Config.py
+++ b/API/Classes/Base/Config.py
@@ -35,11 +35,12 @@ CLASS_FOLDER = WEBAPP_PATH / "Classes"
 SOLVERs_FOLDER = WEBAPP_PATH / "SOLVERs"
 EXTRACT_FOLDER = BASE_DIR
 
-# Ensure DataStorage exists before chmod
+# Ensure DataStorage exists
 DATA_STORAGE.mkdir(parents=True, exist_ok=True)
-os.chmod(DATA_STORAGE, 0o777)
 
-
+# Validate writability instead of forcing permissions
+if not os.access(DATA_STORAGE, os.W_OK):
+    raise PermissionError(f"Data storage path is not writable: {DATA_STORAGE}")
 #absolute paths
 # OSEMOSYS_ROOT = os.path.abspath(os.getcwd())
 # UPLOAD_FOLDER = Path(OSEMOSYS_ROOT, 'WebAPP')

--- a/API/Classes/Case/ImportTemplate.py
+++ b/API/Classes/Case/ImportTemplate.py
@@ -837,9 +837,9 @@ class ImportTemplate():
             resDataPath = Path(Config.DATA_STORAGE,casename,'view','resData.json')
             viewDataPath = Path(Config.DATA_STORAGE,casename,'view','viewDefinitions.json')
             if not os.path.exists(resPath):
-                os.makedirs(resPath, mode=0o777, exist_ok=False)
+                os.makedirs(resPath, exist_ok=True)
             if not os.path.exists(viewPath):
-                os.makedirs(viewPath, mode=0o777, exist_ok=False)
+                os.makedirs(viewPath, exist_ok=True)
                 resData = {
                     "osy-cases":[]
                 }

--- a/API/Routes/Case/CaseRoute.py
+++ b/API/Routes/Case/CaseRoute.py
@@ -286,10 +286,10 @@ def saveCase():
             File.writeFile( viewData, viewDataPath)
             
             if not os.path.exists(resPath):
-                os.makedirs(resPath, mode=0o777, exist_ok=False)
+                os.makedirs(resPath, exist_ok=True)
 
             if not os.path.exists(viewPath):
-                os.makedirs(viewPath, mode=0o777, exist_ok=False)
+                os.makedirs(viewPath, exist_ok=True)
                 resData = {
                     "osy-cases":[]
                 }
@@ -359,9 +359,9 @@ def saveCase():
                 resDataPath = Path(Config.DATA_STORAGE,casename,'view','resData.json')
                 viewDataPath = Path(Config.DATA_STORAGE,casename,'view','viewDefinitions.json')
                 if not os.path.exists(resPath):
-                    os.makedirs(resPath, mode=0o777, exist_ok=False)
+                    os.makedirs(resPath, exist_ok=True)
                 if not os.path.exists(viewPath):
-                    os.makedirs(viewPath, mode=0o777, exist_ok=False)
+                    os.makedirs(viewPath, exist_ok=True)
                     resData = {
                         "osy-cases":[]
                     }

--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -301,8 +301,8 @@ def uploadCaseUnchunked_old():
                                         shutil.rmtree(viewPath)
 
                                     
-                                    os.makedirs(resPath, mode=0o777, exist_ok=False)
-                                    os.makedirs(viewPath, mode=0o777, exist_ok=False)
+                                    os.makedirs(resPath, exist_ok=True)
+                                    os.makedirs(viewPath, exist_ok=True)
                                     resData = {
                                         "osy-cases":[]
                                     }
@@ -470,8 +470,8 @@ def handle_full_zip(file, filepath=None):
                             shutil.rmtree(resPath)
                         if os.path.exists(viewPath):
                             shutil.rmtree(viewPath)
-                        os.makedirs(resPath, mode=0o777, exist_ok=False)
-                        os.makedirs(viewPath, mode=0o777, exist_ok=False)
+                        os.makedirs(resPath, exist_ok=True)
+                        os.makedirs(viewPath, exist_ok=True)
                         resData = {"osy-cases":[]}
                         File.writeFile(resData, resDataPath)
                         viewData = {"osy-views": viewDef}


### PR DESCRIPTION
This PR addresses one of the remaining cleanup items noted in Issue #3 by removing broad chmod / mode=0o777 usage and relying on OS-agnostic directory creation and writability checks.

Scope intentionally limited; no solver logic, path resolution, or config architecture was modified.

Partially closes #3