### PR TITLE
refactor: preserve traceback in SyncS3 exception handlers

### DIFF
--- a/API/Classes/Base/SyncS3.py
+++ b/API/Classes/Base/SyncS3.py
@@ -31,8 +31,8 @@ class SyncS3():
             else:
                 cases = []
             return cases
-        except(IOError):
-            raise IOError
+        except IOError:
+            raise
 
     def downloadSync(self, prefix, local, bucket):
         """
@@ -113,8 +113,8 @@ class SyncS3():
         try:
             my_bucket = self.resource.Bucket(Config.S3_BUCKET)
             my_bucket.objects.filter(Prefix=case+"/").delete()
-        except(IOError):
-            raise IOError
+        except IOError:
+            raise
 
     def updateSync(self, localFile, awsInitDir, bucketName):
         """


### PR DESCRIPTION
## Summary

* **What changed:**
  Replaced same-exception rethrows (`raise IOError`) with a bare `raise` in `API/Classes/Base/SyncS3.py`.

* **Why:**
  - Using `raise IOError` re-instantiates the exception and discards the original traceback. 
  - A bare `raise` preserves the original exception context, improving debuggability and aligning with the direction clarified in #88 and prior refactor in `CaseClass.py`.

## Related issues

* [x] Issue exists and is linked
* Closes #88 

## Validation

* [x] Tests added/updated (or not applicable)
* [x] Validation steps documented (not applicable)
* [x] Evidence attached (diff shows only same-exception rethrows updated)

This change does not alter control flow or exception contracts. It only preserves original tracebacks.

## Documentation

* [x] Docs updated in this PR (not applicable)
* [x] Any setup/workflow changes reflected in repo docs (not applicable)

## Scope check

* [x] No unrelated refactors
* [x] Implemented from a feature branch
* [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
* [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)