### PR TITLE
refactor: preserve traceback in OsemosysClass exception handlers

### DIFF
--- a/API/Classes/Case/OsemosysClass.py
+++ b/API/Classes/Case/OsemosysClass.py
@@ -938,8 +938,8 @@ class Osemosys():
                     (obj['TsId'] == Timeslice if Timeslice is not None else True)):
                     obj[year] = value
             File.writeFile( jsonData, jsonPath)
-        except(IOError):
-            raise IOError
+        except IOError:
+            raise
 
     def updateTEViewData(self, casename, ScId, GroupId, ParamId, TechId, EmisId, value):
         try:
@@ -952,5 +952,5 @@ class Osemosys():
                         (k == EmisId if EmisId is not None else True)):
                         obj[k] = value
             File.writeFile( jsonData, jsonPath)
-        except(IOError):
-            raise IOError
+        except IOError:
+            raise


### PR DESCRIPTION
## Summary

* What changed:
  Replaced same-exception rethrows (`raise IOError`) with a bare `raise` in `API/Classes/Case/OsemosysClass.py`.

* Why:
  - Using `raise IOError` re-instantiates the exception and discards the original traceback.
  - A bare `raise` preserves the original exception context and improves debuggability, consistent with the direction clarified in #88.

## Related issues

* [x] Issue exists and is linked
* Closes #88 
* Related #

## Validation

* [x] Tests added/updated (not applicable)
* [x] Validation steps documented (not applicable)
* [x] Evidence attached (diff shows only same-exception rethrows updated)

## Documentation

* [x] Docs updated in this PR (not applicable)
* [x] Any setup/workflow changes reflected in repo docs (not applicable)

## Scope check

* [x] No unrelated refactors
* [x] Implemented from a feature branch
* [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
* [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)