### PR TITLE
fix(security): harden config endpoints and restrict global config writes

### DIFF
--- a/API/Routes/Case/CaseRoute.py
+++ b/API/Routes/Case/CaseRoute.py
@@ -149,6 +149,11 @@ def getResultData():
 def getParamFile():
     try:
         dataJson = request.json['dataJson']
+
+        allowed_files = {"Parameters.json", "Variables.json"}
+        if dataJson not in allowed_files:
+            return jsonify({"message": "Invalid configuration file requested.", "status_code": "error"}), 400
+
         configPath = Path(Config.DATA_STORAGE, dataJson)
         ConfigFile = File.readParamFile(configPath)
         response = ConfigFile       
@@ -182,6 +187,10 @@ def resultsExists():
 @case_api.route("/saveParamFile", methods=['POST'])
 def saveParamFile():
     try:
+        active_case = session.get('osycase')
+        if not active_case:
+            return jsonify({'message': 'No active session.', 'status_code': 'error'}), 403
+
         ParamData = request.json['ParamData']
         VarData = request.json['VarData']
 


### PR DESCRIPTION
## Summary

- **What changed:**
  - Added an allowlist check in `/getParamFile` to restrict configuration file access to `Parameters.json` and `Variables.json`.
  - Added session validation in `/saveParamFile` requiring an active Flask session (`session.get('osycase')`) before allowing writes to global configuration files.

- **Why:**
  - The `/saveParamFile` endpoint previously allowed unauthenticated HTTP clients to overwrite global configuration files via POST requests.
  - This enabled modification of system-wide defaults (`Parameters.json`, `Variables.json`) without session context or access control.
  - The change ensures configuration writes require an active session and prevents arbitrary file access via `/getParamFile`.

## Related issues

- [x] Issue exists and is linked
- Closes #140
- Related #

## Validation

- [x] Tests added/updated (not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

**Validation steps**

1. Start the API:
  ```
  scripts/start.sh
  ```

2. Attempt an unauthenticated configuration write without an active session:
  ```
  curl -X POST http://127.0.0.1:5002/saveParamFile \
    -H "Content-Type: application/json" \
    -d @payload.json
  ```

3. Observed response:
  ```
  {"message":"No active session.","status_code":"error"}
  ```

4. Verify behavior:
- The request is rejected without a session.
- `Parameters.json` remains unchanged.
- UI `/Config` defaults remain unchanged.

5. Attempt arbitrary file access via `/getParamFile` with a filename outside the allowlist.

Expected behavior:

- Request is rejected with:
  ```
  {"message": "Invalid configuration file requested.", "status_code": "error"}
  ```

## Documentation

- [x] Docs updated in this PR (not applicable)
- [x] Any setup/workflow changes reflected in repo docs (not applicable)

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

## Screenshots
1. Unauthenticated configuration write (`saveParamFile` endpoint)
<img width="1918" height="1075" alt="image" src="https://github.com/user-attachments/assets/1b631d59-55aa-42a6-9a44-2a4e5988e57b" />
2. Validation of `getParamFile` endpoint

  - Allowed valid request
    <img width="1918" height="1075" alt="image" src="https://github.com/user-attachments/assets/b92d7d02-9ae4-4983-af44-18b7bc00c661" />
  - Malicious request (should be blocked)
    <img width="637" height="117" alt="image" src="https://github.com/user-attachments/assets/cf0ee681-0398-4797-b20e-0abe2e3492b1" />
