### PR TITLE
feat: add optional Docker-based development environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Version control
+.git
+.gitignore
+
+# Python artefacts
+.env
+dist/
+build/
+venv/
+venv
+.venv/
+**/__pycache__
+**/*.py[cod]
+**/*.pyo
+
+# Editor / IDE
+.vscode
+
+# Sphinx build output (not needed in image)
+docs/source
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Demo data zip (not needed in image)
+assets/demo-data/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+FROM python:3.11-slim
+
+# App config
+ARG PORT=5002
+ENV PORT=${PORT} \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Create non-root user
+RUN useradd -m muiogo
+
+# Install system deps
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        glpk-utils coinor-cbc unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Python deps first (better caching)
+COPY requirements.txt .
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+# Copy source
+COPY --chown=muiogo:muiogo . .
+
+# Seed demo data and fix permissions
+RUN chown -R muiogo:muiogo /app/WebAPP/DataStorage
+
+EXPOSE ${PORT}
+
+# Basic healthcheck
+HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:${PORT}')" \
+    || exit 1
+
+USER muiogo
+
+WORKDIR /app/API
+
+CMD ["sh", "-c", "python -m waitress --host=0.0.0.0 --port=${PORT} app:app"]

--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ For setup options, use the "--help" flag:
 > the [Advanced Setup and Packaging](#advanced-setup-and-packaging) section
 > below.
 
+### Docker (Optional)
+
+```bash
+docker compose up --build
+```
+
+Open <http://localhost:5002>.
+
+See [docs/DOCKER.md](docs/DOCKER.md) for full usage, including:
+
+- Development mode (live reload)
+- Port override via HOST_PORT
+- Data persistence
+- Troubleshooting
+
 ## Demo Data
 
 The demo dataset (`CLEWs.Demo.zip`) is hosted as a [GitHub release asset](https://github.com/EAPD-DRB/MUIOGO/releases/tag/demo-data) and downloaded automatically during setup when not already cached locally.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,17 @@
+# Dev override: live reload + source mount
+# Usage:
+# docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+
+services:
+  api:
+    volumes:
+      - .:/app
+      - datastorage:/app/WebAPP/DataStorage
+    environment:
+      PORT: "5002"
+      FLASK_DEBUG: "1"
+    working_dir: /app/API
+    command: >
+      sh -c "python /app/scripts/setup_dev.py --only-demo-data &&
+             python -m flask --app app run --debug --host=0.0.0.0 --port=$$PORT"
+    restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  api:
+    build:
+      context: .
+      args:
+        PORT: "5002"
+    ports:
+      - "${HOST_PORT:-5002}:5002"
+    volumes:
+      - datastorage:/app/WebAPP/DataStorage
+    command: >
+      sh -c "python /app/scripts/setup_dev.py --only-demo-data &&
+             python -m waitress --host=0.0.0.0 --port=$$PORT app:app"
+    restart: unless-stopped
+
+volumes:
+  datastorage:

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,0 +1,162 @@
+# Docker Quick Start
+
+MUIOGO provides an **optional** Docker-based development environment.
+
+This path is strictly additive.
+
+## Prerequisites
+
+| Platform | Requirement |
+| --- | --- |
+| Windows | Docker Desktop + WSL 2 enabled |
+| macOS | Docker Desktop |
+| Linux | Docker Engine + Docker Compose plugin |
+
+## Installing Docker
+
+If Docker is not already installed:
+
+### Windows
+
+- Install **Docker Desktop for Windows**:
+
+  <https://docs.docker.com/desktop/setup/install/windows-install/>
+
+- Requirements:
+  - WSL 2 enabled (Windows Subsystem for Linux)
+  - Recommended to run Linux containers (default)
+
+- Verify WSL version:
+
+    ```powershell
+    wsl --version
+    ```
+
+- If WSL is not installed:
+
+    ```powershell
+    wsl --install
+    ```
+
+- Start Docker Desktop and wait until the Docker whale icon reports “Running.”
+
+### macOS
+
+- Install **Docker Desktop for macOS**:
+
+  <https://docs.docker.com/desktop/setup/install/mac-install/>
+- Launch Docker Desktop and wait until the Docker whale indicates “Running.”
+
+### Linux
+
+- Install Docker Engine + Compose plugin:
+
+  <https://docs.docker.com/engine/install/ubuntu/>
+
+- After installation, verify:
+
+    ```bash
+    docker --version
+    docker compose version
+    ```
+
+- For other Linux distributions, see the official Docker installation guides:
+
+  <https://docs.docker.com/engine/install/>
+
+## Quick Start
+
+### Start the App
+
+```bash
+docker compose up --build
+```
+
+- Builds the image and starts (foreground - logs stream to terminal)
+
+Open <http://localhost:5002> in your browser.
+
+### Run in detached mode (background)
+
+```bash
+docker compose up --build -d
+```
+
+#### View logs
+
+```bash
+docker compose logs -f
+```
+
+### Port Override
+
+```bash
+HOST_PORT=8080 docker compose up --build
+```
+
+Then open <http://localhost:8080>.
+
+> Note: The app still runs on port 5002 inside the container.
+> HOST_PORT only changes the external port on your machine.
+
+## Development Mode (Live Reload)
+
+For local development, you can run the app with live reload:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+```
+
+- Source code is mounted into the container
+- Changes to .py files reload automatically
+- No rebuild needed for code changes
+
+This uses Flask’s development server instead of waitress.
+> Note: This mode is intended for development only.
+
+## Stopping and Cleanup
+
+```bash
+# Stop containers - DataStorage volume is preserved
+docker compose down
+
+# Stop containers and remove the DataStorage volume (wipes all case data)
+docker compose down -v
+```
+
+## Data Persistence
+
+`WebAPP/DataStorage/` is stored in a named Docker volume `datastorage`.
+
+Data persists across restarts.
+
+- To wipe data: **`docker compose down -v`**
+
+### Accessing Data Files from the Host
+
+```bash
+# Copy the entire DataStorage out of the volume to the host
+docker compose cp api:/app/WebAPP/DataStorage ./datastorage-backup
+
+# Open an interactive shell inside the running container
+docker compose exec api sh
+```
+
+## Verifying Solvers
+
+```bash
+docker compose exec api glpsol --version
+docker compose exec api cbc -stop
+```
+
+Both should print version information.
+
+## Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| Port already in use | `HOST_PORT=8080 docker compose up --build` |
+| App unreachable after `docker compose up --build -d` | `docker compose logs api` - wait for "MUIOGO API starting" |
+| DataStorage empty after volume wipe | Restart with `docker compose up`; demo data is re-seeded automatically |
+| Solver not found inside container | `docker compose build --no-cache` to force a clean install |
+| Build fails on `apt-get` step | Ensure Docker Desktop is running; retry once (transient mirror issue) |

--- a/scripts/setup_dev.py
+++ b/scripts/setup_dev.py
@@ -1381,4 +1381,7 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    if "--only-demo-data" in sys.argv:
+        ok = install_demo_data(force=False, yes=True)
+        raise SystemExit(0 if ok else 1)
     raise SystemExit(main())


### PR DESCRIPTION
## Linked issue

- Closes #115 

## Existing related work reviewed

- Issues/PRs reviewed: #115 (this PR directly addresses it)

## Overlap assessment

- Classification: New feature (additive infrastructure)
- Overlapping items: None
- Why this is not duplicate/superseded: First and only Docker implementation for this repo

## Why this PR should proceed

- Implements the accepted enhancement from #115
- Fully additive; existing setup paths remain unchanged
- Reduces onboarding friction by eliminating host-specific solver installation and PATH configuration issues
- Provides a reproducible, cross-platform setup (Windows/macOS/Linux) for new contributors
- Tested end-to-end across standard, dev, and port-override workflows

## Summary

- What changed:
  - `Dockerfile`: Python 3.11-slim, GLPK + CBC via apt, non-root user, HEALTHCHECK
  - `docker-compose.yml`: named `datastorage` volume, `HOST_PORT` override, runtime demo-data seeding
  - `docker-compose.dev.yml`: live source mount + Flask debug auto-reload
  - `.dockerignore`: excludes venv, `__pycache__`, editor artifacts, demo-data zip
  - `docs/DOCKER.md`: quick start, dev mode, port override, persistence, troubleshooting
  - `README.md`: Docker quick start section linking to `docs/DOCKER.md`
  - `scripts/setup_dev.py`: `--only-demo-data` flag for idempotent runtime container seeding

- Why: Local setup depends on host-specific tooling that is fragile across platforms. Docker provides a consistent, reproducible environment without replacing existing setup paths.

## Validation

- [x] Tests added/updated (not applicable - infrastructure only)
- [x] Validation steps documented
- [x] Evidence attached (video below)

Commands:
```bash
docker compose up --build                                                    # standard
HOST_PORT=8080 docker compose up --build                                     # port override
docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build    # dev mode
docker compose exec api glpsol --version                                     # glpk solver check
docker compose exec api cbc -stop                                            # cbc solver check
```

### Demo flows

https://github.com/user-attachments/assets/f1c688b0-11aa-426f-874c-e84a7be04e3f

- Standard run [0:02]
- Port override [0:44]
- Dev mode (live reload) [1:40]

### Solver verification

https://github.com/user-attachments/assets/64ac0260-c81d-4603-9d27-e232642e8a7a

- glpsol --version [0:13]
- cbc -stop [0:20]

## Documentation

- [x] Docs updated in this PR
- [x] Any setup/workflow changes reflected in repo docs - added `docs/DOCKER.md`, updated `README`

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

## Exception rationale

