### PR TITLE
Fix/non pythonic none comparisons

### DIFF
--- a/API/Routes/Case/CaseRoute.py
+++ b/API/Routes/Case/CaseRoute.py
@@ -134,7 +134,7 @@ def getResultData():
     try:
         casename = request.json['casename']
         dataJson = request.json['dataJson']
-        if casename != None:
+        if casename is not None:
             dataPath = Path(Config.DATA_STORAGE,casename,'view',dataJson)
             data = File.readFile(dataPath)
             response = data   
@@ -160,7 +160,7 @@ def getParamFile():
 def resultsExists():
     try:
         casename = request.json['casename']
-        if casename != None:
+        if casename is not None:
             resPath = Path(Config.DATA_STORAGE, casename, 'view', 'RYT.json')
             dataPath = Path(Config.DATA_STORAGE,casename,'view','resData.json')
             data = File.readFile(dataPath)
@@ -224,7 +224,7 @@ def updateData():
         case = session.get('osycase', None)
         dataJson = request.json['dataJson']
         dataPath = Path(Config.DATA_STORAGE, case, dataJson)
-        if case != None:
+        if case is not None:
             sourceData = File.readFile(dataPath)
             sourceData[param] = data
             File.writeFile(sourceData, dataPath)
@@ -268,7 +268,7 @@ def saveCase():
 
 
         #ako je izabran case, edit mode
-        if case != None and case != '':
+        if case is not None and case != '':
             genDataPath = Path(Config.DATA_STORAGE, case, "genData.json")
 
             ##update za view i res ukoliko nema

--- a/API/Routes/Case/ViewDataRoute.py
+++ b/API/Routes/Case/ViewDataRoute.py
@@ -7,7 +7,7 @@ viewdata_api = Blueprint('ViewDataRoute', __name__)
 def viewData():
     try:
         casename = request.json['casename']
-        if casename != None:
+        if casename is not None:
             osy = Osemosys(casename)
             data = {}
             data['Tech'] = osy.viewDataByTech()
@@ -24,7 +24,7 @@ def viewData():
 def viewTEData():
     try:
         casename = request.json['casename']
-        if casename != None:
+        if casename is not None:
             osy = Osemosys(casename)
             data = {}
             data['Tech'] = osy.viewRTByTech()
@@ -52,7 +52,7 @@ def updateViewData():
         Timeslice = request.json['Timeslice']
         value = request.json['value']
 
-        if casename != None:
+        if casename is not None:
             osy = Osemosys(casename)
             osy.updateViewData(casename, year, ScId, groupId, paramId, TechId, CommId, EmisId, Timeslice, value)
             response = {
@@ -81,7 +81,7 @@ def updateTEViewData():
         emisId = request.json['emisId']
         value = request.json['value']
 
-        if casename != None:
+        if casename is not None:
             osy = Osemosys(casename)
             data = osy.updateTEViewData(casename, scId, groupId, paramId, techId, emisId, value)
             response = {

--- a/API/Routes/DataFile/DataFileRoute.py
+++ b/API/Routes/DataFile/DataFileRoute.py
@@ -12,7 +12,7 @@ def generateDataFile():
         casename = request.json['casename']
         caserunname = request.json['caserunname']
 
-        if casename != None:
+        if casename is not None:
             txtFile = DataFile(casename)
             txtFile.generateDatafile(caserunname)
             response = {
@@ -30,7 +30,7 @@ def createCaseRun():
         caserunname = request.json['caserunname']
         data = request.json['data']
 
-        if casename != None:
+        if casename is not None:
             caserun = DataFile(casename)
             response = caserun.createCaseRun(caserunname, data)
      
@@ -46,7 +46,7 @@ def updateCaseRun():
         oldcaserunname = request.json['oldcaserunname']
         data = request.json['data']
 
-        if casename != None:
+        if casename is not None:
             caserun = DataFile(casename)
             response = caserun.updateCaseRun(caserunname, oldcaserunname, data)
      
@@ -72,7 +72,7 @@ def deleteCaseRun():
                 elif os.path.isdir(item_path):
                     shutil.rmtree(item_path)  # delete subfolder
 
-        if casename != None:
+        if casename is not None:
             caserun = DataFile(casename)
             response = caserun.deleteCaseRun(caserunname, resultsOnly)    
         return jsonify(response), 200
@@ -100,7 +100,7 @@ def deleteScenarioCaseRuns():
         scenarioId = request.json['scenarioId']
         casename = request.json['casename']
 
-        if casename != None:
+        if casename is not None:
             caserun = DataFile(casename)
             response = caserun.deleteScenarioCaseRuns(scenarioId)
      
@@ -115,7 +115,7 @@ def saveView():
         param = request.json['param']
         data = request.json['data']
 
-        if casename != None:
+        if casename is not None:
             caserun = DataFile(casename)
             response = caserun.saveView(data, param)
      
@@ -143,7 +143,7 @@ def readDataFile():
     try:
         casename = request.json['casename']
         caserunname = request.json['caserunname']
-        if casename != None:
+        if casename is not None:
             txtFile = DataFile(casename)
             data = txtFile.readDataFile(caserunname)
             response = data    
@@ -158,7 +158,7 @@ def validateInputs():
     try:
         casename = request.json['casename']
         caserunname = request.json['caserunname']
-        if casename != None:
+        if casename is not None:
             df = DataFile(casename)
             validation = df.validateInputs(caserunname)
             response = validation    
@@ -246,7 +246,7 @@ def batchRun():
         modelname = request.json['modelname']
         cases = request.json['cases']
 
-        if modelname != None:
+        if modelname is not None:
             txtFile = DataFile(modelname)
             for caserun in cases:
                 txtFile.generateDatafile(caserun)
@@ -263,7 +263,7 @@ def cleanUp():
     try:
         modelname = request.json['modelname']
 
-        if modelname != None:
+        if modelname is not None:
             model = DataFile(modelname)
             response = model.cleanUp()    
 


### PR DESCRIPTION
## Summary
This PR fixes non-Pythonic None comparisons across multiple API route files by replacing `!= None` and `== None` with the recommended `is not None` and `is None` identity operators, following PEP 8 guidelines.

- What changed:
   - Replaced all `!= None` with `is not None`
   - Replaced all `== None` with `is None`

- Why:
   - Follows Python best practices (PEP 8 style guide)
   - Identity checks (`is`/`is not`) are more efficient than equality checks (`==`/`!=`)
   - Prevents unexpected behavior with objects that override `__eq__` method
   - Improves code maintainability and readability
   - Aligns with Python community standards

## Related issues

- Closes #207 