### PR TITLE
fix: use context managers to prevent file handle leaks in FileClass

### DIFF
--- a/API/Classes/Base/FileClass.py
+++ b/API/Classes/Base/FileClass.py
@@ -4,16 +4,13 @@ import json
 class File:
     @staticmethod
     def readFile(path):
-        try:   
-            f = open(path, mode="r")
-            data = json.loads(f.read())
-            #cirilica u json file
-            #data = json.load(open(path, encoding='utf-8-sig'))
-            f.close()
+        try:
+            with open(path, mode="r") as f:
+                data = json.loads(f.read())
             return data
-        except( IndexError):
+        except IndexError:
             raise IndexError
-        except(IOError):
+        except IOError:
             raise IOError
         except OSError:
             raise OSError
@@ -21,35 +18,19 @@ class File:
     @staticmethod
     def writeFile(data, path):
         try:
-            f = open(path, mode="w")
-            #json
-            #f.write(json.dumps(data, ensure_ascii=False, separators=(',', ':')))
-            #f.write(json.dumps(data, ensure_ascii=True,  indent=4, sort_keys=False))
-            #ascii false da zapisemo cirilicu u file
-            f.write(json.dumps(data, ensure_ascii=True,  indent=4, sort_keys=False))
-            #usjon
-            #f.write(json.dumps(data))
-            f.close()
-        # except(IOError, IndexError):
-        #     return('File not found or file is empty')
-        #ovako prosljedjujemo exception u prethodnom slucaju vracamo response u funkciju koja poziva writeFile
-        except(IOError, IndexError):
+            with open(path, mode="w") as f:
+                f.write(json.dumps(data, ensure_ascii=True, indent=4, sort_keys=False))
+        except (IOError, IndexError):
             raise IndexError
         except OSError:
             raise OSError
-        
-        #drugi nacin pisanj u file
-        #with open(self.hData, mode="w") as f:
-        #json.dump(data,f)
 
     @staticmethod
     def writeFileUJson(data, path):
         try:
-            f = open(path, mode="w")
-            #usjon
-            f.write(json.dumps(data))
-            f.close()
-        except(IOError, IndexError):
+            with open(path, mode="w") as f:
+                f.write(json.dumps(data))
+        except (IOError, IndexError):
             raise IndexError
         except OSError:
             raise OSError
@@ -57,13 +38,12 @@ class File:
     @staticmethod
     def readParamFile(path):
         try:
-            f = open(path, mode="r")
-            data = json.loads(f.read())
-            f.close()
+            with open(path, mode="r") as f:
+                data = json.loads(f.read())
             return data
-        except( IndexError):
+        except IndexError:
             raise IndexError
-        except(IOError):
+        except IOError:
             raise IOError
         except OSError:
             raise OSError


### PR DESCRIPTION
## Summary

Fixes #123

All four file I/O methods in [API/Classes/Base/FileClass.py](cci:7://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/Classes/Base/FileClass.py:0:0-0:0) used raw `open()` 
calls where `f.close()` was placed inside the `try` block — after the operation 
that could raise. If an exception occurred, `f.close()` was never reached, 
silently leaking the file handle.

## Changes

**File:** [API/Classes/Base/FileClass.py](cci:7://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/Classes/Base/FileClass.py:0:0-0:0)

Replaced all `open/close` pairs with `with open(...) as f:` context managers 
in all four methods:

- [readFile](cci:1://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/Classes/Base/FileClass.py:4:4-15:25)
- [writeFile](cci:1://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/Classes/Base/FileClass.py:17:4-25:25)
- [writeFileUJson](cci:1://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/Classes/Base/FileClass.py:27:4-35:25)
- [readParamFile](cci:1://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/Classes/Base/FileClass.py:37:4-48:25)

The `with` statement guarantees `__exit__()` (and therefore `close()`) is called 
regardless of whether the body raises an exception.

## Before / After

```python
# Before — f.close() never reached if json.loads() raises
f = open(path, mode="r")
data = json.loads(f.read())   # ← exception here leaks f
f.close()                     # ← never runs

# After — handle always released
with open(path, mode="r") as f:
    data = json.loads(f.read())   # ← exception still closes f cleanly
