### PR TITLE
[Enhancement] Improve validation for /setSession endpoint (#242)

### DIFF
--- a/API/app.py
+++ b/API/app.py
@@ -114,10 +114,20 @@ def getSession():
 @app.route("/setSession", methods=['POST'])
 def setSession():
     try:
-        cs = request.json['case']
+        if not request.is_json:
+            return jsonify({'message': 'Request must be JSON.', 'status_code': 'error'}), 400
+            
+        data = request.get_json(silent=True)
+        if data is None:
+            return jsonify({'message': 'Malformed JSON payload.', 'status_code': 'error'}), 400
+            
+        cs = data['case']
         if cs is None:
             session.pop('osycase', None)
             return jsonify({"osycase": None}), 200
+
+        if not isinstance(cs, str) or not cs.strip():
+            return jsonify({'message': 'Invalid case name.', 'status_code': 'error'}), 400
 
         from pathlib import Path
         if not Path(Config.DATA_STORAGE, cs).is_dir():


### PR DESCRIPTION
## Summary
**What changed:**  
Added comprehensive request validation to the `/setSession` endpoint (`API/app.py`):

- Enforced `application/json` Content-Type check.
- Handled malformed or missing payloads safely, returning a **400 Bad Request**.
- Added type-checking to ensure the `case` payload is a valid string, returning **400 Bad Request** for:
  - empty strings (`""`)
  - whitespace (`"   "`)
  - non-string values (e.g., `123`)
- Retained the existing `{"case": null}` logic (from #163) required by the AddCase frontend component to clear the active session successfully.

**Why:**  
While PR #163  safely prevented backend **500 crashes** caused by explicit `null` payloads, the endpoint was still vulnerable to malformed JSON, empty strings, and improper data types.

Passing an empty string, for example, would cause `Path()` to evaluate the current root directory, falsely returning `True` for `.is_dir()` and incorrectly setting the active session.

This PR implements the follow-up changes requested by @SeaCelo to bulletproof the endpoint.


## Related issues

- [x] Issue exists and is linked
- Closes #242 
- Related #163 #161 

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented
1. Ran the API locally and sent malformed JSON / non-JSON payloads via JavaScript `fetch()`.  
   Verified **400 Bad Request** was returned.
2. Sent:
   - `{"case": ""}`
   - `{"case": "   "}`
   - `{"case": 123}`  
   Verified **400 Bad Request** was properly returned.

3. Used the application UI to ensure clicking **"Create new configuration"** still successfully passed `{"case": null}`, cleared the session, and returned **200 OK**.

- [x] Evidence attached (logs/screenshots/output as relevant)

Validation Tests
Test 1: Empty String Case (Should return 400 Bad Request)

```
fetch('http://127.0.0.1:5002/setSession', {
  method: 'POST',
  headers: { 'Content-Type': 'application/json' },
  body: JSON.stringify({ case: "" })
}).then(res => res.json()).then(console.log);
```

Test 2: Whitespace String Case (Should return 400 Bad Request)
```
fetch('http://127.0.0.1:5002/setSession', {
  method: 'POST',
  headers: { 'Content-Type': 'application/json' },
  body: JSON.stringify({ case: "   " })
}).then(res => res.json()).then(console.log);
```

Test 3: Non-String Case (Should return 400 Bad Request)
```
fetch('http://127.0.0.1:5002/setSession', {
  method: 'POST',
  headers: { 'Content-Type': 'application/json' },
  body: JSON.stringify({ case: 12345 })
}).then(res => res.json()).then(console.log);
```

Test 4: Purely Malformed JSON / Non-JSON (Should return 400 Bad Request)
```
fetch('http://127.0.0.1:5002/setSession', {
  method: 'POST',
  headers: { 'Content-Type': 'application/json' },
  body: "This is not valid JSON string"
}).then(res => res.json()).then(console.log);
```

Test 5: Valid null Case (Should return 200 OK)
```
fetch('http://127.0.0.1:5002/setSession', {
  method: 'POST',
  headers: { 'Content-Type': 'application/json' },
  body: JSON.stringify({ case: null })
}).then(res => res.json()).then(console.log);
```
<img width="1017" height="666" alt="image" src="https://github.com/user-attachments/assets/acd12be8-a550-4468-8bcc-5b6c0a1cc6f4" />

## Documentation

- [ ] Docs updated in this PR (or not applicable)
- [ ] Any setup/workflow changes reflected in repo docs

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)
