### PR TITLE
Fix: Internal Server Error When Generating Data File for Restored Cases

### DIFF
--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -724,6 +724,8 @@ class DataFile(Osemosys):
 
             dataFilePath = Path(Config.DATA_STORAGE, self.case, 'res',caserunname,'data.txt')
 
+            # Ensure case run directory exists (may be missing after restore)
+            os.makedirs(dataFilePath.parent, exist_ok=True)
 
             # self.f = open(self.dataFile, mode="w", encoding='utf-8')
             #self.f = open(dataFilePath, mode="w", encoding='utf-8')

--- a/API/Routes/DataFile/DataFileRoute.py
+++ b/API/Routes/DataFile/DataFileRoute.py
@@ -22,6 +22,10 @@ def generateDataFile():
         return jsonify(response), 200
     except(IOError):
         return jsonify('No existing cases!'), 404
+    except OSError as e:
+        return jsonify({'message': f'File system error: {str(e)}', 'status_code': 'error'}), 500
+    except Exception as e:
+        return jsonify({'message': f'Error generating data file: {str(e)}', 'status_code': 'error'}), 500
 
 @datafile_api.route("/createCaseRun", methods=['POST'])
 def createCaseRun():


### PR DESCRIPTION
# Bug Fix: Defensive Directory Creation for Data Generation 



##  Summary
This PR resolves a **500 Internal Server Error** that occurred when attempting to generate a data file for a restored case where the execution directory (`res/<caserunname>/`) was missing from the filesystem.

This ensures that the application remains resilient even if the metadata exists in `resData.json` but the physical directory structure was lost during a backup/restore cycle or manual cleanup.

---

##  Root Cause Analysis
The `generateDatafile()` method attempted to write a `data.txt` file directly to the path:
`res/<caserunname>/data.txt`

If the parent directory (`<caserunname>/`) did not exist, the operation would raise a `FileNotFoundError`, crashing the Flask route and returning an unhandled 500 error to the UI.

**Typical Failure Scenario:**
1. A case run is initialized, and metadata is saved to `resData.json`.
2. The system is backed up without the (empty) result directories.
3. The model is restored on a new machine.
4. Generating the data file fails because the expected directory path is missing.

---

## Changes Implemented

### 1. Defensive Directory Provisioning
Added an idempotent directory check using `pathlib` before the file write operation:
```python
os.makedirs(dataFilePath.parent, exist_ok=True)