### PR TITLE
refactor: preserve traceback by using bare raise in FileClass.py

### DIFF
--- a/API/Classes/Base/FileClass.py
+++ b/API/Classes/Base/FileClass.py
@@ -9,11 +9,11 @@ class File:
                 data = json.loads(f.read())
             return data
         except IndexError:
-            raise IndexError
+            raise
         except IOError:
-            raise IOError
+            raise
         except OSError:
-            raise OSError
+            raise
 
     @staticmethod
     def writeFile(data, path):
@@ -23,7 +23,7 @@ class File:
         except (IOError, IndexError):
             raise IndexError
         except OSError:
-            raise OSError
+            raise
 
     @staticmethod
     def writeFileUJson(data, path):
@@ -33,7 +33,7 @@ class File:
         except (IOError, IndexError):
             raise IndexError
         except OSError:
-            raise OSError
+            raise
 
     @staticmethod
     def readParamFile(path):
@@ -42,8 +42,8 @@ class File:
                 data = json.loads(f.read())
             return data
         except IndexError:
-            raise IndexError
+            raise
         except IOError:
-            raise IOError
+            raise
         except OSError:
-            raise OSError
+            raise


### PR DESCRIPTION
## Summary

- **What changed:**
  Replaced same-exception rethrows (`raise IOError`, `raise OSError`, `raise IndexError`) inside corresponding `except` blocks with a bare `raise` in `API/Classes/Base/FileClass.py`.

- **Why:**
  Re-raising the same exception type using `raise IOError` (or similar) re-instantiates the exception and discards the original traceback.
  Using a bare `raise` preserves the original exception context and improves debuggability, consistent with the approach introduced in PR #82.

## Related issues

- [x] Issue exists and is linked
- Closes #88 

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented (not applicable - no behavioral change)
- [x] Evidence attached (diff shows only same-exception rethrows updated)

This change does not alter control flow or error contracts. It only preserves original tracebacks.

## Documentation

- [x] Docs updated in this PR (not applicable)
- [x] Any setup/workflow changes reflected in repo docs (not applicable)

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)
