### PR TITLE
Add model summary API endpoint for quick case overview

### DIFF
--- a/API/Routes/Case/CaseRoute.py
+++ b/API/Routes/Case/CaseRoute.py
@@ -454,7 +454,51 @@ def run():
     except(IndexError):
         return jsonify('No existing cases!'), 404
 
+@case_api.route("/getModelSummary", methods=['POST'])
+def getModelSummary():
+    try:
+        casename = request.json['casename']
 
+        genDataPath = Path(Config.DATA_STORAGE, casename, 'genData.json')
+        genData = File.readFile(genDataPath)
+
+        # Count result runs
+        resDataPath = Path(Config.DATA_STORAGE, casename, 'view', 'resData.json')
+        result_count = 0
+
+        if os.path.exists(resDataPath):
+            resData = File.readFile(resDataPath)
+            result_count = len(resData.get('osy-cases', []))
+
+        # Calculate folder size
+        case_path = Path(Config.DATA_STORAGE, casename)
+        total_size = sum(
+            f.stat().st_size for f in case_path.rglob('*') if f.is_file()
+        )
+
+        summary = {
+            "casename": casename,
+            "version": genData.get('osy-version', 'unknown'),
+            "description": genData.get('osy-desc', ''),
+            "year_start": genData.get('osy-ys', ''),
+            "year_end": genData.get('osy-ye', ''),
+            "technologies": len(genData.get('osy-tech', [])),
+            "commodities": len(genData.get('osy-comm', [])),
+            "emissions": len(genData.get('osy-emis', [])),
+            "storages": len(genData.get('osy-stg', [])),
+            "timeslices": len(genData.get('osy-ts', [])),
+            "seasons": len(genData.get('osy-se', [])),
+            "constraints": len(genData.get('osy-constraints', [])),
+            "modes": genData.get('osy-mo', 0),
+            "result_runs": result_count,
+            "size_mb": round(total_size / (1024 * 1024), 2),
+        }
+
+        return jsonify(summary), 200
+
+    except (IOError, KeyError):
+        return jsonify({"error": "Could not read model"}), 404
+        
 ####################################################################################OBSOLETE AND SyncS3###################################################
 
 # @case_api.route("/getData", methods=['POST'])


### PR DESCRIPTION
This PR adds a new API endpoint `/getModelSummary` that provides a high-level overview of a model.

Currently the API only exposes `/getCases`, which returns only case names. This makes it difficult to understand what each model contains without opening it manually.

The new endpoint returns metadata such as:

- technology count
- commodity count
- emissions
- time horizon
- number of result runs
- approximate model size

This allows the UI or external tools to quickly inspect models.

Implementation:
• Added new route in `CaseRoute.py`
• Reads `genData.json`
• Optionally reads `view/resData.json`
• Computes case directory size

This change is read-only and does not affect existing API functionality.

Closes #233 