### PR TITLE
Widening allowed Python version Gate for setup.bat 

### DIFF
--- a/scripts/setup.bat
+++ b/scripts/setup.bat
@@ -18,25 +18,41 @@ if not "%CONDA_DEFAULT_ENV%"=="" (
     exit /b 1
 )
 
-where python3.11 >nul 2>&1
-if %errorlevel% equ 0 (
-    set "PYTHON=python3.11"
-    goto :run
-)
-
-where py >nul 2>&1
-if %errorlevel% equ 0 (
-    py -3.11 -c "import sys" >nul 2>&1
-    if %errorlevel% equ 0 (
-        set "PYTHON=py -3.11"
+REM Try versioned executables first (3.12, 3.11, 3.10)
+for %%V in (3.12 3.11 3.10) do (
+    where python%%V >nul 2>&1
+    if !errorlevel! equ 0 (
+        set "PYTHON=python%%V"
         goto :run
     )
 )
 
-echo ERROR: Python 3.11 was not found in PATH.
-echo Install Python 3.11, then re-run setup.
-echo   In PowerShell (winget): winget install -e --id Python.Python.3.11
-echo   Python.org Windows installer: https://www.python.org/downloads/windows/
+REM Try the Python Launcher (py.exe) with each supported version
+where py >nul 2>&1
+if %errorlevel% equ 0 (
+    for %%V in (3.12 3.11 3.10) do (
+        py -%%V -c "import sys" >nul 2>&1
+        if !errorlevel! equ 0 (
+            set "PYTHON=py -%%V"
+            goto :run
+        )
+    )
+)
+
+REM Try plain `python` and let setup_dev.py validate the version
+where python >nul 2>&1
+if %errorlevel% equ 0 (
+    python -c "import sys; v=sys.version_info; exit(0 if (3,10)<=v<(3,13) else 1)" >nul 2>&1
+    if !errorlevel! equ 0 (
+        set "PYTHON=python"
+        goto :run
+    )
+)
+
+echo ERROR: No supported Python runtime found (requires 3.10, 3.11, or 3.12^).
+echo Install a supported version, then re-run setup.
+echo   winget: winget install -e --id Python.Python.3.12
+echo   Python.org: https://www.python.org/downloads/windows/
 exit /b 1
 
 :run


### PR DESCRIPTION
## Summary

- What changed: `setup.bat` now probes for Python 3.12, 3.11, and 3.10 in order (versioned executables first, then `py` launcher, then plain `python` with an inline version check) before failing. Previously it only looked for Python 3.11 and exited immediately if it wasn't found.
- Why: The project states `>=3.10, <3.13` support in `setup_dev.py` but the `.bat` wrapper never reflected that. Any machine with Python 3.10 or 3.12 hit an immediate failure before `setup_dev.py` was even called. Reproduced on current `main` with Python 3.12.7.

## Related issues

- [x] Issue exists and is linked
- Closes #264 

## Validation

- [x] Tests added/updated (or not applicable) — setup script, no unit tests applicable
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

Ran `scripts\setup.bat --check` on Windows 11 with Python 3.12.7 (3.11 not installed):
Using Python:
Python 3.12.7

MUIOGO Development Environment Setup
Platform : Windows (AMD64)
Python : 3.12.7
Support : >=3.10, <3.13
`setup_dev.py` is reached and runs correctly.

## Documentation

- [x] Docs updated in this PR (or not applicable) — no doc changes needed, error message in the script is self-explanatory

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

# OUTPUT CONFIRMATION:

<img width="871" height="587" alt="image" src="https://github.com/user-attachments/assets/18ce1079-1f68-46f0-95f7-6c8c1327c6ee" />
