### PR TITLE
refactor(setup): remove unused _venv_pip helper after pip invocation fix

### DIFF
--- a/scripts/setup_dev.py
+++ b/scripts/setup_dev.py
@@ -296,12 +296,6 @@ def _venv_python() -> Path:
     return VENV_DIR / "bin" / "python"
 
 
-def _venv_pip() -> Path:
-    if SYSTEM == "Windows":
-        return VENV_DIR / "Scripts" / "pip.exe"
-    return VENV_DIR / "bin" / "pip"
-
-
 def setup_venv() -> bool:
     """Create a Python venv if one does not already exist."""
     _print_header("Step 1: Python virtual environment")
@@ -338,7 +332,6 @@ def install_python_deps() -> bool:
         _print_fail("requirements.txt not found", str(REQUIREMENTS))
         return False
 
-    pip = str(_venv_pip())
     python = str(_venv_python())
     current_req_hash = _sha256(REQUIREMENTS)
     cached_req_hash = _read_requirements_hash()


### PR DESCRIPTION
## Summary

- What changed:
  - Removed the `_venv_pip()` helper function from `setup_dev.py`.
  - Removed the unused `pip` variable inside `install_python_deps()`.
- Why:
  - After PR #87 switched dependency installation to `python -m pip`, the `_venv_pip()` helper and related `pip` variable became unused.
  - This is a small follow-up cleanup suggested during review.
  - No functional changes.

## Related issues

- [x] Issue exists and is linked
- Refs #86 

## Validation

- [x] Tests added/updated (not applicable)
- [x] Validation steps documented (not applicable; no behavior change)
- [x] Evidence attached (not applicable; cleanup only)

## Documentation

- [x] Docs updated in this PR (not applicable)
- [x] Any setup/workflow changes reflected in repo docs (not applicable)

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:mac-port`
