### PR TITLE
fix: prevent setSession call when casename is null (Fixes #161)

### DIFF
--- a/API/app.py
+++ b/API/app.py
@@ -105,6 +105,10 @@ def getSession():
 def setSession():
     try:
         cs = request.json['case']
+        if cs is None:
+            session.pop('osycase', None)
+            return jsonify({"osycase": None}), 200
+
         from pathlib import Path
         if not Path(Config.DATA_STORAGE, cs).is_dir():
             return jsonify({'message': 'Case not found.', 'status_code': 'error'}), 404


### PR DESCRIPTION
## Summary

- What changed:
  Added a `None` check in the `API/app.py ` `/setSession` endpoint to handle when `request.json['case']` is null. When intercepted, it will immediately clear the session cleanly and return `200 OK` rather than trying to construct a `pathlib.Path` from None.
<img width="565" height="82" alt="image" src="https://github.com/user-attachments/assets/483c05b1-a9a2-4acd-942c-53795242ed2f" />


- Why:
 When clicking "create new configuration" on the `Addcase` screen, the UI sends a `{"case": null}` payload to reset the active session. This caused a 500 Internal Server Error backend crash rather than actually clearing the session.

## Related issues

- [x] Issue exists and is linked
- Closes #161 
- Related #

## Validation

- [ ] Tests added/updated (or not applicable)
- [x] Validation steps documented
  Select an existing case, Click the "create new configuration" button, Verify no 500 errors appear in the server console and the form successfully clears, showing "Model messages: Configure new Model!"
Solution stops this error and allows user to create a new case.

- [ ] Evidence attached (logs/screenshots/output as relevant)

## Documentation

- [x] Docs updated in this PR (or not applicable)
- [ ] Any setup/workflow changes reflected in repo docs

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)
