### PR TITLE
Fix: Validate required Excel sheets upfront in ImportTemplate.importProcess()`

### DIFF
--- a/API/Classes/Case/ImportTemplate.py
+++ b/API/Classes/Case/ImportTemplate.py
@@ -470,6 +470,16 @@ class ImportTemplate():
 
             df_sheet_all = pd.read_excel(self.TEMPLATE_PATH, sheet_name=None, engine='openpyxl')
 
+            required_sheets = [
+                'TECHNOLOGY', 'FUEL', 'EMISSION', 'STORAGE', 'YEAR',
+                'MODE_OF_OPERATION', 'TIMESLICE', 'SEASON', 'DAYTYPE',
+                'DAILYTIMEBRACKET', 'InputActivityRatio', 'OutputActivityRatio',
+                'EmissionActivityRatio', 'TechnologyFromStorage', 'TechnologyToStorage'
+            ]
+            missing_sheets = [s for s in required_sheets if s not in df_sheet_all]
+            if missing_sheets:
+                return {"message": f"Template is missing required sheet(s): {', '.join(missing_sheets)}", "status_code": "error"}
+
             techs_xls =  df_sheet_all['TECHNOLOGY']
             comms_xls =  df_sheet_all['FUEL']
             emis_xls =  df_sheet_all['EMISSION']

--- a/API/Classes/Case/ImportTemplate.py
+++ b/API/Classes/Case/ImportTemplate.py
@@ -471,7 +471,7 @@ class ImportTemplate():
             df_sheet_all = pd.read_excel(self.TEMPLATE_PATH, sheet_name=None, engine='openpyxl')
 
             required_sheets = [
-                'TECHNOLOGY', 'FUEL', 'EMISSION', 'STORAGE', 'YEAR',
+                'TECHNOLOGY', 'TECHGROUP', 'FUEL', 'EMISSION', 'STORAGE', 'YEAR',
                 'MODE_OF_OPERATION', 'TIMESLICE', 'SEASON', 'DAYTYPE',
                 'DAILYTIMEBRACKET', 'InputActivityRatio', 'OutputActivityRatio',
                 'EmissionActivityRatio', 'TechnologyFromStorage', 'TechnologyToStorage'


### PR DESCRIPTION


## Summary

- **What changed:** Added upfront validation in `ImportTemplate.importProcess()` that checks all 15 required Excel sheets are present before any sheet access is attempted. If any are missing, the method now returns a clear, structured error message listing exactly which sheets are absent.

- **Why:** Previously, accessing a missing sheet key on the `df_sheet_all` dictionary would raise a raw `KeyError` with no user-friendly context. For non-technical users (e.g. policymakers importing country energy data), this was completely opaque — especially combined with the existing error-handler issue that surfaces exception classes rather than their messages. The new validation catches all missing sheets in one pass and returns a readable response like `"Template is missing required sheet(s): FUEL, YEAR"` before anything crashes.


## Validation

- [ ] Tests added/updated (or not applicable)
- [x] Validation steps documented
- **To validate manually:** Upload a template `.xlsx` file with one or more of the required sheets removed (e.g. delete the `FUEL` or `YEAR` tab). The API should now return a `status_code: "error"` response with a message naming the missing sheet(s), rather than throwing an unhandled exception.

## Documentation

- [x] Docs updated in this PR (or not applicable) — no doc changes needed; this is an internal error-handling improvement with no API contract changes.

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch (`import-template`)
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)