### PR TITLE
fix: implement path-confinement checks in file operations

### DIFF
--- a/API/Classes/Base/Config.py
+++ b/API/Classes/Base/Config.py
@@ -3,6 +3,34 @@ import os
 #from dotenv import load_dotenv
 import platform
 
+# Central path validation utility (prevents path traversal)
+def validate_path(base_dir, user_input):
+    base_raw = os.fspath(base_dir)
+    user_raw = "" if user_input is None else os.fspath(user_input)
+
+    if isinstance(base_raw, (bytes, bytearray)):
+        base_raw = base_raw.decode("utf-8", "surrogateescape")
+    if isinstance(user_raw, (bytes, bytearray)):
+        user_raw = user_raw.decode("utf-8", "surrogateescape")
+
+    if "\x00" in base_raw or "\x00" in user_raw:
+        raise PermissionError("Path Traversal Attempt Detected")
+
+    base_abs = os.path.realpath(os.path.abspath(os.path.normpath(base_raw)))
+    target_abs = os.path.realpath(
+        os.path.abspath(os.path.normpath(os.path.join(base_abs, user_raw)))
+    )
+
+    try:
+        common = os.path.commonpath([base_abs, target_abs])
+    except ValueError:
+        raise PermissionError("Path Traversal Attempt Detected")
+
+    if common != base_abs or target_abs == base_abs:
+        raise PermissionError("Path Traversal Attempt Detected")
+
+    return target_abs
+
 #load environment variables
 #load_dotenv()
 

--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -209,8 +209,8 @@ def backupCase():
         #case = request.json['casename']
         case = request.args.get('case')
 
-        casePath = Path('WebAPP', 'DataStorage',case)
-        zippedFile = Path('WebAPP', 'DataStorage', case+'.zip')
+        casePath = Path(Config.validate_path(Config.DATA_STORAGE, case))
+        zippedFile = Path(Config.validate_path(Config.DATA_STORAGE, f"{case}.zip"))
 
         '''File system data storage'''
         with ZipFile(zippedFile, 'w') as zipObj:
@@ -239,6 +239,8 @@ def backupCase():
 
         return send_file(zippedFile.resolve(), as_attachment=True)
 
+    except PermissionError:
+        return jsonify({"error": "Invalid path"}), 400
     except(IOError):
         return jsonify('No existing cases!'), 404
     except OSError:
@@ -414,9 +416,10 @@ def handle_full_zip(file, filepath=None):
     # Ako je file objekat (upload iz browsera)
     if filepath is None:
         submitted_file = file.filename
-        filepath = os.path.join(Config.DATA_STORAGE, submitted_file)
+        filepath = Config.validate_path(Config.DATA_STORAGE, submitted_file)
         file.save(filepath)
     else:
+        filepath = Config.validate_path(Config.DATA_STORAGE, filepath)
         submitted_file = os.path.basename(filepath)
 
     case = os.path.splitext(submitted_file)[0]
@@ -566,7 +569,7 @@ def uploadCase():
         # -------------------------------
         # 2) Snimi chunk
         # -------------------------------
-        chunk_dir = os.path.join(Config.DATA_STORAGE, "_chunks", dz_uuid)
+        chunk_dir = Config.validate_path(Config.DATA_STORAGE, Path("_chunks", dz_uuid))
         os.makedirs(chunk_dir, exist_ok=True)
 
         chunk_path = os.path.join(chunk_dir, f"chunk_{dz_chunk_index}")
@@ -583,7 +586,7 @@ def uploadCase():
         # -------------------------------
         # 4) Spajanje ZIP fajla
         # -------------------------------
-        final_zip = os.path.join(Config.DATA_STORAGE, f"{dz_uuid}.zip")
+        final_zip = Config.validate_path(Config.DATA_STORAGE, f"{dz_uuid}.zip")
 
         with open(final_zip, "wb") as merged:
             for i in range(dz_total_chunks):
@@ -605,6 +608,8 @@ def uploadCase():
         #return handle_full_zip(open(final_zip, "rb"), final_zip)
         return handle_full_zip(None, final_zip) 
 
+    except PermissionError:
+        return jsonify({"error": "Invalid path"}), 400
     except Exception as e:
         return jsonify({"error": str(e)}), 500
     


### PR DESCRIPTION
## Summary 

-Created a centralized security utility Config.validate_path() in API/Classes/Base/Config.py.
-Implemented path normalization using realpath and boundary verification via commonpath.
-Added protection against Null Byte injections (\x00).
-Refactored UploadRoute.py (including backupCase, handle_full_zip, and chunked uploads) to use this guard.
-Added explicit PermissionError handling to return 400 Bad Request for traversal attempts.

### Why:
Without this, the server is vulnerable to Path Traversal attacks. This architectural change ensures that even as the project grows and more routes are added, we have a single, robust method to enforce file system boundaries, significantly reducing the attack surface.

Closes #212 
 

Scope check
- [x] No unrelated refactors.
- [x] Implemented from a feature branch.
- [x] Change is deliverable without upstream OSeMOSYS/MUIO dependency.
- [x] Base repo/branch is EAPD-DRB/MUIOGO:main.