### PR TITLE
fix: guard against None value in OsemosysClass PARAM dict build

### DIFF
--- a/API/Classes/Case/OsemosysClass.py
+++ b/API/Classes/Case/OsemosysClass.py
@@ -66,7 +66,7 @@ class Osemosys():
         for k, l in self.PARAMETERS.items():
             tmp = {}
             for de in l:
-                tmp[de['id']] = de['value'].replace(" ", "")
+                tmp[de['id']] = (de['value'] or "").replace(" ", "")
             d[k] = tmp
         self.PARAM = d
 


### PR DESCRIPTION
de['value'].replace(' ', '') crashed with AttributeError when any parameter entry in Parameters.json had value: null. This blocked all solver runs unconditionally with an unhandled 500.

Changed to (de['value'] or '').replace(' ', '') so None is treated as an empty string and the space-stripping behaviour is preserved for all valid string values.

Fixes #150 