### PR TITLE
Add a setup file for the Mac setup and update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ For setup options, use the "--help" flag:
 - macOS / Linux: `./scripts/setup.sh --help`
 - Windows: `scripts\setup.bat --help`
 
+## Troubleshooting
+
+For common setup issues, especially on **macOS (Apple Silicon)**, please refer to the [Troubleshooting Guide](docs/TROUBLESHOOTING.md).
+
 ## Demo Data
 
 - Archive: `assets/demo-data/CLEWs.Demo.zip`

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,47 @@
+# Troubleshooting MUIOGO Setup
+
+This guide addresses common issues encountered during the setup and execution of MUIOGO.
+
+## macOS (Apple Silicon / Intel) Common Issues
+
+### Homebrew Permission Errors
+When running `./scripts/setup.sh`, you may encounter an error message stating that `/opt/homebrew` is not writable. This prevents the script from automatically installing the required solvers (`glpk` and `cbc`).
+
+**Error Message Example:**
+```text
+Error: /opt/homebrew is not writable. You should change the ownership and permissions of /opt/homebrew back to your user account.
+```
+
+**Resolution:**
+1. Open your terminal.
+2. Run the following command to fix the permissions (you will be prompted for your Mac password):
+   ```bash
+   sudo chown -R $(whoami) /opt/homebrew
+   ```
+3. After fixing permissions, manually install the solvers:
+   ```bash
+   brew install glpk cbc
+   ```
+4. Verify the installation:
+   ```bash
+   glpsol --version
+   cbc --version
+   ```
+
+### Python 3.11 Not Found
+MUIOGO requires Python 3.11 specifically. If you have other versions installed, the setup script may fail.
+
+**Resolution:**
+Install Python 3.11 using Homebrew:
+```bash
+brew install python@3.11
+```
+
+## Solver Verification
+
+If the application starts but model runs fail, ensure the solvers are in your system's PATH. You can check this by running:
+```bash
+which glpsol
+which cbc
+```
+If these commands do not return a path, please install them manually as described in the [Requirements](../README.md#requirements) section.


### PR DESCRIPTION
## Summary

- What changed:
      - Created a new documentation file:  `docs/TROUBLESHOOTING.md` specifically for macOS and Apple Silicon setup issues.
       - Updated `README.md` to include a "Troubleshooting" section that links to the new guide.
- Why:
          - To provide clear, actionable steps for users who encounter Homebrew permission errors (`/opt/homebrew is not writable`) or Python version mismatches during the initial setup. This makes the onboarding process smoother for Mac developers.

## Related issues

- [x] Issue exists and is linked
- Closes #
- Related #

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

## Documentation

- [x] Docs updated in this PR (or not applicable)
- [x] Any setup/workflow changes reflected in repo docs

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)
