### PR TITLE
fix(config): load S3 credentials from environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# AWS / S3 configuration
+S3_KEY=your_aws_access_key
+S3_SECRET=your_aws_secret_key
+S3_BUCKET=your_s3_bucket_name
+
+# Enable S3 sync (0 or 1)
+AWS_SYNC=0

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ WebAPP/References/wijmoOLD/
 WebAPP/References/wijmo/DistributionKey.txt
 WebAPP/References/wijmo/licence.js
 app.spec
+.env

--- a/API/Classes/Base/Config.py
+++ b/API/Classes/Base/Config.py
@@ -1,21 +1,19 @@
 from pathlib import Path
 import os
-#from dotenv import load_dotenv
 import platform
 
-#load environment variables
-#load_dotenv()
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    # dotenv is optional; environment variables may already be set
+    pass
 
 SYSTEM = platform.system()
 
-# S3_BUCKET = os.environ.get("S3_BUCKET")
-# S3_KEY = os.environ.get("S3_KEY")
-# S3_SECRET = os.environ.get("S3_SECRET")
-
-#S3 bucket is not used in Osemosys
-S3_BUCKET = ""
-S3_KEY = ""
-S3_SECRET = ""
+S3_BUCKET = os.environ.get("S3_BUCKET", "")
+S3_KEY = os.environ.get("S3_KEY", "")
+S3_SECRET = os.environ.get("S3_SECRET", "")
 
 ALLOWED_EXTENSIONS = set(['zip', 'application/zip'])
 ALLOWED_EXTENSIONS_XLS = set(['xls', 'xlsx'])

--- a/API/Classes/Base/SyncS3.py
+++ b/API/Classes/Base/SyncS3.py
@@ -10,6 +10,13 @@ from Classes.Base import Config
 class SyncS3():
     def __init__(self):
         #S3.__init__(self)
+        if not Config.S3_KEY or not Config.S3_SECRET:
+            raise RuntimeError(
+                "S3 credentials are missing. Please set S3_KEY and S3_SECRET "
+                "via environment variables or a .env file. "
+                "See .env.example for details."
+            )
+
         self.resource = boto3.resource(
         "s3",
         aws_access_key_id=Config.S3_KEY,
@@ -21,6 +28,7 @@ class SyncS3():
             aws_access_key_id=Config.S3_KEY,
             aws_secret_access_key=Config.S3_SECRET
         )
+
 
     def getCasesSyncInit(self):
         try:


### PR DESCRIPTION
## Summary

This PR completes the intended environment-based configuration for S3.

### What changed
- Re-enabled optional dotenv-based configuration loading
- Load S3 credentials from environment variables instead of hardcoded values
- Added `.env.example` to document required configuration keys
- Ignored `.env` to prevent accidental secret leaks
- Fail fast with a clear error when S3 credentials are missing and S3 sync is enabled

### Why
Environment-based configuration was partially implemented but commented out,
resulting in S3 being initialized with empty credentials and unclear runtime
failures. This PR finishes that implementation while remaining backward-compatible.

## Related issue
Closes #147 