### PR TITLE
Bug-Fix-Loop

### DIFF
--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -82,6 +82,7 @@ class DataFile(Osemosys):
         r = self.R(File.readFile(self.rPath))
         for id, param in self.PARAM['R'].items():
             self.f.write('{} {} {} {} {} {}'.format('param', param,'default', self.defaultValue[id], ':=','\n'))
+            tmp = self.defaultValue[id]
             for sc in self.scOrder:
                 if r[id][sc['ScId']]['value'] is not None and sc['Active'] == True:
                     tmp = r[id][sc['ScId']]['value']
@@ -107,6 +108,7 @@ class DataFile(Osemosys):
             self.f.write('{}{}{}'.format(self.years, ':=', '\n'))
             ryString = ''
             for yearId in self.yearIDs:
+                tmp = self.defaultValue[id]
                 for sc in self.scOrder:
                     if ry[id][sc['ScId']][yearId] is not None and sc['Active'] == True:
                         tmp = ry[id][sc['ScId']][yearId]
@@ -121,6 +123,7 @@ class DataFile(Osemosys):
             self.f.write('{}{}{}'.format(self.techs, ':=', '\n'))
             rtString = ''
             for techId in self.techIDs:
+                tmp = self.defaultValue[id]
                 for sc in self.scOrder:
                     if rt[id][sc['ScId']][techId] is not None and sc['Active'] == True:
                         tmp = rt[id][sc['ScId']][techId]
@@ -135,6 +138,7 @@ class DataFile(Osemosys):
             self.f.write('{}{}{}'.format(self.emis, ':=', '\n'))
             reString = ''
             for emiId in self.emiIDs:
+                tmp = self.defaultValue[id]
                 for sc in self.scOrder:
                     if re[id][sc['ScId']][emiId] is not None and sc['Active'] == True:
                         tmp = re[id][sc['ScId']][emiId]
@@ -149,6 +153,7 @@ class DataFile(Osemosys):
             self.f.write('{}{}{}'.format(self.stgs, ':=', '\n'))
             rsString = ''
             for stgId in self.stgIDs:
+                tmp = self.defaultValue[id]
                 for sc in self.scOrder:
                     if re[id][sc['ScId']][stgId] is not None and sc['Active'] == True:
                         tmp = re[id][sc['ScId']][stgId]


### PR DESCRIPTION
---

## Summary

**What changed:**

In `gen_R()`, `gen_RY()`, `gen_RT()`, `gen_RE()`, and `gen_RS()`, the variable `tmp` was only ever assigned inside the scenario loop condition:

```python
for sc in self.scOrder:
    if r[id][sc['ScId']]['value'] is not None and sc['Active'] == True:
        tmp = r[id][sc['ScId']]['value']   # only set if condition is true
self.f.write('{} {} {}'.format('RE1', tmp, '\n'))  # used unconditionally
```

If no active scenario had a non-`None` value for a given parameter, `tmp` was never set. On the first parameter iteration this caused a hard crash (`NameError: name 'tmp' is not defined`). On every subsequent iteration it silently carried over the value from the *previous* parameter and wrote it to the solver data file — wrong data, no error, no warning.

**Why this matters:** The solver data file drives the optimisation model. A parameter written with a stale value from a completely different parameter leads to incorrect results without any indication that something went wrong. For a tool used to inform energy policy decisions this is a serious correctness issue.

**Fix:** Add `tmp = self.defaultValue[id]` before the `for sc` loop in each of the five methods. If no active scenario provides a value, the declared parameter default is used — which is exactly what the `param ... default ...` header already advertises to the solver.

---


## Validation

- [ ] Tests added/updated (or not applicable)
- [x] Validation steps documented

To reproduce before the fix: create a case where all scenarios have `Active == False` (or all values are `None`) for at least one parameter, then trigger `generateDatafile()`. It will either crash on the first affected parameter or silently write a value from a previous parameter. After the fix, `self.defaultValue[id]` is written correctly in both cases.

---

## Documentation

- [ ] Docs updated in this PR (or not applicable)
- [x] No setup or workflow changes — internal data generation logic only

---

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch (`bug-fix-loop`)
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)