### PR TITLE
feat(config): add pyproject.toml with optional dependency groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,15 @@
 requires = ["setuptools>=67.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+where = ["API"]
+
 [project]
 name = "muiogo"
 version = "0.1.0"
 description = "Modelling User Interface for OG-Core and OSeMOSYS"
-requires-python = ">=3.11,<3.13"
-license = {text = "Apache-2.0"}
+requires-python = ">=3.10,<3.13"
+license = { file = "LICENSE" }
 
 dependencies = [
     "blinker==1.8.2",
@@ -45,9 +48,9 @@ dev = [
     "coverage>=7.0,<8.0",
 ]
 build-win = [
-    "altgraph==0.17.4",
-    "pefile==2023.2.7",
-    "pyinstaller==5.13.2",
-    "pyinstaller-hooks-contrib==2024.7",
-    "pywin32-ctypes==0.2.2",
+    "altgraph>=0.17",
+    "pefile>=2023.2",
+    "pyinstaller>=5.13,<7.0",
+    "pyinstaller-hooks-contrib>=2024.0",
+    "pywin32-ctypes>=0.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["setuptools>=67.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "muiogo"
+version = "0.1.0"
+description = "Modelling User Interface for OG-Core and OSeMOSYS"
+requires-python = ">=3.11,<3.13"
+license = {text = "Apache-2.0"}
+
+dependencies = [
+    "blinker==1.8.2",
+    "boto3==1.34.122",
+    "botocore==1.34.122",
+    "click==8.1.7",
+    "colorama==0.4.6",
+    "et-xmlfile==1.1.0",
+    "Flask==3.0.3",
+    "Flask-Cors==4.0.1",
+    "itsdangerous==2.2.0",
+    "Jinja2==3.1.4",
+    "jmespath==1.0.1",
+    "MarkupSafe==2.1.5",
+    "numpy==1.26.4",
+    "openpyxl==3.1.4",
+    "packaging==24.0",
+    "pandas==2.2.2",
+    "python-dateutil==2.9.0.post0",
+    "python-dotenv==1.0.1",
+    "pytz==2024.1",
+    "s3transfer==0.10.1",
+    "six==1.16.0",
+    "tzdata==2024.1",
+    "urllib3==2.2.1",
+    "waitress==3.0.0",
+    "Werkzeug==3.0.3",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0,<9.0",
+    "pytest-cov>=4.0,<6.0",
+    "ruff>=0.4,<1.0",
+    "coverage>=7.0,<8.0",
+]
+build-win = [
+    "altgraph==0.17.4",
+    "pefile==2023.2.7",
+    "pyinstaller==5.13.2",
+    "pyinstaller-hooks-contrib==2024.7",
+    "pywin32-ctypes==0.2.2",
+]


### PR DESCRIPTION
Add `pyproject.toml` as the modern standard for project metadata and dependency management.

This is **PR 3 of 3** as requested in #121.

 **What's included**
A single new file: `pyproject.toml`

| Section | Content |
|---|---|
| `[build-system]` | `setuptools.build_meta` (stable public backend) |
| `[project]` | Name, version, license, `requires-python = ">=3.11,<3.13"` |
| `dependencies` | 25 runtime deps matching current `requirements.txt` pins |
| `[project.optional-dependencies] dev` | pytest, pytest-cov, ruff, coverage |
| `[project.optional-dependencies] build-win` | pyinstaller, pywin32-ctypes, pefile, altgraph |

 **Usage**
```ip install .                # runtime deps
pip install .[dev]           # + dev/testing tools
pip install .[build-win]     # + Windows packaging tools
```

**Design decisions**
- requires-python = ">=3.11,<3.13" matches setup script constraints
- pyinstaller-hooks-contrib==2024.7 matches the current main pin
- setuptools.build_meta used instead of private internal API
- Runtime deps are exact pins (matching requirements.txt); optional groups use ranges

**What is NOT in this PR**
- No changes to [requirements.txt](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- No changes to [setup_dev.py](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
- No changes to [README.md](vscode-file://vscode-app/c:/Users/HP/AppData/Local/Programs/Microsoft%20VS%20Code/072586267e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

**Verification**
- [x] Valid TOML (parsed with tomllib)
- [x]  All fields validated programmatically
- [x]  Single file, single concern

Relates to #104