### PR TITLE
fix(setup): resolve Windows batch parser error in setup.bat

### DIFF
--- a/scripts/setup.bat
+++ b/scripts/setup.bat
@@ -21,7 +21,7 @@ if not "%CONDA_DEFAULT_ENV%"=="" (
 where python3.11 >nul 2>&1
 if %errorlevel% equ 0 (
     set "PYTHON=python3.11"
-    goto :check_version
+    goto :run
 )
 
 where py >nul 2>&1
@@ -29,7 +29,7 @@ if %errorlevel% equ 0 (
     py -3.11 -c "import sys" >nul 2>&1
     if %errorlevel% equ 0 (
         set "PYTHON=py -3.11"
-        goto :check_version
+        goto :run
     )
 )
 
@@ -39,19 +39,7 @@ echo   In PowerShell (winget): winget install -e --id Python.Python.3.11
 echo   Python.org Windows installer: https://www.python.org/downloads/windows/
 exit /b 1
 
-:check_version
-for /f "tokens=*" %%i in ('!PYTHON! -c "import sys; print(sys.version_info[:2] == (3, 11))"') do set "PY_OK=%%i"
-if not "!PY_OK!"=="True" (
-    echo ERROR: Unsupported Python version. Found:
-    !PYTHON! --version
-    echo MUIOGO setup expects Python 3.11.
-    echo Install/upgrade Python 3.11:
-    echo   In PowerShell (winget): winget install -e --id Python.Python.3.11
-    echo   Python.org Windows installer: https://www.python.org/downloads/windows/
-    exit /b 1
-)
-
+:run
 echo Using Python:
 !PYTHON! --version
-
 !PYTHON! "%SCRIPT_DIR%setup_dev.py" %*


### PR DESCRIPTION
## Summary

- What changed: Removed the `for /f` Python version check block from `scripts/setup.bat`.
- Why:
   - On Windows, the `for /f (...)` construct containing nested parentheses:

      ```bash
      for /f "tokens=*" %%i in ('!PYTHON! -c "import sys; print(sys.version_info[:2] == (3, 11))"') do set "PY_OK=%%i"
     ```
  
     causes an immediate parser failure:
  
     ```bash
     : was unexpected at this time.
     ```

   - This prevents the script from reaching `setup_dev.py`
   
   - Python version validation is already handled inside `setup_dev.py`, so the batch-level version check was redundant.

## Related issues

- [x] Issue exists and is linked
- Refs #86 

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented (not applicable)
- [x] Evidence attached (logs/screenshots/output as relevant)

## Documentation

- [x] Docs updated in this PR (or not applicable)
- [x] Any setup/workflow changes reflected in repo docs (no changes needed)

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:mac-port`

## Screenshot:
<img width="1918" height="1078" alt="image" src="https://github.com/user-attachments/assets/db13f3fa-c8dd-4aba-bf66-95bd09089653" />
