### PR TITLE
Feature: ogcore output schema endpoint

### DIFF
--- a/API/Routes/OGCore/OGCoreRoute.py
+++ b/API/Routes/OGCore/OGCoreRoute.py
@@ -1,0 +1,85 @@
+from flask import Blueprint, jsonify
+from pathlib import Path
+import pandas as pd
+from Classes.Base import Config
+
+ogcore_api = Blueprint('OGCoreRoute', __name__)
+
+
+@ogcore_api.route("/ogcore/schema", methods=['GET'])
+def ogcore_schema():
+    """
+    Returns the complete CLEWS output variable schema derived from Config.VARIABLES_C.
+    Lists all solver output variables with their column definitions and whether
+    they carry a dual (shadow price) value instead of a primal value.
+
+    Intended as the static schema contract for OG-Core integration — use this
+    to know what CLEWS produces and what columns to expect in each result CSV
+    before calling /ogcore/results.
+    """
+    dual_keys = set(Config.DUALS.keys())
+    schema = {}
+
+    for variable, columns in Config.VARIABLES_C.items():
+        schema[variable] = {
+            "columns": columns,
+            "value_column": variable,
+            "is_dual": variable in dual_keys
+        }
+
+    return jsonify({
+        "status_code": "success",
+        "variable_count": len(schema),
+        "schema": schema
+    }), 200
+
+
+@ogcore_api.route("/ogcore/results/<casename>/<caserunname>", methods=['GET'])
+def ogcore_results(casename, caserunname):
+    """
+    Returns structured solver results for a completed case run.
+
+    Reads the CSV files produced by generateCSVfromCBC() from:
+      DataStorage/<casename>/res/<caserunname>/csv/<VariableName>.csv
+
+    Returns 404 if the run directory does not exist on disk or if no CSV
+    results have been written yet.
+    Returns 200 with result records keyed by variable name once the run is complete.
+
+    Only variables that have a CSV on disk are included in the response.
+    The solver does not always produce all variables — this depends on model
+    configuration. Missing variables are counted but not included in results.
+    """
+    run_dir = Path(Config.DATA_STORAGE, casename, 'res', caserunname)
+    if not run_dir.is_dir():
+        return jsonify({
+            "message": f"Run '{caserunname}' not found for case '{casename}'.",
+            "status_code": "error"
+        }), 404
+
+    csv_dir = run_dir / 'csv'
+    if not csv_dir.is_dir():
+        return jsonify({
+            "message": "Run directory exists but no results were found. Has the solver completed successfully?",
+            "status_code": "error"
+        }), 404
+
+    results = {}
+    variables_missing = []
+
+    for variable in Config.VARIABLES_C:
+        csv_path = csv_dir / f"{variable}.csv"
+        if csv_path.is_file():
+            df = pd.read_csv(csv_path)
+            results[variable] = df.to_dict(orient='records')
+        else:
+            variables_missing.append(variable)
+
+    return jsonify({
+        "status_code": "success",
+        "casename": casename,
+        "caserunname": caserunname,
+        "variables_found": len(results),
+        "variables_missing": len(variables_missing),
+        "results": results
+    }), 200

--- a/API/app.py
+++ b/API/app.py
@@ -35,6 +35,7 @@ from Routes.Case.CaseRoute import case_api
 from Routes.Case.SyncS3Route import syncs3_api
 from Routes.Case.ViewDataRoute import viewdata_api
 from Routes.DataFile.DataFileRoute import datafile_api
+from Routes.OGCore.OGCoreRoute import ogcore_api
 
 def _configure_logging():
     if getattr(_configure_logging, "_configured", False):
@@ -103,6 +104,7 @@ app.register_blueprint(case_api)
 app.register_blueprint(viewdata_api)
 app.register_blueprint(datafile_api)
 app.register_blueprint(syncs3_api)
+app.register_blueprint(ogcore_api)
 
 CORS(app)
 


### PR DESCRIPTION
## Summary

- **What changed:** Two new endpoints under `/ogcore`. `GET /ogcore/schema` returns the full list of OGCore output variables with column definitions and dual flags. `GET /ogcore/results/<casename>/<caserunname>` reads completed solver CSVs and returns records per variable, with 409 if a run is still active and 404 if the run directory does not exist. `is_run_active()` was added to `JobManager` to support the 409 check. Blueprint registered in `app.py`.
- **Why:** OGCore integration needs a stable endpoint to query available output variables and pull completed run data through the API rather than reading files directly from disk.

## Related issues

- [x] Issue exists and is linked
- Closes #201
- Related #186

## Validation

- [x] Tests added/updated (not applicable, no test suite in repo)
- [x] Validation steps documented
- [x] Evidence attached

**Steps to reproduce manually:**

1. Start the server: `python app.py`
2. Run the cases below in order

**Test 1 -- schema endpoint**

Request: `GET /ogcore/schema`

```
HTTP 200
variable_count: 58
first_5_keys: ['AccumulatedNewCapacity', 'AccumulatedNewStorageCapacity', 'AnnualEmissions', 'AnnualFixedOperatingCost', 'AnnualTechnologyEmission']
sample: AccumulatedNewCapacity -> {"columns": ["r", "t", "y"], "is_dual": false, "value_column": "AccumulatedNewCapacity"}
```

**Test 2 -- run not found (404)**

Request: `GET /ogcore/results/NONEXISTENT_CASE/run1`

```json
{"message": "Run 'run1' not found for case 'NONEXISTENT_CASE'.", "status_code": "error"}
HTTP 404
```

**Test 3 -- run in progress (409)**

Fire `POST /run` then immediately poll results:

```json
{"job_id": "c0ca8de7-29f5-4d2c-9316-569ae8c2fa61", "message": "Run is still in progress. Poll /runStatus/<job_id> for updates.", "status_code": "error"}
HTTP 409
```

**Test 4 -- completed run (200)**

Request: `GET /ogcore/results/CLEWs%20Demo/REF`

```json
{"status_code": "success", "variables_found": 39, "variables_missing": 19}
HTTP 200
```

## Documentation

- [x] Docs updated in this PR (not applicable, internal API endpoints)
- [x] Any setup/workflow changes reflected in repo docs (no setup changes)

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch (`feature/ogcore-output-schema-endpoint`)
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [ ] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream) -- this PR targets `feature/174-async-solver-execution` as base since it depends on #186. 
To switch base to `main` once #186 merges.