### PR TITLE
feat: add request field validation to prevent KeyError 500s

### DIFF
--- a/API/Classes/Base/RequestValidator.py
+++ b/API/Classes/Base/RequestValidator.py
@@ -1,0 +1,34 @@
+from flask import request, jsonify
+
+
+def get_required_fields(fields: list):
+    """
+    Extract and validate required fields from the request JSON body.
+
+    Returns:
+        (data_dict, None)        — on success, data_dict contains all requested fields
+        (None, error_response)   — if body is not JSON or any field is missing
+
+    Usage:
+        fields, err = get_required_fields(['casename', 'caserunname'])
+        if err:
+            return err
+        casename    = fields['casename']
+        caserunname = fields['caserunname']
+    """
+    if not request.is_json or request.json is None:
+        return None, (jsonify({
+            "message": "Request body must be valid JSON.",
+            "status_code": "error"
+        }), 400)
+
+    data = {}
+    for field in fields:
+        if field not in request.json:
+            return None, (jsonify({
+                "message": f"Missing required field: '{field}'",
+                "status_code": "error"
+            }), 400)
+        data[field] = request.json[field]
+
+    return data, None

--- a/API/Routes/Case/CaseRoute.py
+++ b/API/Routes/Case/CaseRoute.py
@@ -9,6 +9,7 @@ from Classes.Case.CaseClass import Case
 from Classes.Case.UpdateCaseClass import UpdateCase
 from Classes.Case.ImportTemplate import ImportTemplate
 from Classes.Base.SyncS3 import SyncS3
+from Classes.Base.RequestValidator import get_required_fields
 
 case_api = Blueprint('CaseRoute', __name__)
 
@@ -41,8 +42,11 @@ def getCases():
 @case_api.route("/getResultCSV", methods=['POST'])
 def getResultCSV():
     try:
-        casename = request.json['casename']
-        caserunname = request.json['caserunname']
+        fields, err = get_required_fields(['casename', 'caserunname'])
+        if err:
+            return err
+        casename = fields['casename']
+        caserunname = fields['caserunname']
         csvFolder = Path(Config.DATA_STORAGE,casename,"res", caserunname, "csv")
         if os.path.isdir(csvFolder):
             csvs = [ f.name for f in os.scandir(csvFolder) ]
@@ -55,7 +59,10 @@ def getResultCSV():
 @case_api.route("/getDesc", methods=['POST'])
 def getDesc():
     try:
-        casename = request.json['casename']
+        fields, err = get_required_fields(['casename'])
+        if err:
+            return err
+        casename = fields['casename']
         genDataPath = Path(Config.DATA_STORAGE,casename,"genData.json")
         genData = File.readFile(genDataPath)
         response = {
@@ -69,7 +76,10 @@ def getDesc():
 @case_api.route("/copyCase", methods=['POST'])
 def copy():
     try:
-        case = request.json['casename']
+        fields, err = get_required_fields(['casename'])
+        if err:
+            return err
+        case = fields['casename']
         active_case = session.get('osycase')
 
         if not active_case:
@@ -107,7 +117,10 @@ def copy():
 @case_api.route("/deleteCase", methods=['POST'])
 def deleteCase():
     try:
-        case = request.json['casename']
+        fields, err = get_required_fields(['casename'])
+        if err:
+            return err
+        case = fields['casename']
         active_case = session.get('osycase')
 
         if not active_case:
@@ -132,8 +145,11 @@ def deleteCase():
 @case_api.route("/getResultData", methods=['POST'])
 def getResultData():
     try:
-        casename = request.json['casename']
-        dataJson = request.json['dataJson']
+        fields, err = get_required_fields(['casename', 'dataJson'])
+        if err:
+            return err
+        casename = fields['casename']
+        dataJson = fields['dataJson']
         if casename != None:
             dataPath = Path(Config.DATA_STORAGE,casename,'view',dataJson)
             data = File.readFile(dataPath)
@@ -148,7 +164,10 @@ def getResultData():
 @case_api.route("/getParamFile", methods=['POST'])
 def getParamFile():
     try:
-        dataJson = request.json['dataJson']
+        fields, err = get_required_fields(['dataJson'])
+        if err:
+            return err
+        dataJson = fields['dataJson']
         configPath = Path(Config.DATA_STORAGE, dataJson)
         ConfigFile = File.readParamFile(configPath)
         response = ConfigFile       
@@ -159,7 +178,10 @@ def getParamFile():
 @case_api.route("/resultsExists", methods=['POST'])
 def resultsExists():
     try:
-        casename = request.json['casename']
+        fields, err = get_required_fields(['casename'])
+        if err:
+            return err
+        casename = fields['casename']
         if casename != None:
             resPath = Path(Config.DATA_STORAGE, casename, 'view', 'RYT.json')
             dataPath = Path(Config.DATA_STORAGE,casename,'view','resData.json')
@@ -182,8 +204,11 @@ def resultsExists():
 @case_api.route("/saveParamFile", methods=['POST'])
 def saveParamFile():
     try:
-        ParamData = request.json['ParamData']
-        VarData = request.json['VarData']
+        fields, err = get_required_fields(['ParamData', 'VarData'])
+        if err:
+            return err
+        ParamData = fields['ParamData']
+        VarData = fields['VarData']
 
         paramPath = Path(Config.DATA_STORAGE, 'Parameters.json')
         varPath = Path(Config.DATA_STORAGE, 'Variables.json')
@@ -201,8 +226,11 @@ def saveParamFile():
 @case_api.route("/saveScOrder", methods=['POST'])
 def saveScOrder():
     try:
-        data = request.json['data']
-        case = request.json['casename']
+        fields, err = get_required_fields(['data', 'casename'])
+        if err:
+            return err
+        data = fields['data']
+        case = fields['casename']
         genDataPath = Path(Config.DATA_STORAGE, case, 'genData.json')
         genData = File.readFile(genDataPath)
         genData['osy-scenarios'] = data
@@ -219,10 +247,13 @@ def saveScOrder():
 @case_api.route("/updateData", methods=['POST'])
 def updateData():
     try:
-        data = request.json['data']
-        param = request.json['param']
+        fields, err = get_required_fields(['data', 'param', 'dataJson'])
+        if err:
+            return err
+        data = fields['data']
+        param = fields['param']
         case = session.get('osycase', None)
-        dataJson = request.json['dataJson']
+        dataJson = fields['dataJson']
         dataPath = Path(Config.DATA_STORAGE, case, dataJson)
         if case != None:
             sourceData = File.readFile(dataPath)
@@ -240,7 +271,10 @@ def updateData():
 @case_api.route("/saveCase", methods=['POST'])
 def saveCase():
     try:
-        genData = request.json['data']
+        fields, err = get_required_fields(['data'])
+        if err:
+            return err
+        genData = fields['data']
         casename = genData['osy-casename']
         case = session.get('osycase', None)
 
@@ -396,8 +430,11 @@ def saveCase():
 @case_api.route("/prepareCSV", methods=['POST'])
 def prepareCSV():
     try:
-        casename = request.json['casename']
-        jsonData = request.json['jsonData']
+        fields, err = get_required_fields(['casename', 'jsonData'])
+        if err:
+            return err
+        casename = fields['casename']
+        jsonData = fields['jsonData']
 
         Pd = pd.DataFrame(jsonData)
 
@@ -437,7 +474,10 @@ def downloadCSV():
 @case_api.route("/importTemplate", methods=['POST'])
 def run():
     try:
-        data = request.json['data']
+        fields, err = get_required_fields(['data'])
+        if err:
+            return err
+        data = fields['data']
         template = ImportTemplate(data["osy-template"])
         response = template.importProcess(data)
  

--- a/API/Routes/Case/SyncS3Route.py
+++ b/API/Routes/Case/SyncS3Route.py
@@ -4,13 +4,17 @@ from pathlib import Path
 import shutil
 from Classes.Base import Config
 from Classes.Base.SyncS3 import SyncS3
+from Classes.Base.RequestValidator import get_required_fields
 
 syncs3_api = Blueprint('SyncS3Route', __name__)
 
 @syncs3_api.route("/deleteResultsPreSync", methods=['POST'])
 def deleteResultsPreSync():
     try:        
-        case = request.json['casename']
+        fields, err = get_required_fields(['casename'])
+        if err:
+            return err
+        case = fields['casename']
         
         resPath = Path(Config.DATA_STORAGE, case, 'res')
         dataPath = Path(Config.DATA_STORAGE, case, 'data.txt')
@@ -30,7 +34,10 @@ def deleteResultsPreSync():
 @syncs3_api.route("/uploadSync", methods=['POST'])
 def uploadSync():
     try:        
-        case = request.json['casename']
+        fields, err = get_required_fields(['casename'])
+        if err:
+            return err
+        case = fields['casename']
 
         s3 = SyncS3()
         localDir = Path(Config.DATA_STORAGE, case)
@@ -49,7 +56,10 @@ def uploadSync():
 @syncs3_api.route("/deleteSync", methods=['POST'])
 def deleteSync():
     try:        
-        case = request.json['casename']
+        fields, err = get_required_fields(['casename'])
+        if err:
+            return err
+        case = fields['casename']
 
         s3 = SyncS3()
         s3.deleteSync(case)
@@ -67,8 +77,11 @@ def deleteSync():
 @syncs3_api.route("/updateSync", methods=['POST'])
 def updateSync():
     try:        
-        case = request.json['casename']
-        filename = request.json['file']
+        fields, err = get_required_fields(['casename', 'file'])
+        if err:
+            return err
+        case = fields['casename']
+        filename = fields['file']
 
         s3 = SyncS3()
         localDir = Path(Config.DATA_STORAGE, case, str(filename))

--- a/API/Routes/Case/ViewDataRoute.py
+++ b/API/Routes/Case/ViewDataRoute.py
@@ -1,12 +1,16 @@
 from flask import Blueprint, jsonify, request
 from Classes.Case.OsemosysClass import Osemosys
+from Classes.Base.RequestValidator import get_required_fields
 
 viewdata_api = Blueprint('ViewDataRoute', __name__)
 
 @viewdata_api.route("/viewData", methods=['POST'])
 def viewData():
     try:
-        casename = request.json['casename']
+        fields, err = get_required_fields(['casename'])
+        if err:
+            return err
+        casename = fields['casename']
         if casename != None:
             osy = Osemosys(casename)
             data = {}
@@ -23,7 +27,10 @@ def viewData():
 @viewdata_api.route("/viewTEData", methods=['POST'])
 def viewTEData():
     try:
-        casename = request.json['casename']
+        fields, err = get_required_fields(['casename'])
+        if err:
+            return err
+        casename = fields['casename']
         if casename != None:
             osy = Osemosys(casename)
             data = {}
@@ -39,18 +46,19 @@ def viewTEData():
 @viewdata_api.route("/updateViewData", methods=['POST'])
 def updateViewData():
     try:
-        #casename, updateType, groupId, paramId, TechId, CommId, EmisId, Timeslice
-        casename = request.json['casename']
-        #updateType = request.json['updateType']
-        year = request.json['year']
-        ScId = request.json['ScId']
-        groupId = request.json['groupId']
-        paramId = request.json['paramId']
-        TechId = request.json['TechId']
-        CommId = request.json['CommId']
-        EmisId = request.json['EmisId']
-        Timeslice = request.json['Timeslice']
-        value = request.json['value']
+        fields, err = get_required_fields(['casename', 'year', 'ScId', 'groupId', 'paramId', 'TechId', 'CommId', 'EmisId', 'Timeslice', 'value'])
+        if err:
+            return err
+        casename   = fields['casename']
+        year       = fields['year']
+        ScId       = fields['ScId']
+        groupId    = fields['groupId']
+        paramId    = fields['paramId']
+        TechId     = fields['TechId']
+        CommId     = fields['CommId']
+        EmisId     = fields['EmisId']
+        Timeslice  = fields['Timeslice']
+        value      = fields['value']
 
         if casename != None:
             osy = Osemosys(casename)
@@ -72,14 +80,16 @@ def updateViewData():
 @viewdata_api.route("/updateTEViewData", methods=['POST'])
 def updateTEViewData():
     try:
-        #casename, updateType, groupId, paramId, TechId, CommId, EmisId, Timeslice
-        casename = request.json['casename']
-        scId = request.json['scId']
-        groupId = request.json['groupId']
-        paramId = request.json['paramId']
-        techId = request.json['techId']
-        emisId = request.json['emisId']
-        value = request.json['value']
+        fields, err = get_required_fields(['casename', 'scId', 'groupId', 'paramId', 'techId', 'emisId', 'value'])
+        if err:
+            return err
+        casename = fields['casename']
+        scId     = fields['scId']
+        groupId  = fields['groupId']
+        paramId  = fields['paramId']
+        techId   = fields['techId']
+        emisId   = fields['emisId']
+        value    = fields['value']
 
         if casename != None:
             osy = Osemosys(casename)

--- a/API/Routes/DataFile/DataFileRoute.py
+++ b/API/Routes/DataFile/DataFileRoute.py
@@ -3,14 +3,18 @@ from pathlib import Path
 import shutil, datetime, time, os
 from Classes.Case.DataFileClass import DataFile
 from Classes.Base import Config
+from Classes.Base.RequestValidator import get_required_fields
 
 datafile_api = Blueprint('DataFileRoute', __name__)
 
 @datafile_api.route("/generateDataFile", methods=['POST'])
 def generateDataFile():
     try:
-        casename = request.json['casename']
-        caserunname = request.json['caserunname']
+        fields, err = get_required_fields(['casename', 'caserunname'])
+        if err:
+            return err
+        casename = fields['casename']
+        caserunname = fields['caserunname']
 
         if casename != None:
             txtFile = DataFile(casename)
@@ -26,9 +30,12 @@ def generateDataFile():
 @datafile_api.route("/createCaseRun", methods=['POST'])
 def createCaseRun():
     try:
-        casename = request.json['casename']
-        caserunname = request.json['caserunname']
-        data = request.json['data']
+        fields, err = get_required_fields(['casename', 'caserunname', 'data'])
+        if err:
+            return err
+        casename = fields['casename']
+        caserunname = fields['caserunname']
+        data = fields['data']
 
         if casename != None:
             caserun = DataFile(casename)
@@ -41,10 +48,13 @@ def createCaseRun():
 @datafile_api.route("/updateCaseRun", methods=['POST'])
 def updateCaseRun():
     try:
-        casename = request.json['casename']
-        caserunname = request.json['caserunname']
-        oldcaserunname = request.json['oldcaserunname']
-        data = request.json['data']
+        fields, err = get_required_fields(['casename', 'caserunname', 'oldcaserunname', 'data'])
+        if err:
+            return err
+        casename = fields['casename']
+        caserunname = fields['caserunname']
+        oldcaserunname = fields['oldcaserunname']
+        data = fields['data']
 
         if casename != None:
             caserun = DataFile(casename)
@@ -57,10 +67,13 @@ def updateCaseRun():
 @datafile_api.route("/deleteCaseRun", methods=['POST'])
 def deleteCaseRun():
     try:        
-        casename = request.json['casename']
-        caserunname = request.json['caserunname']
-        resultsOnly = request.json['resultsOnly']
-        
+        fields, err = get_required_fields(['casename', 'caserunname', 'resultsOnly'])
+        if err:
+            return err
+        casename    = fields['casename']
+        caserunname = fields['caserunname']
+        resultsOnly = fields['resultsOnly']
+
         casePath = Path(Config.DATA_STORAGE, casename, 'res', caserunname)
         if not resultsOnly:
             shutil.rmtree(casePath)
@@ -97,8 +110,11 @@ def deleteCaseRun():
 @datafile_api.route("/deleteScenarioCaseRuns", methods=['POST'])
 def deleteScenarioCaseRuns():
     try:
-        scenarioId = request.json['scenarioId']
-        casename = request.json['casename']
+        fields, err = get_required_fields(['scenarioId', 'casename'])
+        if err:
+            return err
+        scenarioId = fields['scenarioId']
+        casename = fields['casename']
 
         if casename != None:
             caserun = DataFile(casename)
@@ -111,9 +127,12 @@ def deleteScenarioCaseRuns():
 @datafile_api.route("/saveView", methods=['POST'])
 def saveView():
     try:
-        casename = request.json['casename']
-        param = request.json['param']
-        data = request.json['data']
+        fields, err = get_required_fields(['casename', 'param', 'data'])
+        if err:
+            return err
+        casename = fields['casename']
+        param = fields['param']
+        data = fields['data']
 
         if casename != None:
             caserun = DataFile(casename)
@@ -126,9 +145,12 @@ def saveView():
 @datafile_api.route("/updateViews", methods=['POST'])
 def updateViews():
     try:
-        casename = request.json['casename']
-        param = request.json['param']
-        data = request.json['data']
+        fields, err = get_required_fields(['casename', 'param', 'data'])
+        if err:
+            return err
+        casename = fields['casename']
+        param = fields['param']
+        data = fields['data']
 
         if casename != None:
             caserun = DataFile(casename)
@@ -141,8 +163,11 @@ def updateViews():
 @datafile_api.route("/readDataFile", methods=['POST'])
 def readDataFile():
     try:
-        casename = request.json['casename']
-        caserunname = request.json['caserunname']
+        fields, err = get_required_fields(['casename', 'caserunname'])
+        if err:
+            return err
+        casename = fields['casename']
+        caserunname = fields['caserunname']
         if casename != None:
             txtFile = DataFile(casename)
             data = txtFile.readDataFile(caserunname)
@@ -156,8 +181,11 @@ def readDataFile():
 @datafile_api.route("/validateInputs", methods=['POST'])
 def validateInputs():
     try:
-        casename = request.json['casename']
-        caserunname = request.json['caserunname']
+        fields, err = get_required_fields(['casename', 'caserunname'])
+        if err:
+            return err
+        casename = fields['casename']
+        caserunname = fields['caserunname']
         if casename != None:
             df = DataFile(casename)
             validation = df.validateInputs(caserunname)
@@ -226,9 +254,12 @@ def downloadResultsFile():
 @datafile_api.route("/run", methods=['POST'])
 def run():
     try:
-        casename = request.json['casename']
-        caserunname = request.json['caserunname']
-        solver = request.json['solver']
+        fields, err = get_required_fields(['casename', 'caserunname', 'solver'])
+        if err:
+            return err
+        casename = fields['casename']
+        caserunname = fields['caserunname']
+        solver = fields['solver']
         txtFile = DataFile(casename)
         response = txtFile.run(solver, caserunname)     
         return jsonify(response), 200
@@ -243,8 +274,11 @@ def run():
 def batchRun():
     try:
         start = time.time()
-        modelname = request.json['modelname']
-        cases = request.json['cases']
+        fields, err = get_required_fields(['modelname', 'cases'])
+        if err:
+            return err
+        modelname = fields['modelname']
+        cases = fields['cases']
 
         if modelname != None:
             txtFile = DataFile(modelname)
@@ -261,7 +295,10 @@ def batchRun():
 @datafile_api.route("/cleanUp", methods=['POST'])
 def cleanUp():
     try:
-        modelname = request.json['modelname']
+        fields, err = get_required_fields(['modelname'])
+        if err:
+            return err
+        modelname = fields['modelname']
 
         if modelname != None:
             model = DataFile(modelname)


### PR DESCRIPTION
## Summary

Closes #185

Adds centralized request field validation across all 33 POST endpoints in 
the API. Previously, missing JSON fields caused unhandled `KeyError` exceptions 
that Flask converted to opaque `500 Internal Server Error` responses. This PR 
replaces all bare `request.json['key']` accesses with a validated helper that 
returns descriptive `400 Bad Request` responses.

## Changes

### New File — [API/Classes/Base/RequestValidator.py](cci:7://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/Classes/Base/RequestValidator.py:0:0-0:0)
A reusable [get_required_fields(fields: list)](cci:1://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/Classes/Base/RequestValidator.py:3:0-33:21) helper that:
- Validates the request body is JSON
- Checks all required fields are present
- Returns [(data_dict, None)](cci:1://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/Routes/DataFile/DataFileRoute.py:253:0-270:49) on success or [(None, 400_response)](cci:1://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/Routes/DataFile/DataFileRoute.py:253:0-270:49) on failure

### Updated Routes (33 endpoints across 4 files)
| File | Routes Updated |
|------|---------------|
| [Routes/Case/CaseRoute.py](cci:7://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/Routes/Case/CaseRoute.py:0:0-0:0) | 13 |
| [Routes/DataFile/DataFileRoute.py](cci:7://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/Routes/DataFile/DataFileRoute.py:0:0-0:0) | 12 |
| [Routes/Case/ViewDataRoute.py](cci:7://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/Routes/Case/ViewDataRoute.py:0:0-0:0) | 4 |
| [Routes/Case/SyncS3Route.py](cci:7://file:///e:/United%20Nations/MUIOGO/MUIOGO/API/Routes/Case/SyncS3Route.py:0:0-0:0) | 4 |

## Before / After

```python
# Before — crashes with 500 on missing field
casename = request.json['casename']

# After — returns 400 with clear message
fields, err = get_required_fields(['casename'])
if err:
    return err
casename = fields['casename']
