### PR TITLE
Fix path traversal vulnerability by validating dzuuid and chunk param…

### DIFF
--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -1,4 +1,5 @@
 import shutil
+import re
 from flask import Blueprint, request, jsonify, send_file, after_this_request
 from zipfile import ZipFile
 from pathlib import Path
@@ -549,6 +550,21 @@ def uploadCase():
         dz_total_chunks = request.form.get("dztotalchunkcount")
         file = request.files.get("file")
 
+        # Validate upload UUID to prevent path traversal
+        if dz_uuid is not None:
+            if not re.match(r'^[a-zA-Z0-9_-]+$', dz_uuid):
+                return jsonify({"error": "Invalid upload ID"}), 400
+
+            try:
+                dz_chunk_index = int(dz_chunk_index)
+                dz_total_chunks = int(dz_total_chunks)
+            except (TypeError, ValueError):
+                return jsonify({"error": "Invalid chunk parameters"}), 400
+
+            if dz_chunk_index < 0 or dz_chunk_index >= dz_total_chunks:
+                return jsonify({"error": "Invalid chunk index"}), 400
+
+
         # Ako nije chunked upload (chrome browser dev mode)
         if dz_uuid is None:
             # ==========================
@@ -606,7 +622,7 @@ def uploadCase():
         return jsonify({"error": "Invalid path"}), 400
     except Exception as e:
         return jsonify({"error": str(e)}), 500
-    
+
 @upload_api.route('/uploadXls', methods=['POST'])
 def uploadXls():
     try: 


### PR DESCRIPTION
## Summary

### What changed
Added validation for the `dzuuid` parameter and chunk metadata in the `/uploadCase` endpoint to prevent unsafe filesystem path construction.

The following validations were added:
- `dzuuid` now allows only `[a-zA-Z0-9_-]`
- `dzchunkindex` and `dztotalchunkcount` are safely converted to integers
- chunk index bounds are validated (`0 <= index < total_chunks`)

### Why
The `dzuuid` parameter is used to construct filesystem paths for chunk storage. Without validation, a malicious user could supply values such as:

../../../../etc

which could potentially lead to path traversal when interacting with filesystem operations such as directory creation or cleanup.

This patch ensures only safe characters are accepted and that chunk metadata is validated before use.

---

## Validation

- [x] Validation steps documented  
- [ ] Tests added/updated (not applicable for this change) 

### Validation steps
1. Verified the API still accepts valid chunk uploads.
2. Confirmed valid UUID values work normally.
3. Tested invalid inputs such as:
   - ../../etc
   - ../../../tmp
4. Server correctly returns `400 Invalid upload ID`.

---

## Documentation

- [x] Docs updated in this PR (or not applicable)  
- [x] Any setup/workflow changes reflected in repo docs

No documentation changes required.

---

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

Addresses #254 