### PR TITLE
Improve validateInputs error handling for missing parameters- issue #249

### DIFF
--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -1629,19 +1629,15 @@ class DataFile(Osemosys):
 
             response = {
                 "msg": msg,
-                "status_code": 'success'
-            }   
+                "status_code": "success",
+            }
             return response
-        except(IOError, KeyError):
-            response = {
-                "msg": 'Some of the params are missing in data file (data file created before 4.9 ver). Please generate data file again and run check',
-                "status_code": 'error'
-            } 
-            return response  
-        except(IOError, IndexError):
-            raise IndexError
+        except IOError:
+            raise
+        except IndexError:
+            raise
         except OSError:
-            raise OSError
+            raise
         
     def preprocessData(self, data_infile, data_outfile):
         try:

--- a/API/Routes/DataFile/DataFileRoute.py
+++ b/API/Routes/DataFile/DataFileRoute.py
@@ -142,20 +142,29 @@ def readDataFile():
     except(IOError):
         return jsonify('No existing cases!'), 404
     
-@datafile_api.route("/validateInputs", methods=['POST'])
+@datafile_api.route("/validateInputs", methods=["POST"])
 def validateInputs():
     try:
-        casename = request.json['casename']
-        caserunname = request.json['caserunname']
-        if casename != None:
+        casename = request.json["casename"]
+        caserunname = request.json["caserunname"]
+        if casename is not None:
             df = DataFile(casename)
             validation = df.validateInputs(caserunname)
-            response = validation    
-        else:  
-            response = None     
-        return jsonify(response), 200
-    except(IOError):
-        return jsonify('No existing cases!'), 404
+            return jsonify(validation), 200
+        else:
+            return jsonify(None), 200
+    except KeyError as e:
+        # UI-friendly but ETL-loggable
+        return jsonify({
+            "msg": (
+                f"Missing parameter in data file: {e!r}. "
+                "Regenerate data file before validation."
+            ),
+            "status_code": "error",
+            "missing_key": str(e),
+        }), 400
+    except IOError:
+        return jsonify("No existing cases!"), 404
 
 @datafile_api.route("/downloadDataFile", methods=['GET'])
 def downloadDataFile():


### PR DESCRIPTION
## Summary

- What changed:

  - Updated `DataFileClass.validateInputs` so it no longer catches KeyError and returns a generic error JSON. It now only handles genuine I/O/OS/index issues and otherwise lets KeyError propagate.
  - Updated `/validateInputs` in `DataFileRoute` to catch KeyError and return a 400 JSON response with a clear message about a missing parameter in the data file and missing_key field exposing the exact parameter name.

- Why:
Previously, missing required parameters from `data.txt` raised KeyError inside validateInputs, which was caught and transformed into a generic response, still returned with HTTP 200. This could hide structural data issues and made debugging difficult. Moving KeyError handling from DataFileClass to DataFileRoute cleanly separates responsibilities:
  - The domain layer (DataFileClass) now fails fast with real exceptions when the input data structure is invalid.
  - The API layer (DataFileRoute) is responsible for translating those domain errors into HTTP responses appropriate for the UI and external callers.

## Related issues

- [x] Issue exists and is linked
- Closes #249 
- Related #

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

Run the below code in terminal before and after removing Params from data.txt
```
curl -X POST http://localhost:<port>/validateInputs \
  -H "Content-Type: application/json" \
  -d '{"casename": "CLEWs Demo", "caserunname": "REF"}'
```

Before removing params:
<img width="873" height="281" alt="Screenshot 2026-03-05 at 6 57 54 PM" src="https://github.com/user-attachments/assets/e823e780-591e-4b57-95d9-acb2fd40f92e" />
After removing params:
<img width="906" height="74" alt="Screenshot 2026-03-05 at 6 57 23 PM" src="https://github.com/user-attachments/assets/84ee8f5c-a793-4862-8491-78e091cebac0" />

## Documentation

- [ ] Docs updated in this PR (or not applicable)
- [ ] Any setup/workflow changes reflected in repo docs

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)
