### PR TITLE
[Bug Fix] UnboundLocalError in updateData route when case session is None

### DIFF
--- a/API/Routes/Case/CaseRoute.py
+++ b/API/Routes/Case/CaseRoute.py
@@ -223,16 +223,23 @@ def updateData():
         param = request.json['param']
         case = session.get('osycase', None)
         dataJson = request.json['dataJson']
+        
+        # Early return if case is None - prevents UnboundLocalError
+        if case is None:
+            return jsonify({
+                "message": "No active case session found. Please select a case first.",
+                "status_code": "error"
+            }), 400
+        
         dataPath = Path(Config.DATA_STORAGE, case, dataJson)
-        if case != None:
-            sourceData = File.readFile(dataPath)
-            sourceData[param] = data
-            File.writeFile(sourceData, dataPath)
-            #File.writeFileUJson(sourceData, dataPath)
-            response = {
-                "message": "Your data has been saved!",
-                "status_code": "success"
-            }      
+        sourceData = File.readFile(dataPath)
+        sourceData[param] = data
+        File.writeFile(sourceData, dataPath)
+        #File.writeFileUJson(sourceData, dataPath)
+        response = {
+            "message": "Your data has been saved!",
+            "status_code": "success"
+        }      
         return jsonify(response), 200
     except(IOError):
         return jsonify('No existing cases!'), 404


### PR DESCRIPTION
## Problem
The `updateData` route crashes with `UnboundLocalError` when user session has no active case because `response` variable is never assigned when `case` is `None`.


This PR fixes the issues mentioned in #142 

## Solution
- Added early return when `case is None`
- Returns proper HTTP 400 with descriptive error message
- Prevents server crash and improves user experience


## Changes
- Modified `updateData()` in `API/Routes/Case/CaseRoute.py`
- Added null check with early return pattern
- Consistent with other routes' error handling

## Testing
- ✅ Valid case session: works as before
- ✅ Null case session: returns 400 instead of 500 crash
- ✅ No regression in existing functionality

Fixes: UnboundLocalError server crash bug
Type: Bug Fix
Priority: High (prevents crashes)