### PR TITLE
feat: introduce run-level UUID isolation (Closes #188)

### DIFF
--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -2,6 +2,8 @@ from pathlib import Path
 import pandas as pd
 import traceback
 import json, shutil, os, time, subprocess
+import uuid
+from datetime import datetime
 from collections import defaultdict
 from itertools import product
 
@@ -2092,6 +2094,21 @@ class DataFile(Osemosys):
                 # lock[caserunname] = threading.Lock() 
                 lock.acquire()
                 caserunname = caserun
+
+            run_uuid = uuid.uuid4().hex
+            run_uuid_path = Path(Config.DATA_STORAGE, self.case, 'res', caserunname, 'runs', run_uuid)
+            run_uuid_path.mkdir(parents=True, exist_ok=True)
+            
+            metadata = {
+                "run_uuid": run_uuid,
+                "timestamp": datetime.now().isoformat(),
+                "solver": solver,
+                "mode": "blocking"
+            }
+            
+            metadata_file = run_uuid_path / "job_metadata.json"
+            with open(metadata_file, "w", encoding="utf-8") as f:
+                json.dump(metadata, f, indent=4)
 
             start_time = time.time()
             txtOut = ""


### PR DESCRIPTION
## Summary

- What changed:
    -Generate a unique UUID on each `/run` invocation.
    -Create directory `res/<caserunname>/runs/<uuid>/`.
    -Write `job_metadata.json` with run_uuid, timestamp, solver, and mode.
    -No changes to solver logic, output paths, API contracts, or frontend behavior.

- Why:
  The system currently overwrites outputs per caserun and lacks run-level identity. This PR introduces foundational run isolation infrastructure to support future async execution and job tracking, while remaining fully backward-compatible.

## Related issues

- [x] Issue exists and is linked
- Closes #188 
- Related #

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented

  **Legacy Test**
  This ensures the normal features still work exactly as they did before.
  - Start backend API Server.
  - Log into the local development Web UI.
  - Open an existing Demo Case.
  - Click Run wait for it to finish.
  - Once complete, check that the status in the UI confirms success.
  - Verify your Results panel and ensure the CSVs are still loading properly.

  **Test The New UUID Tracking Infrastructure**

    - After running the model from Step 1, open your  IDE. Navigate to your app's internal storage directory for that run `WebAPP/DataStorage/<CaseName>/res/<CaseRunName>/runs/`
    - A new folder with a long hex string will be visible where the job_metadata.json will be visible.
    - Open job_metadata.json. You should see the exact timestamp the run was fired, the solver you selected, and the UUID itself.
  <img width="426" height="138" alt="image" src="https://github.com/user-attachments/assets/1ec85372-8922-422f-8af3-1761018548ff" />

  **Test The Concurrent Safety (The Stress Test)**
      This proves that backend race-conditions won't crash the immediate directory assignment loop for multiple hits. Repeat the same steps as above in 2 different tabs/browsers.    
    <img width="279" height="89" alt="image" src="https://github.com/user-attachments/assets/444f832f-2185-40d1-b37c-766630477978" />

- [x] Evidence attached (logs/screenshots/output as relevant)


## Documentation

- [x] Docs updated in this PR (or not applicable)
- [ ] Any setup/workflow changes reflected in repo docs

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)
