### PR TITLE
Fix UX- Sidebar not entirely visible and active state not initializing on reload

### DIFF
--- a/WebAPP/App/Controller/AddCase.js
+++ b/WebAPP/App/Controller/AddCase.js
@@ -61,6 +61,7 @@ export default class AddCase {
 
     static initPage(model) {
         Message.clearMessages();
+        Sidebar.Reload(model.casename);
         //$('a[href="#tabComms"]').click();
         //Navbar.initPage(model.casename, model.pageId);
         //console.log('model ', model)

--- a/WebAPP/App/Controller/Config.js
+++ b/WebAPP/App/Controller/Config.js
@@ -28,7 +28,7 @@ export default class Config {
         .then(data => {
             let [casename, PARAMETERS, VARIABLES] = data;
             let model = new Model(PARAMETERS, VARIABLES);
-            this.initPage(model);
+            this.initPage(model, casename);
             this.initEvents(model);
         })
         .catch(error =>{ 
@@ -36,9 +36,10 @@ export default class Config {
         });
     }
 
-    static initPage(model){
+    static initPage(model, casename){
         Message.clearMessages();
-        Html.title(model.casename, "Parameters", "Year, technology, commodity, emission...");
+        Sidebar.Reload(casename);
+        Html.title(casename, "Parameters", "Year, technology, commodity, emission...");
         let $divParamGrid = $('#osy-gridParam');
         let $divVarGrid = $('#osy-gridVar');
         var daParamGrid = new $.jqx.dataAdapter(model.srcParamGrid);        
@@ -61,7 +62,7 @@ export default class Config {
         .then(data => {
             let [casename, PARAMETERS, VARIABLES] = data;
             let model = new Model(PARAMETERS, VARIABLES);
-            this.initPage(model);
+            this.initPage(model, casename);
             this.initEvents(model);
         })
         .catch(error =>{ 

--- a/WebAPP/App/Controller/LegacyImport.js
+++ b/WebAPP/App/Controller/LegacyImport.js
@@ -4,6 +4,7 @@ import { Base } from "../../Classes/Base.Class.js";
 import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { Model } from "../Model/LegacyImport.Model.js";
 import { DEF } from "../../Classes/Definition.Class.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class LegacyImport {
     static async onLoad(){
@@ -19,6 +20,7 @@ export default class LegacyImport {
 
     static initPage(model){
         Message.clearMessages();
+        Sidebar.Reload(null);
         Html.title('', model.pageID, 'Import facility with OTOOLE provided xls template');
         Html.importData();
         LegacyImport.initEvents(model);

--- a/WebAPP/App/Controller/R.js
+++ b/WebAPP/App/Controller/R.js
@@ -8,6 +8,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class R {
     static onLoad(group, param){
@@ -42,6 +43,7 @@ export default class R {
 
     static initPage(model){
         Message.clearMessages();
+        Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams( model.PARAMETERS[model.group], model.param);
 

--- a/WebAPP/App/Controller/RE.js
+++ b/WebAPP/App/Controller/RE.js
@@ -8,7 +8,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
-// import { Sidebar } from "./Sidebar.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RE {
     static onLoad(group, param){
@@ -42,6 +42,7 @@ export default class RE {
 
     static initPage(model){
         Message.clearMessages();
+        Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams( model.PARAMETERS[model.group], model.param);
 

--- a/WebAPP/App/Controller/RESViewer.js
+++ b/WebAPP/App/Controller/RESViewer.js
@@ -7,6 +7,7 @@ import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
 import { Chart } from "../../Classes/Chart.Class.js";
 import { DataModel } from "../../Classes/DataModel.Class.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RESViewer {
     static onLoad() {
@@ -156,6 +157,7 @@ export default class RESViewer {
 
         //console.log('model js ', model)
         Message.clearMessages();
+            Sidebar.Reload(model.casename);
         let $div = 'osy-RESViewer';
 
         Html.title(model.casename, 'RES Viewer', 'Reference Energy System');

--- a/WebAPP/App/Controller/RESViewerMermaid.js
+++ b/WebAPP/App/Controller/RESViewerMermaid.js
@@ -5,6 +5,7 @@ import { Model } from "../Model/RESViewerMermaid.Model.js";
 import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RESViewer {
     static onLoad() {
@@ -42,6 +43,7 @@ export default class RESViewer {
 
     static initPage(model) {
         Message.clearMessages();
+            Sidebar.Reload(model.casename);
         mermaid.initialize({startOnLoad:false, maxTextSize: 900000});
 
    

--- a/WebAPP/App/Controller/RS.js
+++ b/WebAPP/App/Controller/RS.js
@@ -8,7 +8,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
-// import { Sidebar } from "./Sidebar.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RS {
     static onLoad(group, param) {
@@ -45,6 +45,7 @@ export default class RS {
 
     static initPage(model) {
         Message.clearMessages();
+        Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS[model.group], model.param);
 

--- a/WebAPP/App/Controller/RT.js
+++ b/WebAPP/App/Controller/RT.js
@@ -8,7 +8,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
-// import { Sidebar } from "./Sidebar.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RT {
     static onLoad(group, param) {
@@ -45,6 +45,7 @@ export default class RT {
 
     static initPage(model) {
         Message.clearMessages();
+        Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS[model.group], model.param);
 

--- a/WebAPP/App/Controller/RTSM.js
+++ b/WebAPP/App/Controller/RTSM.js
@@ -7,6 +7,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RTSM {
     static onLoad(group, param) {
@@ -70,6 +71,7 @@ export default class RTSM {
         
 
         //Navbar.initPage(model.casename);
+        @@        Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS['RTSM'], model.param);
 

--- a/WebAPP/App/Controller/RY.js
+++ b/WebAPP/App/Controller/RY.js
@@ -9,6 +9,7 @@ import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
 // import { Sidebar } from "./Sidebar.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RY {
     static onLoad(group, param) {
@@ -44,6 +45,7 @@ export default class RY {
     static initPage(model) {
         Message.clearMessages();
         // Sidebar.Load(model.PARAMETERS);
+        Sidebar.Reload(model.casename);
         //Navbar.initPage(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS[model.group], model.param);

--- a/WebAPP/App/Controller/RYC.js
+++ b/WebAPP/App/Controller/RYC.js
@@ -7,6 +7,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RYC {
     static onLoad(group, param) {
@@ -45,6 +46,7 @@ export default class RYC {
     static initPage(model) {
         Message.clearMessages();
         //Navbar.initPage(model.casename);
+            Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS[model.group], model.param);
 

--- a/WebAPP/App/Controller/RYCTs.js
+++ b/WebAPP/App/Controller/RYCTs.js
@@ -8,6 +8,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RYCTs {
     static onLoad(group, param) {
@@ -43,6 +44,7 @@ export default class RYCTs {
     static initPage(model) {
         Message.clearMessages();
         //Navbar.initPage(model.casename);
+            Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS['RYCTs'], model.param);
         let $divGrid = $('#osy-gridRYCTs');

--- a/WebAPP/App/Controller/RYCn.js
+++ b/WebAPP/App/Controller/RYCn.js
@@ -8,6 +8,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RYCn {
     static onLoad(group, param) {
@@ -45,6 +46,7 @@ export default class RYCn {
     static initPage(model) {
         Message.clearMessages();
         //Navbar.initPage(model.casename);
+    Sidebar.Reload(model.casename);
 
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS[model.group], model.param);

--- a/WebAPP/App/Controller/RYDtb.js
+++ b/WebAPP/App/Controller/RYDtb.js
@@ -7,6 +7,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RYDtb {
     static onLoad(group, param) {
@@ -43,6 +44,7 @@ export default class RYDtb {
     static initPage(model) {
         Message.clearMessages();
         //Navbar.initPage(model.casename);
+            Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS[model.group], model.param);
         //Html.ddlTimeslices($('#osy-timeslices1'), model.timeslices);

--- a/WebAPP/App/Controller/RYS.js
+++ b/WebAPP/App/Controller/RYS.js
@@ -7,6 +7,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RYS {
     static onLoad(group, param) {
@@ -54,6 +55,7 @@ export default class RYS {
         console.log('model ', model)
         Message.clearMessages();
         //Navbar.initPage(model.casename);
+            Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS[model.group], model.param);
         

--- a/WebAPP/App/Controller/RYSeDt.js
+++ b/WebAPP/App/Controller/RYSeDt.js
@@ -7,6 +7,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RYSeDt {
     static onLoad(group, param) {
@@ -42,6 +43,7 @@ export default class RYSeDt {
     static initPage(model) {
         Message.clearMessages();
         //Navbar.initPage(model.casename);
+            Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS['RYSeDt'], model.param);
         let $divGrid = $('#osy-gridRYSeDt');

--- a/WebAPP/App/Controller/RYT.js
+++ b/WebAPP/App/Controller/RYT.js
@@ -7,6 +7,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RYT {
     static onLoad(group, param) {
@@ -54,6 +55,7 @@ export default class RYT {
         console.log('model ', model)
         Message.clearMessages();
         //Navbar.initPage(model.casename);
+            Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS[model.group], model.param);
         

--- a/WebAPP/App/Controller/RYTC.js
+++ b/WebAPP/App/Controller/RYTC.js
@@ -8,6 +8,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RYTC {
     static onLoad(group, param) {
@@ -117,6 +118,7 @@ export default class RYTC {
     static initPage(model) {
         Message.clearMessages();
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
+            Sidebar.Reload(model.casename);
         Html.ddlParams(model.PARAMETERS['RYTC'], model.param);
 
         // Html.ddlTechs(model.techs[model.param], model.techs[model.param][0]['TechId']);

--- a/WebAPP/App/Controller/RYTCM.js
+++ b/WebAPP/App/Controller/RYTCM.js
@@ -7,6 +7,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RYTCM {
     static onLoad(group, param) {
@@ -70,6 +71,7 @@ export default class RYTCM {
         
 
         //Navbar.initPage(model.casename);
+            Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS['RYTCM'], model.param);
 

--- a/WebAPP/App/Controller/RYTCn.js
+++ b/WebAPP/App/Controller/RYTCn.js
@@ -8,6 +8,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RYTCn {
     static onLoad(group, param) {
@@ -63,6 +64,7 @@ export default class RYTCn {
     static initPage(model) {
         Message.clearMessages();
         //Navbar.initPage(model.casename);
+            Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS['RYTCn'], model.param);
         // Html.ddlTechs(model.techs[model.cons[0]['ConId']], model.techs[model.cons[0]['ConId']][0]['TechId']);

--- a/WebAPP/App/Controller/RYTE.js
+++ b/WebAPP/App/Controller/RYTE.js
@@ -8,6 +8,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RYTE {
     static onLoad(group, param) {
@@ -63,6 +64,7 @@ export default class RYTE {
     static initPage(model) {
         Message.clearMessages();
         //Navbar.initPage(model.casename);
+            Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS['RYTE'], model.param);
         Html.ddlTechs(model.techs, model.techs[0]['TechId']);

--- a/WebAPP/App/Controller/RYTEM.js
+++ b/WebAPP/App/Controller/RYTEM.js
@@ -7,6 +7,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RYTEM {
     static onLoad(group, param) {
@@ -64,6 +65,7 @@ export default class RYTEM {
     static initPage(model) {
         Message.clearMessages();
         //Navbar.initPage(model.casename);
+            Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS['RYTEM'], model.param);
         let $divGrid = $('#osy-gridRYTEM');

--- a/WebAPP/App/Controller/RYTM.js
+++ b/WebAPP/App/Controller/RYTM.js
@@ -7,6 +7,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RYTM {
     static onLoad(group, param) {
@@ -44,6 +45,7 @@ export default class RYTM {
     static initPage(model) {
         Message.clearMessages();
         //Navbar.initPage(model.casename);
+            Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS['RYTM'], model.param);
     

--- a/WebAPP/App/Controller/RYTSM.js
+++ b/WebAPP/App/Controller/RYTSM.js
@@ -7,6 +7,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RYTSM {
     static onLoad(group, param) {
@@ -70,6 +71,7 @@ export default class RYTSM {
         
 
         //Navbar.initPage(model.casename);
+            Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS['RYTSM'], model.param);
 

--- a/WebAPP/App/Controller/RYTTs.js
+++ b/WebAPP/App/Controller/RYTTs.js
@@ -7,6 +7,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RYTTs {
     static onLoad(group, param) {
@@ -51,6 +52,7 @@ export default class RYTTs {
     static initPage(model) {
         Message.clearMessages();
         //Navbar.initPage(model.casename);
+            Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS['RYTTs'], model.param);
 

--- a/WebAPP/App/Controller/RYTs.js
+++ b/WebAPP/App/Controller/RYTs.js
@@ -7,6 +7,7 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { GROUPNAMES } from "../../Classes/Const.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class RYTs {
     static onLoad(group, param) {
@@ -43,6 +44,7 @@ export default class RYTs {
     static initPage(model) {
         Message.clearMessages();
         //Navbar.initPage(model.casename);
+            Sidebar.Reload(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);
         Html.ddlParams(model.PARAMETERS[model.group], model.param);
         //Html.ddlTimeslices($('#osy-timeslices1'), model.timeslices);

--- a/WebAPP/App/Controller/Sidebar.js
+++ b/WebAPP/App/Controller/Sidebar.js
@@ -22,9 +22,13 @@ export class Sidebar {
             let model = new Model(PARAMETERS,VARIABLES, genData, RESULTEXISTS);
             this.initAppRoutes(model);
             this.initEvents();
+            // Notify that sidebar menu population is complete
+            try { window.dispatchEvent(new Event('sidebarReady')); } catch(e) {}
         })
         .catch(error => {
             Message.danger(error);
+            // Ensure app doesn't stay hidden if sidebar population fails
+            try { window.dispatchEvent(new Event('sidebarReady')); } catch(e) {}
         });
     }
 
@@ -222,5 +226,63 @@ export class Sidebar {
                 else $this.closest('li').fadeIn();
             });
         });
+
+        // Update active state based on current page
+        this.updateActiveState();
+    }
+
+    /**
+     * Update the sidebar active state based on current page ID from localStorage or hash
+     */
+    static updateActiveState() {
+        // Wait for sidebar to be available in DOM
+        const checkSidebar = () => {
+            // Check if sidebar navigation exists
+            if ($('#Navi').length === 0) {
+                // Sidebar not loaded yet, retry after a short delay
+                setTimeout(checkSidebar, 50);
+                return;
+            }
+
+            // Get current page ID from localStorage
+            let currentPageId = localStorage.getItem("osy-pageId");
+            
+            if (!currentPageId) {
+                // If not in localStorage, try to get from current hash
+                let hash = window.location.hash;
+                if (hash && hash.length > 1) {
+                    // Extract page id from hash (e.g., #/AddCase -> AddCase, #/R/id -> R)
+                    let parts = hash.substring(2).split('/');
+                    currentPageId = parts[0];
+                } else {
+                    currentPageId = "Home";
+                }
+            }
+
+            // Remove active class from all menu items
+            $('#Navi li').removeClass('active');
+
+            // Find and activate the correct menu item
+            if (currentPageId === 'Home') {
+                $('#Navi li:first').addClass('active');
+            } else {
+                // Search through all menu items for matching link
+                $('#Navi a').each(function() {
+                    let href = $(this).attr('href');
+                    
+                    // Check if this link matches the current page
+                    if (href && (href.includes(`#/${currentPageId}`) || href === `#/${currentPageId}`)) {
+                        let $li = $(this).closest('li');
+                        $li.addClass('active');
+                        
+                        // Also activate parent if this is a nested item
+                        $li.parents('li').addClass('active');
+                    }
+                });
+            }
+        };
+
+        // Start the check
+        checkSidebar();
     }
 }

--- a/WebAPP/App/Controller/ViewData.js
+++ b/WebAPP/App/Controller/ViewData.js
@@ -6,6 +6,7 @@ import { Grid } from "../../Classes/Grid.Class.js";
 import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
+import { Sidebar } from "./Sidebar.js";
 
 export default class ViewData {
     static onLoad() {
@@ -47,6 +48,7 @@ export default class ViewData {
 
     static initPage(model) {
         Message.clearMessages();
+        Sidebar.Reload(model.casename);
         Html.title(model.casename, 'View input data', 'Technologies, commodities, emissions');
         Html.ddlTechs(model.techs, model.techs[0]['TechId']);
 

--- a/WebAPP/AppResults/Controller/Pivot.js
+++ b/WebAPP/AppResults/Controller/Pivot.js
@@ -7,6 +7,7 @@ import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "../../App/Controller/MessageSelect.js"
 import { DataModelResult } from "../../Classes/DataModelResult.Class.js";
 import { DefaultObj } from "../../Classes/DefaultObj.Class.js";
+import { Sidebar } from "../../App/Controller/Sidebar.js";
 
 export default class Pivot {
     static onLoad() {
@@ -94,6 +95,7 @@ export default class Pivot {
 
     static initPage(model) {
         Message.clearMessages();
+            Sidebar.Reload(model.casename);
         Html.title(model.casename, model.VARNAMES[model.group][model.param], model.group);
 
         //console.log('model ', model)

--- a/WebAPP/Routes/Routes.Class.js
+++ b/WebAPP/Routes/Routes.Class.js
@@ -1,6 +1,7 @@
 import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { Message } from "../../Classes/Message.Class.js";
 import { Model } from "./Routes.Model.js";
+import { Sidebar } from "../App/Controller/Sidebar.js";
 
 export class Routes {
     static Load(casename) {
@@ -150,7 +151,8 @@ export class Routes {
             console.error(request + ' seems to be a dead end...');
         });
         //setup hasher
-        hasher.init(); //start listening for history change 
+        hasher.init(); //start listening for history change
+
         //Listen to hash changes
         window.addEventListener("hashchange", function() {
             var route = '/';
@@ -159,9 +161,50 @@ export class Routes {
                 route = hash.split('#').pop();
             }
             crossroads.parse(route);
+
+            // Update sidebar active state after route is parsed
+            // Use a small delay to ensure DOM is updated and localStorage is set
+            setTimeout(function() {
+                Sidebar.updateActiveState();
+            }, 150);
         });
-        // trigger hashchange on first page load
-        window.dispatchEvent(new CustomEvent("hashchange"));
+
+        // Trigger initial routing only after sidebar is loaded to avoid flashing
+        let initialTriggered = false;
+        const triggerInitialRoute = function() {
+            if (initialTriggered) return;
+            initialTriggered = true;
+            var route = '/';
+            var hash = window.location.hash;
+            if (hash.length > 0) {
+                route = hash.split('#').pop();
+            }
+            crossroads.parse(route);
+            setTimeout(function() { Sidebar.updateActiveState(); }, 150);
+        };
+
+        // If static sidebar HTML loads, trigger initial route immediately
+        window.addEventListener('sidebarLoaded', triggerInitialRoute);
+        // Fallback: trigger initial route after 500ms in case event missed
+        setTimeout(triggerInitialRoute, 500);
+
+        // When the dynamic sidebar menu is ready, reveal the aside and update active state
+        window.addEventListener('sidebarReady', function() {
+            try {
+                var left = document.getElementById('left-panel');
+                if (left) left.style.display = '';
+            } catch (e) {}
+            Sidebar.updateActiveState();
+        });
+
+        // Safety fallback: reveal the aside after 2000ms if sidebarReady not fired
+        setTimeout(function() {
+            try {
+                var left = document.getElementById('left-panel');
+                if (left && left.style.display === 'none') left.style.display = '';
+            } catch (e) {}
+            Sidebar.updateActiveState();
+        }, 2000);
     }
 }
 

--- a/WebAPP/index.html
+++ b/WebAPP/index.html
@@ -99,7 +99,7 @@
 		<!-- #NAVIGATION -->
 		<!-- Left panel : Navigation area -->
 		<!-- Note: This width of the aside area can be adjusted through LESS/SASS variables -->
-		<aside id="left-panel"></aside>
+		<aside id="left-panel" style="display:none"></aside>
 		
 		<!-- #MAIN PANEL -->
 		<div id="main" role="main">	
@@ -134,8 +134,17 @@
 
 		<div id="modals"></div>
 		
-		<script> $("aside").load("App/View/Sidebar.html"); </script>
-        <script> $("header").load("App/View/Navbar.html"); </script>
+		<script>
+			$("aside").load("App/View/Sidebar.html", function() {
+				// notify routes that sidebar is ready
+				window.dispatchEvent(new Event('sidebarLoaded'));
+			});
+		</script>
+		<script>
+			$("header").load("App/View/Navbar.html", function() {
+				window.dispatchEvent(new Event('navbarLoaded'));
+			});
+		</script>
 
 		<!--ROUTES-->
 		<script type="module" src="{{ url_for('static', filename='Routes/Routes.Class.js') }}"></script>


### PR DESCRIPTION
## Summary

- What changed:
  - Fixed sidebar active state initialization so the correct route is highlighted on full page reload and the entire side bar with 8 options is visible.
  - Ensured active state logic runs during initial load (not only on navigation events).
  - Adjusted related controllers to ensure proper state synchronization.

- Why:
Previously, the sidebar active state only appeared correctly after navigating to another page.
On full reload, the active class was not applied because initialization logic was not executed during initial render. It only showed 3 options in the side bar if user accessed website from AddCase or Config

## Related issues

- [x] Issue exists and is linked
- Closes #83 
- Related #

## Validation

- [x] Tests added/updated (or not applicable)- Not applicatble
- [X] Validation steps documented
- [X] Evidence attached (logs/screenshots/output as relevant)

**Validation step**- 
  1. Start application.
  2. Navigate to any page.
  3. Reload the page.
  4. Confirm the correct sidebar item remains highlighted and all options are visible.
  5. Navigate between pages and confirm no regression.

https://github.com/user-attachments/assets/c5c004ef-d1f1-44e3-b839-f4c1a1b78744

## Documentation

- [x] Docs updated in this PR (or not applicable)- behaviour fix only
- [x] Any setup/workflow changes reflected in repo docs

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)
