### PR TITLE
[fix] Missing request validation on /setSession endpoint for malformed JSON and empty strings

### DIFF
--- a/API/app.py
+++ b/API/app.py
@@ -114,10 +114,18 @@ def getSession():
 @app.route("/setSession", methods=['POST'])
 def setSession():
     try:
-        cs = request.json['case']
+        data = request.get_json(silent=True)
+        if data is None:
+            return jsonify({'message': 'Invalid JSON payload.', 'status_code': 'error'}), 400
+            
+        cs = data['case']
+        
         if cs is None:
             session.pop('osycase', None)
             return jsonify({"osycase": None}), 200
+
+        if not str(cs).strip():
+            return jsonify({'message': 'Case name cannot be empty.', 'status_code': 'error'}), 400
 
         from pathlib import Path
         if not Path(Config.DATA_STORAGE, cs).is_dir():
@@ -127,7 +135,6 @@ def setSession():
         return jsonify(response), 200
     except KeyError:
         return jsonify('No selected parameters!'), 404
-
 
 if __name__ == '__main__':
 # if __name__ == 'app':


### PR DESCRIPTION
## Summary

- **What changed:** Updated the `/setSession` endpoint in `API/app.py` to use `request.get_json(silent=True)` for safe payload parsing. Added validation to ensure the `case` value is not an empty string or just whitespace (`if not str(cs).strip():`).
- **Why:** Previously, sending non-JSON or malformed payloads caused a 500 Internal Server Error because `request.json` would fail. Additionally, empty string payloads could bypass the `None` check and cause unpredictable path resolution issues.

## Related issues

- [x] Issue exists and is linked
- Closes #236 
- Related #77 

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented
  - **Steps Taken:**
    1. Sent POST to `/setSession` with a non-JSON payload -> Verified it returns `400 Bad Request` with the message "Invalid JSON payload." instead of crashing the server.
    2. Sent POST to `/setSession` with `{"case": "   "}` -> Verified it returns `400 Bad Request` with the message "Case name cannot be empty."
    3. Sent POST to `/setSession` with `{"case": null}` -> Verified it still cleanly clears the session and returns `200` 
- [ ] Evidence attached (logs/screenshots/output as relevant) *(Note: check this box if you drag and drop a screenshot of your terminal/Postman testing this)*

## Documentation

- [x] Docs updated in this PR (or not applicable)
- [ ] Any setup/workflow changes reflected in repo docs

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)