### PR TITLE
fix(security): prevent path traversal and zip slip vulnerabilities

### DIFF
--- a/API/Classes/Base/path_security.py
+++ b/API/Classes/Base/path_security.py
@@ -30,13 +30,20 @@ from __future__ import annotations
 
 import logging
 import re
-from pathlib import Path, PurePosixPath, PureWindowsPath
+import shutil
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+
+class PathValidationError(ValueError):
+    """Raised when a user-supplied path component fails validation."""
+    pass
+
+
 # Only allow alphanumeric, hyphens, underscores, dots, spaces, and
 # parentheses — i.e. characters that are safe in filenames on all major OSes.
-_SAFE_COMPONENT_RE = re.compile(r"^[A-Za-z0-9 _\-.()\[\]]+$")
+_SAFE_COMPONENT_RE = re.compile(r"^[A-Za-z0-9 _\-()\[\].]+$")
 
 
 def validate_path_component(name: str) -> str:
@@ -54,7 +61,7 @@ def validate_path_component(name: str) -> str:
 
     Raises
     ------
-    ValueError
+    PathValidationError
         When the component contains forbidden characters or sequences.
     """
     if not isinstance(name, str) or not name:
@@ -100,7 +107,7 @@ def safe_resolve_path(base_dir: Path, *parts: str) -> Path:
 
     Raises
     ------
-    ValueError
+    PathValidationError
         When the resolved path escapes *base_dir*.
     """
     # Validate every individual component first
@@ -120,7 +127,7 @@ def safe_resolve_path(base_dir: Path, *parts: str) -> Path:
             resolved_base,
             resolved_target,
         )
-        raise ValueError("Invalid path: target is outside the allowed directory")
+        raise PathValidationError("Invalid path: target is outside the allowed directory")
 
     return resolved_target
 
@@ -162,9 +169,9 @@ def safe_zip_extract(zip_file, destination: Path) -> None:
         # Ensure parent directories exist
         target.parent.mkdir(parents=True, exist_ok=True)
 
-        # Extract the single member safely
+        # Extract the single member safely using streaming copy
         with zip_file.open(member) as src, open(target, "wb") as dst:
-            dst.write(src.read())
+            shutil.copyfileobj(src, dst)
 
 
 # ---------------------------------------------------------------------- #
@@ -183,4 +190,4 @@ def _reject(name: object, reason: str) -> None:
         reason,
         name,
     )
-    raise ValueError("Invalid path supplied")
+    raise PathValidationError("Invalid path supplied")

--- a/API/Routes/Case/CaseRoute.py
+++ b/API/Routes/Case/CaseRoute.py
@@ -9,13 +9,13 @@ from Classes.Case.CaseClass import Case
 from Classes.Case.UpdateCaseClass import UpdateCase
 from Classes.Case.ImportTemplate import ImportTemplate
 from Classes.Base.SyncS3 import SyncS3
-from Classes.Base.path_security import validate_path_component, safe_resolve_path
+from Classes.Base.path_security import validate_path_component, safe_resolve_path, PathValidationError
 
 case_api = Blueprint('CaseRoute', __name__)
 
-@case_api.errorhandler(ValueError)
+@case_api.errorhandler(PathValidationError)
 def handle_invalid_path(exc):
-    return jsonify({"error": str(exc) or "Invalid path supplied"}), 400
+    return jsonify({"error": "Invalid path supplied"}), 400
 
 @case_api.route("/initSyncS3", methods=['GET'])
 def initSyncS3():
@@ -232,9 +232,10 @@ def updateData():
         param = request.json['param']
         case = session.get('osycase', None)
         dataJson = request.json['dataJson']
+        if case is None:
+            return jsonify('No active case in session!'), 401
+        validate_path_component(case)
         validate_path_component(dataJson)
-        if case is not None:
-            validate_path_component(case)
         dataPath = safe_resolve_path(Config.DATA_STORAGE, case, dataJson)
         if case != None:
             sourceData = File.readFile(dataPath)
@@ -442,8 +443,9 @@ def prepareCSV():
 def downloadCSV():
     try:
         casename = session.get('osycase', None)
-        if casename is not None:
-            validate_path_component(casename)
+        if casename is None:
+            return jsonify('No active case in session!'), 401
+        validate_path_component(casename)
         dataFile = safe_resolve_path(Config.DATA_STORAGE, casename, 'export.csv')
         
         return send_file(dataFile, as_attachment=True,mimetype='application/csv', max_age=0)

--- a/API/Routes/DataFile/DataFileRoute.py
+++ b/API/Routes/DataFile/DataFileRoute.py
@@ -3,13 +3,13 @@ from pathlib import Path
 import shutil, datetime, time, os
 from Classes.Case.DataFileClass import DataFile
 from Classes.Base import Config
-from Classes.Base.path_security import validate_path_component, safe_resolve_path
+from Classes.Base.path_security import validate_path_component, safe_resolve_path, PathValidationError
 
 datafile_api = Blueprint('DataFileRoute', __name__)
 
-@datafile_api.errorhandler(ValueError)
+@datafile_api.errorhandler(PathValidationError)
 def handle_invalid_path(exc):
-    return jsonify({"error": str(exc) or "Invalid path supplied"}), 400
+    return jsonify({"error": "Invalid path supplied"}), 400
 
 @datafile_api.route("/generateDataFile", methods=['POST'])
 def generateDataFile():
@@ -190,8 +190,9 @@ def downloadDataFile():
         #path = "/Examples.pdf"
         case = session.get('osycase', None)
         caserunname = request.args.get('caserunname')
-        if case is not None:
-            validate_path_component(case)
+        if case is None:
+            return jsonify('No active case in session!'), 401
+        validate_path_component(case)
         validate_path_component(caserunname)
         dataFile = safe_resolve_path(Config.DATA_STORAGE, case, 'res', caserunname, 'data.txt')
         return send_file(dataFile, as_attachment=True, max_age=0)
@@ -204,8 +205,9 @@ def downloadFile():
     try:
         case = session.get('osycase', None)
         file = request.args.get('file')
-        if case is not None:
-            validate_path_component(case)
+        if case is None:
+            return jsonify('No active case in session!'), 401
+        validate_path_component(case)
         validate_path_component(file)
         dataFile = safe_resolve_path(Config.DATA_STORAGE, case, 'res', 'csv', file)
         return send_file(dataFile, as_attachment=True, max_age=0)
@@ -219,8 +221,9 @@ def downloadCSVFile():
         case = session.get('osycase', None)
         file = request.args.get('file')
         caserunname = request.args.get('caserunname')
-        if case is not None:
-            validate_path_component(case)
+        if case is None:
+            return jsonify('No active case in session!'), 401
+        validate_path_component(case)
         validate_path_component(file)
         validate_path_component(caserunname)
         dataFile = safe_resolve_path(Config.DATA_STORAGE, case, 'res', caserunname, 'csv', file)
@@ -234,8 +237,9 @@ def downloadResultsFile():
     try:
         case = session.get('osycase', None)
         caserunname = request.args.get('caserunname')
-        if case is not None:
-            validate_path_component(case)
+        if case is None:
+            return jsonify('No active case in session!'), 401
+        validate_path_component(case)
         validate_path_component(caserunname)
         dataFile = safe_resolve_path(Config.DATA_STORAGE, case, 'res', caserunname, 'results.txt')
         return send_file(dataFile, as_attachment=True, max_age=0)

--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -9,13 +9,49 @@ from threading import Thread
 
 from Classes.Base import Config
 from Classes.Base.FileClass import File
-from Classes.Base.path_security import validate_path_component, safe_resolve_path, safe_zip_extract
+from Classes.Base.path_security import (
+    validate_path_component as _validate_path_component,
+    safe_resolve_path as _safe_resolve_path,
+    safe_zip_extract as _safe_zip_extract,
+    PathValidationError,
+)
 
 upload_api = Blueprint('UploadRoute', __name__)
 
-@upload_api.errorhandler(ValueError)
+
+class _UploadPathValidationError(PathValidationError):
+    """Upload-specific path validation error for narrower catching."""
+    pass
+
+
+def validate_path_component(*args, **kwargs):
+    """Wrapper that converts low-level PathValidationError to upload-specific."""
+    try:
+        return _validate_path_component(*args, **kwargs)
+    except PathValidationError as exc:
+        raise _UploadPathValidationError("Invalid path supplied") from exc
+
+
+def safe_resolve_path(*args, **kwargs):
+    """Wrapper that converts low-level PathValidationError to upload-specific."""
+    try:
+        return _safe_resolve_path(*args, **kwargs)
+    except PathValidationError as exc:
+        raise _UploadPathValidationError("Invalid path supplied") from exc
+
+
+def safe_zip_extract(*args, **kwargs):
+    """Wrapper that converts low-level PathValidationError to upload-specific."""
+    try:
+        return _safe_zip_extract(*args, **kwargs)
+    except PathValidationError as exc:
+        raise _UploadPathValidationError("Invalid path supplied") from exc
+
+
+@upload_api.errorhandler(_UploadPathValidationError)
 def handle_invalid_path(exc):
-    return jsonify({"error": str(exc) or "Invalid path supplied"}), 400
+    # Return a fixed, generic error message to avoid leaking internals.
+    return jsonify({"error": "Invalid path supplied"}), 400
 
 #File extension checking
 def allowed_filename(filename):

--- a/API/test_path_security.py
+++ b/API/test_path_security.py
@@ -1,0 +1,124 @@
+"""Quick smoke-test for the path_security module after PR review changes."""
+
+import sys, os, tempfile, zipfile, shutil
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+
+from Classes.Base.path_security import (
+    validate_path_component,
+    safe_resolve_path,
+    safe_zip_extract,
+    PathValidationError,
+)
+
+passed = 0
+failed = 0
+
+def ok(msg):
+    global passed
+    passed += 1
+    print(f"  PASS: {msg}")
+
+def fail(msg):
+    global failed
+    failed += 1
+    print(f"  FAIL: {msg}")
+
+
+print("=== 1. PathValidationError is a ValueError subclass ===")
+if issubclass(PathValidationError, ValueError):
+    ok("PathValidationError inherits ValueError")
+else:
+    fail("PathValidationError should inherit ValueError")
+
+
+print("\n=== 2. Valid names accepted ===")
+for name in ["MyCase", "DEMO CASE", "file.json", "case_123", "v5.0", "test(1)"]:
+    try:
+        validate_path_component(name)
+        ok(f"accepted {name!r}")
+    except PathValidationError:
+        fail(f"rejected valid name {name!r}")
+
+
+print("\n=== 3. Malicious inputs rejected as PathValidationError ===")
+malicious = [
+    "../../etc/passwd",
+    "foo/bar",
+    "foo\\bar",
+    "file\x00.json",
+    "",
+    "..",
+    ".",
+    "..\\Windows\\System32",
+]
+for name in malicious:
+    try:
+        validate_path_component(name)
+        fail(f"accepted malicious {name!r}")
+    except PathValidationError:
+        ok(f"rejected {name!r}")
+    except Exception as e:
+        fail(f"{name!r} raised {type(e).__name__} instead of PathValidationError")
+
+
+print("\n=== 4. safe_resolve_path works ===")
+base = Path("WebAPP", "DataStorage")
+try:
+    result = safe_resolve_path(base, "MyCase", "genData.json")
+    ok(f"resolved -> {result}")
+except Exception as e:
+    fail(f"raised {e}")
+
+
+print("\n=== 5. safe_resolve_path rejects traversal as PathValidationError ===")
+try:
+    safe_resolve_path(base, "..", "..", "etc", "passwd")
+    fail("should have raised")
+except PathValidationError:
+    ok("traversal blocked")
+except Exception as e:
+    fail(f"raised {type(e).__name__} instead of PathValidationError")
+
+
+print("\n=== 6. safe_zip_extract blocks Zip Slip (streaming) ===")
+tmp = tempfile.mkdtemp()
+try:
+    malicious_zip = os.path.join(tmp, "evil.zip")
+    safe_dir = os.path.join(tmp, "safe_extract")
+    os.makedirs(safe_dir, exist_ok=True)
+
+    with zipfile.ZipFile(malicious_zip, "w") as zf:
+        zf.writestr("model/genData.json", "OK")
+        zf.writestr("../../../evil.txt", "HACKED")
+        zf.writestr("model/../../../escape.txt", "ESCAPED")
+
+    with zipfile.ZipFile(malicious_zip, "r") as zf:
+        safe_zip_extract(zf, Path(safe_dir))
+
+    if os.path.exists(os.path.join(safe_dir, "model", "genData.json")):
+        ok("normal file extracted")
+    else:
+        fail("normal file missing")
+
+    if not os.path.exists(os.path.join(tmp, "evil.txt")):
+        ok("evil.txt blocked")
+    else:
+        fail("evil.txt escaped!")
+
+    if not os.path.exists(os.path.join(tmp, "escape.txt")):
+        ok("escape.txt blocked")
+    else:
+        fail("escape.txt escaped!")
+finally:
+    shutil.rmtree(tmp)
+
+
+print("\n" + "=" * 50)
+print(f"Results: {passed} passed, {failed} failed")
+if failed == 0:
+    print("=== ALL SECURITY TESTS PASSED ===")
+else:
+    print("!!! SOME TESTS FAILED !!!")
+    sys.exit(1)


### PR DESCRIPTION
## Summary

Implements production-grade input validation and path sanitization across all API routes
that accept user-supplied filenames, case names, or ZIP uploads. This prevents attackers
from reading/writing arbitrary files on the server through path traversal (CWE-22) or
extracting files outside the intended directory via Zip Slip (CWE-23).

## Security Impact

**Severity: CRITICAL**

Before this fix, an attacker could:
- Read arbitrary server files (`../../etc/passwd`, `..\..\Windows\System32\config\SAM`)
- Overwrite application code (`../../../API/app.py`)
- Extract malicious files outside `DataStorage/` via crafted ZIP archives

All platforms (Linux, macOS, Windows) were affected.

## Root Cause

1. **Path Traversal** — Multiple API routes constructed filesystem paths by concatenating
   user-supplied query parameters (`casename`, `caserunname`, `file`, `dataJson`) directly
   into `Path()` with zero validation. An attacker could supply payloads like
   `../../etc/passwd` to escape the `DATA_STORAGE` directory.

2. **Zip Slip** — `UploadRoute.py` called `zf.extractall()` on user-uploaded ZIP files
   without checking individual entry paths. A crafted ZIP containing entries like
   `../../../malicious.py` would extract files outside the intended directory.

## Solution

### New module: `API/Classes/Base/path_security.py`

| Function | Purpose |
|---|---|
| `validate_path_component(name)` | Rejects any single component containing `..`, `/`, `\`, null bytes, or chars outside a safe whitelist. Raises `ValueError`. |
| `safe_resolve_path(base_dir, *parts)` | Validates each component, then resolves the full path and asserts it stays inside `base_dir` (defense-in-depth). |
| `safe_zip_extract(zip_file, destination)` | Iterates ZIP entries, resolves each target path, skips any entry that would escape `destination`, and logs a WARNING. |

### Defense-in-depth strategy
1. **Component-level rejection** — catches traversal at the earliest point
2. **Resolved-path containment check** — guarantees the final canonical path is inside the trusted root
3. **Security logging** — `logging.warning()` on every blocked attempt for forensic auditing
4. **Clean error responses** — HTTP 400 with `{"error": "Invalid path supplied"}`, no information leakage

## Files Modified

| File | Changes |
|---|---|
| `API/Classes/Base/path_security.py` | **NEW** — Shared validation module |
| `API/Routes/Case/CaseRoute.py` | Secured 12 endpoints: `copyCase`, `deleteCase`, `updateData`, `saveCase`, `getResultCSV`, `getDesc`, `getResultData`, `getParamFile`, `resultsExists`, `saveScOrder`, `prepareCSV`, `downloadCSV` |
| `API/Routes/DataFile/DataFileRoute.py` | Secured 5 endpoints: `deleteCaseRun`, `downloadDataFile`, `downloadFile`, `downloadCSVFile`, `downloadResultsFile` |
| `API/Routes/Upload/UploadRoute.py` | Replaced all 8 `zf.extractall()` calls with `safe_zip_extract()`; secured `backupCase` |

## Testing Performed

### Path traversal (all blocked with HTTP 400)
``
```
# Linux/macOS traversal
curl -X POST http://localhost:5000/case/copyCase \
  -H "Content-Type: application/json" \
  -d '{"casename": "../../etc/passwd"}'
# → {"error": "Invalid path supplied"} 400

# Windows traversal
curl -X POST http://localhost:5000/case/deleteCase \
  -H "Content-Type: application/json" \
  -d '{"casename": "..\\Windows\\System32"}'
# → {"error": "Invalid path supplied"} 400

# Download traversal
curl "http://localhost:5000/dataFile/downloadFile?file=../../../API/app.py&casename=test"
# → {"error": "Invalid path supplied"} 400

```

**Zip Slip (malicious entries silently skipped)**
- Created ZIP with ../../../evil.txt entry → entry blocked, log WARNING produced
- Normal entries extract correctly

**Regression**
- Valid case names (DEMO CASE, MyModel_v2, test.case) pass validation
- All existing functionality preserved

**Checklist**

- [x]  Shared validation utility in Classes/Base/
- [x]  Component-level validation (reject .., /, \, null bytes)
- [x]  Resolved-path containment check (stays within DATA_STORAGE)
- [x]  All endpoints using user-supplied paths are patched
- [x]  All zf.extractall() replaced with safe extraction
- [x]  HTTP 400 JSON error for invalid inputs (never 500)
- [x]  logging.warning() on blocked attempts
- [x]  No information leakage in error responses
- [x]  Uses pathlib exclusively (not os.path)
- [x]  Follows OWASP secure file handling guidelines
- [x]  Syntax-checked all modified files
- [x]  Unit tested all attack vectors locally

Fixes #94