### PR TITLE
async solver execution with job-based run management 

### DIFF
--- a/API/Classes/Base/JobManager.py
+++ b/API/Classes/Base/JobManager.py
@@ -1,0 +1,158 @@
+import threading
+import uuid
+import time
+from typing import Optional, Dict, Any
+
+# Job status constants
+JOB_PENDING   = "pending"
+JOB_RUNNING   = "running"
+JOB_COMPLETED = "completed"
+JOB_ERROR     = "error"
+JOB_CANCELLED = "cancelled"
+
+MAX_JOBS = 100    # Maximum jobs kept in memory before eviction
+JOB_TTL  = 86400  # Seconds before terminal jobs are evicted (24h)
+
+
+class Job:
+    """Tracks a single solver run — its status, result, and how to cancel it."""
+    def __init__(self, job_id: str, casename: str, caserunname: str, solver: str):
+        self.job_id      = job_id
+        self.casename    = casename
+        self.caserunname = caserunname
+        self.solver      = solver
+        self.status      = JOB_PENDING
+        self.result      = None
+        self.error       = None
+        self.created_at  = time.time()
+        self.started_at  = None
+        self.finished_at = None
+        self.cancel_event = threading.Event()
+        self.process      = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Job snapshot, safe to return directly in an HTTP response."""
+        return {
+            "job_id":       self.job_id,
+            "casename":     self.casename,
+            "caserunname":  self.caserunname,
+            "solver":       self.solver,
+            "status":       self.status,
+            "result":       self.result,
+            "error":        self.error,
+            "created_at":   self.created_at,
+            "started_at":   self.started_at,
+            "finished_at":  self.finished_at,
+        }
+
+    def cancel(self):
+        """Tell the solver to stop and kill the process if it's still running."""
+        self.cancel_event.set()
+        if self.process is not None:
+            try:
+                self.process.kill()
+            except OSError:
+                pass  # already finished
+
+
+class JobManager:
+    """
+    Keeps track of all solver jobs. One instance shared across the app.
+    Route handlers create jobs here; worker threads update them.
+    """
+    _instance: Optional["JobManager"] = None
+    _class_lock = threading.Lock()
+
+    def __init__(self):
+        self._jobs: Dict[str, Job] = {}
+        self._jobs_lock = threading.Lock()
+
+    @classmethod
+    def get_instance(cls) -> "JobManager":
+        """Get the shared instance, creating it if it doesn't exist yet."""
+        if cls._instance is None:
+            with cls._class_lock:
+                if cls._instance is None:
+                    cls._instance = cls()
+        return cls._instance
+
+    # Job lifecycle
+
+    def create_job(self, casename: str, caserunname: str, solver: str) -> Job:
+        """Start tracking a new job and return it."""
+        job_id = str(uuid.uuid4())
+        job = Job(job_id, casename, caserunname, solver)
+        with self._jobs_lock:
+            self._evict_old_jobs()
+            self._jobs[job_id] = job
+        return job
+
+    def get_job(self, job_id: str) -> Optional[Job]:
+        """Look up a job by its ID. Returns None if it doesn't exist."""
+        with self._jobs_lock:
+            return self._jobs.get(job_id)
+
+    def start_job(self, job_id: str):
+        """Mark the job as running."""
+        with self._jobs_lock:
+            job = self._jobs.get(job_id)
+            if job and job.status == JOB_PENDING:
+                job.status = JOB_RUNNING
+                job.started_at = time.time()
+
+    def complete_job(self, job_id: str, result: dict):
+        """Store the result and mark the job as done."""
+        with self._jobs_lock:
+            job = self._jobs.get(job_id)
+            if job and job.status == JOB_RUNNING:
+                job.status = JOB_COMPLETED
+                job.result = result
+                job.finished_at = time.time()
+
+    def fail_job(self, job_id: str, error: str):
+        """Store the error and mark the job as failed."""
+        with self._jobs_lock:
+            job = self._jobs.get(job_id)
+            if job and job.status == JOB_RUNNING:
+                job.status = JOB_ERROR
+                job.error = error
+                job.finished_at = time.time()
+
+    def cancel_job(self, job_id: str) -> bool:
+        """
+        Cancel a job that is still in progress.
+        Returns True if the signal was sent, False if not found or already finished.
+        """
+        with self._jobs_lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return False
+            if job.status in (JOB_COMPLETED, JOB_ERROR, JOB_CANCELLED):
+                return False
+            job.status = JOB_CANCELLED
+            job.finished_at = time.time()
+        job.cancel()
+        return True
+
+    # Cleanup
+
+    def _evict_old_jobs(self):
+        """Remove old finished jobs before adding a new one."""
+        now = time.time()
+        terminal = (JOB_COMPLETED, JOB_ERROR, JOB_CANCELLED)
+
+        stale = [
+            jid for jid, j in self._jobs.items()
+            if j.status in terminal and j.finished_at is not None
+            and (now - j.finished_at) > JOB_TTL
+        ]
+        for jid in stale:
+            del self._jobs[jid]
+
+        if len(self._jobs) >= MAX_JOBS:
+            terminal_jobs = sorted(
+                [(jid, j) for jid, j in self._jobs.items() if j.status in terminal],
+                key=lambda x: x[1].finished_at or 0
+            )
+            for jid, _ in terminal_jobs[:len(self._jobs) - MAX_JOBS + 1]:
+                del self._jobs[jid]

--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -2083,7 +2083,41 @@ class DataFile(Osemosys):
         except OSError:
             raise OSError
 
-    def run( self, solver, caserun, lock=None ):
+    def _popen_with_cancel(self, cmd, cwd, cancel_event=None, job=None, start_time=None, timeout=3600):
+        """
+        Run a subprocess and check every 0.5s for cancellation or timeout.
+        Raises RuntimeError on cancel or timeout so the caller can clean up.
+        """
+        proc = subprocess.Popen(
+            cmd,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if job is not None:
+            job.process = proc
+        if start_time is None:
+            start_time = time.time()
+        while proc.poll() is None:
+            if cancel_event is not None and cancel_event.is_set():
+                proc.kill()
+                proc.communicate()
+                raise RuntimeError("__cancelled__")
+            if time.time() - start_time > timeout:
+                proc.kill()
+                proc.communicate()
+                raise RuntimeError("__timeout__")
+            time.sleep(0.5)
+        stdout, stderr = proc.communicate()
+        return subprocess.CompletedProcess(
+            args=proc.args,
+            returncode=proc.returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    def run( self, solver, caserun, lock=None, cancel_event=None, job=None, timeout=3600 ):
         try:
             caserunname = caserun
             if lock is not None:
@@ -2129,11 +2163,11 @@ class DataFile(Osemosys):
             self.deleteCaseResultsJSON(caserunname)
 
             if solver == 'glpk':
-                glpk_out = subprocess.run(
+                glpk_out = self._popen_with_cancel(
                     [str(glpsol_exec), "-m", modelfile, "-d", datafile, "-o", resultfile],
                     cwd=glpfolder,
-                    capture_output=True,
-                    text=True,
+                    cancel_event=cancel_event, job=job,
+                    start_time=start_time, timeout=timeout,
                 )
                 cbc_out = subprocess.CompletedProcess(args=["cbc"], returncode=0, stdout="", stderr="")
             else:
@@ -2153,11 +2187,11 @@ class DataFile(Osemosys):
                 txtOut = txtOut + ("Preprocessing time {:0.2f}s;{}".format(time.time() - start_time, '\n'))
 
                 #return output to variable preprocessed data file
-                glpk_out = subprocess.run(
+                glpk_out = self._popen_with_cancel(
                     [str(glpsol_exec), "--check", "-m", modelfile, "-d", datafile_processed, "--wlp", lpfile],
                     cwd=glpfolder,
-                    capture_output=True,
-                    text=True,
+                    cancel_event=cancel_event, job=job,
+                    start_time=start_time, timeout=timeout,
                 )
             
 
@@ -2183,11 +2217,11 @@ class DataFile(Osemosys):
 
                 #cbc_out = subprocess.run('cbc ' + lpfile +' -presolve off -postsolve on -logLevel 3 solve -printing all -solu '  + resultfile, cwd=cbcfolder,  capture_output=True, text=True, shell=True)
                 # prin
-                cbc_out = subprocess.run(
+                cbc_out = self._popen_with_cancel(
                     [str(cbc_exec), lpfile, "solve", "-printing", "all", "-solu", resultfile],
                     cwd=cbcfolder,
-                    capture_output=True,
-                    text=True,
+                    cancel_event=cancel_event, job=job,
+                    start_time=start_time, timeout=timeout,
                 )
                 # -printing all prints all constraints to result.txt
                 print("SOLUTION DONE! --- %s seconds --- %s" % (time.time() - start_time, caserunname))
@@ -2262,6 +2296,25 @@ class DataFile(Osemosys):
             return response
             # urllib.request.urlretrieve(self.dataFile, dataFile)
 
+        except RuntimeError as ex:
+            msg = str(ex)
+            if msg == "__cancelled__":
+                return {
+                    "cbc_message": "", "cbc_stdmsg": "",
+                    "glpk_message": "", "glpk_stdmsg": "",
+                    "timer": "Run cancelled by user.",
+                    "status_code": "cancelled",
+                    "caserun": caserun
+                }
+            if msg == "__timeout__":
+                return {
+                    "cbc_message": "", "cbc_stdmsg": "",
+                    "glpk_message": "", "glpk_stdmsg": "",
+                    "timer": f"Run timed out after {timeout}s.",
+                    "status_code": "error",
+                    "caserun": caserun
+                }
+            raise
         except Exception as ex:
             print(ex) # do whatever you want for debugging.
             raise    # re-raise exception.

--- a/API/Routes/DataFile/DataFileRoute.py
+++ b/API/Routes/DataFile/DataFileRoute.py
@@ -1,8 +1,9 @@
 from flask import Blueprint, jsonify, request, send_file, session
 from pathlib import Path
-import shutil, datetime, time, os
+import shutil, datetime, time, os, threading
 from Classes.Case.DataFileClass import DataFile
 from Classes.Base import Config
+from Classes.Base.JobManager import JobManager
 
 datafile_api = Blueprint('DataFileRoute', __name__)
 
@@ -215,32 +216,89 @@ def downloadResultsFile():
 @datafile_api.route("/run", methods=['POST'])
 def run():
     try:
-        casename = request.json['casename']
+        casename    = request.json['casename']
         caserunname = request.json['caserunname']
-        solver = request.json['solver']
-        txtFile = DataFile(casename)
-        response = txtFile.run(solver, caserunname)     
-        return jsonify(response), 200
-    # except Exception as ex:
-    #     print(ex)
-    #     return ex, 404
-    
-    except(IOError):
-        return jsonify('No existing cases!'), 404
-    
+        solver      = request.json['solver']
+        timeout     = request.json.get('timeout', 3600)
+
+        manager = JobManager.get_instance()
+        job = manager.create_job(casename, caserunname, solver)
+
+        def worker():
+            manager.start_job(job.job_id)
+            try:
+                txt_file = DataFile(casename)
+                result = txt_file.run(
+                    solver,
+                    caserunname,
+                    cancel_event=job.cancel_event,
+                    job=job,
+                    timeout=timeout,
+                )
+                if result.get('status_code') == 'cancelled':
+                    pass  # cancel_job() already set the status
+                else:
+                    manager.complete_job(job.job_id, result)
+            except Exception as exc:
+                manager.fail_job(job.job_id, str(exc))
+
+        thread = threading.Thread(target=worker, daemon=True, name=f"solver-{job.job_id[:8]}")
+        thread.start()
+
+        return jsonify({
+            "job_id":      job.job_id,
+            "status":      "running",
+            "status_code": "accepted",
+            "message":     "Solver job started. Poll /runStatus/<job_id> for updates."
+        }), 202
+
+    except KeyError as exc:
+        return jsonify({"message": f"Missing required field: {exc}", "status_code": "error"}), 400
+    except Exception as exc:
+        return jsonify({"message": str(exc), "status_code": "error"}), 500
+
+
+@datafile_api.route("/runStatus/<job_id>", methods=['GET'])
+def runStatus(job_id):
+    manager = JobManager.get_instance()
+    job = manager.get_job(job_id)
+    if job is None:
+        return jsonify({"message": "Job not found.", "status_code": "error"}), 404
+    return jsonify(job.to_dict()), 200
+
+
+@datafile_api.route("/cancelRun/<job_id>", methods=['POST'])
+def cancelRun(job_id):
+    manager = JobManager.get_instance()
+    cancelled = manager.cancel_job(job_id)
+    if not cancelled:
+        job = manager.get_job(job_id)
+        if job is None:
+            return jsonify({"message": "Job not found.", "status_code": "error"}), 404
+        return jsonify({
+            "message": f"Job cannot be cancelled \u2014 current status: {job.status}",
+            "status_code": "error"
+        }), 409
+    return jsonify({
+        "message": "Cancellation signal sent.",
+        "status_code": "success"
+    }), 200
+
+
 @datafile_api.route("/batchRun", methods=['POST'])
 def batchRun():
     try:
         start = time.time()
         modelname = request.json['modelname']
         cases = request.json['cases']
+        solver = request.json.get('solver', 'cbc')
 
         if modelname != None:
             txtFile = DataFile(modelname)
             for caserun in cases:
                 txtFile.generateDatafile(caserun)
 
-            response = txtFile.batchRun( 'CBC', cases) 
+            response = txtFile.batchRun( solver, cases) 
         end = time.time()  
         response['time'] = end-start 
         return jsonify(response), 200

--- a/API/app.py
+++ b/API/app.py
@@ -56,6 +56,10 @@ app.register_blueprint(syncs3_api)
 
 CORS(app)
 
+# Start the job manager now so it's ready before the first request.
+from Classes.Base.JobManager import JobManager
+JobManager.get_instance()
+
 #potrebno kad je front end na drugom serveru 127.0.0.1
 @app.after_request
 def add_headers(response):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,8 @@
 - static frontend assets from `WebAPP/`
 - model data and run artifacts in `WebAPP/DataStorage/`
 
-Solver execution is handled by backend subprocess calls (GLPK/CBC).
+Solver execution runs asynchronously , the API returns immediately with a job ID
+and the solver runs in the background.
 
 ## Major components
 
@@ -57,6 +58,23 @@ If no solver is found through any of these steps, a `RuntimeError` is raised
 at startup with a clear, actionable message. This replaces the previous
 hardcoded, platform-specific path strings which failed silently on
 Linux and Apple Silicon (see issue #43).
+
+### Solver execution
+
+Solver runs are handled asynchronously via `JobManager` in
+`API/Classes/Base/JobManager.py`.
+
+When `POST /run` is called:
+
+1. A job is created with a unique ID and the solver starts in a background thread.
+2. The API returns the job ID immediately with HTTP 202.
+3. The client polls `GET /runStatus/<job_id>` to check progress.
+4. If needed, `POST /cancelRun/<job_id>` stops the solver and cleans up.
+
+Each job moves through these states: `pending → running → completed / error / cancelled`.
+
+Jobs are kept in memory and evicted after 24 hours. They are not persisted across
+server restarts.
 
 ## Upstream/downstream relationship
 


### PR DESCRIPTION
## Summary

- What changed: Added `JobManager` to track solver runs as background jobs. `POST /run` now returns a job ID immediately instead of waiting for the solver to finish. Two new endpoints handle status polling (`GET /runStatus/<job_id>`) and cancellation (`POST /cancelRun/<job_id>`). The solver subprocess is now started with `Popen` and checked every 0.5s so it can be cancelled or timed out cleanly. Fixed `batchRun` which was ignoring the solver field from the request and always using CBC.
- Why: The solver was called with `subprocess.run()` inside the request handler, which blocked the thread for the entire duration of the run. If the browser timed out and disconnected, the solver kept running but the result was thrown away. There was also no way to cancel a run once started. This change fixes both.

## Related issues

- [x] Issue exists and is linked
- Closes #174


## Validation

- [x] Tests added/updated (or not applicable) -- not applicable, no test suite exists in this repo yet
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

**Manual verification steps:**

1. Start the server and open the app
2. Trigger a run via `POST /run` with a valid casename, caserunname, and solver
3. Confirm the response comes back immediately with a `job_id` and HTTP 202 -- the browser should not hang
4. Call `GET /runStatus/<job_id>` -- confirm status moves from `running` to `completed` once the solve finishes and the full result is present in the response
5. Start another run, then call `POST /cancelRun/<job_id>` while it is running -- confirm the response is `Cancellation signal sent` and a follow-up status poll shows `cancelled`
6. Call `POST /batchRun` with `solver: glpk` -- confirm it uses GLPK instead of CBC

## Documentation

- [x] Docs updated in this PR (or not applicable)
- [x] Any setup/workflow changes reflected in repo docs

`docs/ARCHITECTURE.md` updated: system overview line updated, new `Solver execution` section added describing the async flow, job states, and in-memory storage behaviour.

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)


### Manual Testing Evidence

Server: `waitress`, `http://127.0.0.1:5002`, demo case `CLEWs Demo / REF`

**Test 1 - `POST /run` returns 202 immediately without blocking**
```json
HTTP 202
{
  "job_id": "41f76b43-181c-4028-b902-f74c3572e556",
  "message": "Solver job started. Poll /runStatus/<job_id> for updates.",
  "status": "running",
  "status_code": "accepted"
}
```

**Test 2 - `GET /runStatus/<job_id>` returns job state**
```json
HTTP 200
{
  "casename": "CLEWs Demo",
  "caserunname": "REF",
  "job_id": "41f76b43-181c-4028-b902-f74c3572e556",
  "solver": "glpk",
  "status": "error",
  "error": "Solver binary 'glpsol' could not be found.",
  "result": null,
  "created_at": 1772552722.995,
  "started_at": 1772552722.996,
  "finished_at": 1772552723.035
}
```

**Test 3 - `POST /cancelRun/<job_id>` returns 409 for a non-running job**
```json
HTTP 409
{
  "message": "Job cannot be cancelled — current status: error",
  "status_code": "error"
}
```
