### PR TITLE
ci: add ruff lint check on pull requests (#175)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,29 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  ruff:
+    name: ruff lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install ruff
+        run: pip install ruff==0.4.4
+
+      - name: Run ruff
+        run: ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[tool.ruff]
+target-version = "py311"
+
+# Exclude vendored third-party assets and generated data directories
+exclude = [
+    "WebAPP/References",
+    "WebAPP/DataStorage",
+    "assets",
+    "docs",
+    ".venv",
+]
+
+[tool.ruff.lint]
+# E9  — syntax errors (SyntaxError, IndentationError)
+# F   — Pyflakes (imports, undefined names, etc.)
+# Only these two categories are enforced now.
+# E501, style rules, and import ordering are deferred until legacy code is cleaned up.
+select = ["E9", "F"]
+
+# Pre-existing violations in the current codebase, deferred for separate cleanup PRs:
+# F401 — unused imports throughout API/
+# F821 — undefined names (false positives from Flask Blueprint dynamic routing)
+# F841 — unused local variables throughout API/
+ignore = ["F401", "F821", "F841"]


### PR DESCRIPTION
## Summary

- What changed:
  - Added a GitHub Actions workflow at `.github/workflows/lint.yml`
  - Configured the workflow to run Ruff on `pull_request` and `push` to `main`
  - Added minimal Ruff configuration (if applicable) to avoid failing on legacy style issues

- Why:
  - The repository previously had no automated CI checks for code quality.
  - This introduces a minimal linting quality gate to reduce manual review burden.
  - Scope is intentionally limited to linting only (no tests, packaging, or full CI/CD pipeline).

## Related issues

- [x] Issue exists and is linked
- Closes #175 
- Related #

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)
Validation steps:

1. Installed Ruff locally:
   pip install ruff

2. Verified lint runs:
   ruff check .

3. Confirmed workflow:
   - Triggers on pull_request to main
   - Triggers on push to main
   - Uses ubuntu-latest
   - Sets up Python 3.10
   - Installs Ruff
   - Runs `ruff check .`

No runtime behavior was modified.

## Documentation

- [x] Docs updated in this PR (or not applicable)
- [x] Any setup/workflow changes reflected in repo docs

No documentation updates required.
This change affects only CI infrastructure.

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)
