### PR TITLE
feat(deps): add requirements-dev.txt for optional dev/testing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ At the moment, this repository starts from a direct copy baseline of MUIO. The g
 - GLPK and CBC solvers:
   - Installed automatically by setup scripts (`./scripts/setup.sh` or `scripts\\setup.bat`)
 
+### Development / testing tools (optional)
+
+Contributors and CI can install dev tools separately:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+This adds `pytest`, `ruff`, `coverage`, and `pytest-cov`. It is not required to run the app.
+
 ## Quick Start
 
 ### macOS / Linux (in Terminal)

--- a/README.md
+++ b/README.md
@@ -41,13 +41,18 @@ At the moment, this repository starts from a direct copy baseline of MUIO. The g
 
 ### Development / testing tools (optional)
 
-Contributors and CI can install dev tools separately:
+Dev tools (`pytest`, `ruff`, `coverage`, `pytest-cov`) are optional and can be installed separately:
 
 ```bash
 pip install -r requirements-dev.txt
 ```
 
-This adds `pytest`, `ruff`, `coverage`, and `pytest-cov`. It is not required to run the app.
+Runtime dependencies are a separate install step — only needed if you want to run the app or tests that import app code:
+
+```bash
+pip install -r requirements.txt        # runtime deps (if needed)
+pip install -r requirements-dev.txt     # dev/testing tools
+```
 
 ## Quick Start
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+# Development and testing dependencies
+# Install with: pip install -r requirements-dev.txt
+# This does NOT auto-install runtime deps; install requirements.txt first.
+
+pytest>=7.0,<9.0
+pytest-cov>=4.0,<6.0
+ruff>=0.4,<1.0
+coverage>=7.0,<8.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Development and testing dependencies
 # Install with: pip install -r requirements-dev.txt
-# This does NOT auto-install runtime deps; install requirements.txt first.
+# This does NOT include runtime deps; install requirements.txt as well if you need to run the app/tests that use them.
 
 pytest>=7.0,<9.0
 pytest-cov>=4.0,<6.0


### PR DESCRIPTION
**Summary**
Add `requirements-dev.txt` as an explicit, opt-in file for development and testing dependencies.

This is **PR 2 of 3** as requested in #121 - focused solely on dev dependencies.

**What's included**

**New file: `requirements-dev.txt`**

| Package | Version range | Purpose |
|---|---|---|
| pytest | >=7.0,<9.0 | Test runner |
| pytest-cov | >=4.0,<6.0 | Coverage plugin for pytest |
| ruff | >=0.4,<1.0 | Fast Python linter |
| coverage | >=7.0,<8.0 | Code coverage measurement |

**Updated: `README.md`**
- Added a "Development / testing tools" section documenting the install step

**Design decisions**
- **Standalone file** — does NOT use `-r requirements.txt` so it can be installed independently
- **NOT auto-installed** by setup scripts — keeps the default `./scripts/setup.sh` flow unchanged
- **Version ranges** (not pins) — dev tools are less sensitive to exact versions than runtime deps
- If auto-installing dev tools from setup scripts is desired, that should be a separate explicit decision (separate PR)

**Install command**
`pip install -r requirements-dev.txt`

**What is NOT in this PR**

1. No changes to [requirements.txt](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
2. No changes to [setup_dev.py](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
3. No [pyproject.toml](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

**Verification**
- [x] [pip install --dry-run -r requirements-dev.txt](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html) resolves all packages
- [x]  README updated with install instructions
- [x]  No existing workflows modified

Relates to #104