### PR TITLE
Fix backupCase to store relative paths in ZIP archive

### DIFF
--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -216,7 +216,8 @@ def backupCase():
                         #create complete filepath of file in directory
                         filePath = os.path.join(folderName, filename)
                         # Add file to zip
-                        zipObj.write(filePath)      
+                        arcname = os.path.relpath(filePath, Config.DATA_STORAGE)
+                        zipObj.write(filePath, arcname)
 
             #osemosys 2.1 backup only input files
             # for filename in os.listdir(str(casePath)):


### PR DESCRIPTION
## Summary

### What changed
Updated the backupCase() function in UploadRoute.py to store relative paths inside the ZIP archive.

Previously:

```python
zipObj.write(filePath)
```

Now:

```python
arcname = os.path.relpath(filePath, Config.DATA_STORAGE)
zipObj.write(filePath, arcname)
```

### Why
Using zipObj.write(filePath) stores absolute filesystem paths inside the ZIP archive.  
This makes backups non-portable and may cause incorrect directory structures when extracting on different machines.

Using a relative path ensures the ZIP archive contains only the case directory structure.

## Validation

- Verified that backup ZIP contains relative paths (e.g., Kenya/genData.json)
- Confirmed backup functionality still works correctly

## Scope

- Single-file change
- No unrelated refactors

Fixes #241 