### PR TITLE
Improve accessibility: ARIA labels, live regions and keyboard support

### DIFF
--- a/WebAPP/App/View/Home.html
+++ b/WebAPP/App/View/Home.html
@@ -47,10 +47,10 @@
         data-widget-editbutton="false" data-widget-togglebutton="false" data-widget-deletebutton="false"
         data-widget-fullscreenbutton="false" data-widget-custombutton="false" data-widget-sortable="false">
         <header>
-          <h2> <i id="icon" class="fa fa-cubes fa-lg osy-second-color"></i> MUIO models</h2>
+          <h2 id="muio-models-title"> <i class="fa fa-cubes fa-lg osy-second-color" aria-hidden="true"></i> MUIO models</h2>
           <div class="widget-toolbar pull-right">
-            <div  class="btn btn-white" id="showLog" data-toggle="tooltip" data-placement="top" title="Introduction to OSeMOSYS">
-              <i class="fa fa-question-circle fa-lg warning "></i>
+            <div class="btn btn-white" id="showLog" data-toggle="tooltip" data-placement="top" title="Introduction to OSeMOSYS" aria-label="Introduction to OSeMOSYS">
+              <i class="fa fa-question-circle fa-lg warning" aria-hidden="true"></i>
             </div>
             <!-- <button type="button" class="btn btn-default" id="showLog" data-toggle="tooltip" data-placement="top"
                 title="Parameters definitions">
@@ -59,19 +59,19 @@
             <span class="dropdown-menu dropdown-menu-extra-wide" id="definition" style="color:#000"></span>
           </div>
           <div class="widget-toolbar smart-form">
-            <label class="input">
-              <input type="text" placeholder="Search ..." class="nav-search-input" id="CaseSearch" />
-              <i class="ace-icon fa fa-search nav-search-icon"></i>
+            <label class="input" for="CaseSearch">
+              <span class="sr-only">Search models</span>
+              <input type="text" placeholder="Search ..." class="nav-search-input" id="CaseSearch" aria-label="Search models" />
+              <i class="ace-icon fa fa-search nav-search-icon" aria-hidden="true"></i>
             </label>
           </div>
           <div class="widget-toolbar">
-            <div class="btn btn-default" data-toggle="modal" data-target="#modalrestore" id="restoreCS" title="Restore model">
-              <i class="fa fa-cloud-upload fa-lg fa-1.5x  osy"></i>
+            <div class="btn btn-default" data-toggle="modal" data-target="#modalrestore" id="restoreCS" title="Restore model" aria-label="Restore model">
+              <i class="fa fa-cloud-upload fa-lg fa-1.5x osy" aria-hidden="true"></i>
             </div>
-            <a class="btn btn-default " href="#LegacyImport" data-toggle="tooltip" data-placement="top" title="Import model">
-              <i class="fa fa-upload fa-lg fa-1.5x  osy"></i>
-              
-            </a> 
+            <a class="btn btn-default" href="#LegacyImport" data-toggle="tooltip" data-placement="top" title="Import model" aria-label="Import model">
+              <i class="fa fa-upload fa-lg fa-1.5x osy" aria-hidden="true"></i>
+            </a>
           </div>
 
         </header>
@@ -93,11 +93,11 @@
   </div>
 </div>
 
-<div id="modaldescriptionps" class="modal fade" role="dialog">
+<div id="modaldescriptionps" class="modal fade" role="dialog" aria-labelledby="mtitleps_desc" aria-modal="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal">&times;</button>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">&times;</button>
         <h4 class="modal-title" lang="en" data-lang-token="description" id="mtitleps_desc"></h4>
       </div>
       <div class="modal-body">
@@ -110,12 +110,12 @@
 
 
 <!--Modal restore cs -->
-<div id="modalrestore" class="modal fade" role="dialog">
+<div id="modalrestore" class="modal fade" role="dialog" aria-labelledby="modalrestore-title" aria-modal="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <button type="button" class="close" data-dismiss="modal">&times;</button>
-        <h4 class="modal-title">Restore model</h4>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">&times;</button>
+        <h4 class="modal-title" id="modalrestore-title">Restore model</h4>
       </div>
       <div class="modal-body">
         <!-- <form action="http://127.0.0.1:5000/upload" class="dropzone" id="myDropzone"></form> -->

--- a/WebAPP/App/View/Navbar.html
+++ b/WebAPP/App/View/Navbar.html
@@ -16,20 +16,20 @@
 
 		<!-- collapse menu button -->
 	<div class="btn-header pull-right">
-		<span> <a href="/#Versions"  title="Code versions"><i class="fa fa-code" style="margin:0px!important"></i></a> </span>
+		<span> <a href="/#Versions" title="Code versions" aria-label="Code versions"><i class="fa fa-code" style="margin:0px!important" aria-hidden="true"></i></a> </span>
 	</div>
 	<!-- collapse menu button -->
 	<div id="hide-menu" class="btn-header pull-right">
-		<span> <a href="javascript:void(0);" data-action="toggleMenu" title="Collapse Menu"><i class="fa fa-reorder" style="margin:0px!important"></i></a> </span>
+		<span> <a href="javascript:void(0);" data-action="toggleMenu" title="Collapse Menu" aria-label="Collapse menu"><i class="fa fa-reorder" style="margin:0px!important" aria-hidden="true"></i></a> </span>
 	</div>
 	<!-- fullscreen button -->
 	<div id="fullscreen" class="btn-header transparent pull-right">
-		<span> <a href="javascript:void(0);" data-action="launchFullscreen" title="Full Screen"><i class="fa fa-arrows-alt" style="margin:0px!important"></i></a> </span>
+		<span> <a href="javascript:void(0);" data-action="launchFullscreen" title="Full Screen" aria-label="Toggle full screen"><i class="fa fa-arrows-alt" style="margin:0px!important" aria-hidden="true"></i></a> </span>
 	</div>
 	<div class="btn-header transparent pull-right">
-		<span> 
-			<a id='osy-sounds' title='Trun sounds off/on'>
-				<i class="fa fa-volume-up" style="margin:0px!important"></i></a> 
+		<span>
+			<a id='osy-sounds' title='Turn sounds off/on' aria-label="Toggle sounds">
+				<i class="fa fa-volume-up" style="margin:0px!important" aria-hidden="true"></i></a>
 		</span>
 	</div>
 </div>

--- a/WebAPP/App/View/Sidebar.html
+++ b/WebAPP/App/View/Sidebar.html
@@ -1,5 +1,5 @@
-<nav>
-    <ul id="Navi">
+<nav aria-label="Main navigation">
+    <ul id="Navi" role="menubar">
         <li class="active">
             <a href="#/" title="Home page">
                 <i class="fa fa-home fa-lg"></i> 
@@ -66,4 +66,4 @@
         </li>
     </ul>
 </nav>
-<span class="minifyme" data-action="minifyMenu"><i class="fa fa-arrow-circle-left hit"></i> </span>
+<span class="minifyme" data-action="minifyMenu" role="button" aria-label="Collapse sidebar" tabindex="0"><i class="fa fa-arrow-circle-left hit" aria-hidden="true"></i></span>

--- a/WebAPP/Classes/Html.Class.js
+++ b/WebAPP/Classes/Html.Class.js
@@ -25,42 +25,42 @@ export class Html {
                         <tr>
                             <td>
                                 <b>
-                                    <span class="selectCS"  data-ps="${value}" data-toggle="tooltip" data-placement="top" title="Select model">
-                                        <span class="glyphicon 
-                                            ${selectedCS == value ? ` glyphicon-check danger ` : ` glyphicon-bookmark osy-green `}  icon-btn">
+                                    <span class="selectCS" role="button" tabindex="0" data-ps="${value}" data-toggle="tooltip" data-placement="top" title="Select model" aria-label="Select model ${value}">
+                                        <span class="glyphicon
+                                            ${selectedCS == value ? ` glyphicon-check danger ` : ` glyphicon-bookmark osy-green `} icon-btn" aria-hidden="true">
                                         </span>
                                         <span class="pointer">${value}</span>
                                     </span>
                                 </b>
                             </td>
                             <td style="width:40px; text-align:center">
-                                <span data-toggle="modal" data-target="#modaldescriptionps">
+                                <span role="button" tabindex="0" data-toggle="modal" data-target="#modaldescriptionps" aria-label="View description for ${value}">
                                     <span class="descriptionPS" data-ps="${value}" data-toggle="tooltip" data-placement="top" title="Model description">
-                                        <span class="glyphicon glyphicon-info-sign text-info icon-btn"></span>
+                                        <span class="glyphicon glyphicon-info-sign text-info icon-btn" aria-hidden="true"></span>
                                     </span>
                                 </span>
                             </td>
                             <td style="width:40px; text-align:center">
-                                <span class="editPS " data-ps="${value}" data-toggle="tooltip" data-placement="top" title="Configure model">
-                                    <span class="glyphicon glyphicon-edit text-info icon-btn"></span>
+                                <span class="editPS" role="button" tabindex="0" data-ps="${value}" data-toggle="tooltip" data-placement="top" title="Configure model" aria-label="Configure model ${value}">
+                                    <span class="glyphicon glyphicon-edit text-info icon-btn" aria-hidden="true"></span>
                                 </span>
                             </td>
                             <td style="width:40px; text-align:center">
-                                <span class="backupCS" data-ps="${value}" data-toggle="tooltip" data-placement="top" title="Backup model" >
-                                    <a href="backupCase?case=${value}"> <span class="glyphicon glyphicon-download-alt text-info icon-btn"></span></a>
+                                <span class="backupCS" data-ps="${value}" data-toggle="tooltip" data-placement="top" title="Backup model">
+                                    <a href="backupCase?case=${value}" aria-label="Backup model ${value}"><span class="glyphicon glyphicon-download-alt text-info icon-btn" aria-hidden="true"></span></a>
                                 </span>
                             </td>
                             <td style="width:40px; text-align:center">
-                                <span data-toggle="modal" data-target="#modalcopy">
-                                    <span class="copyCS" data-ps="${value}"' + 'id="copy_${value}"  data-toggle="tooltip" data-placement="top" title="Copy model" >
-                                        <span class="glyphicon glyphicon-duplicate text-info icon-btn"></span>
+                                <span role="button" tabindex="0" data-toggle="modal" data-target="#modalcopy" aria-label="Copy model ${value}">
+                                    <span class="copyCS" data-ps="${value}" id="copy_${value}" data-toggle="tooltip" data-placement="top" title="Copy model">
+                                        <span class="glyphicon glyphicon-duplicate text-info icon-btn" aria-hidden="true"></span>
                                     </span>
                                 </span>
                             </td>
                             <td style="width:40px; text-align:center">
                                 <span>
-                                    <span class="deleteModel" data-ps="${value}"'+'data-toggle="tooltip" data-placement="top" title="Delete model">
-                                        <span  class="glyphicon glyphicon-trash danger icon-btn"></span>
+                                    <span class="deleteModel" role="button" tabindex="0" data-ps="${value}" data-toggle="tooltip" data-placement="top" title="Delete model" aria-label="Delete model ${value}">
+                                        <span class="glyphicon glyphicon-trash danger icon-btn" aria-hidden="true"></span>
                                     </span>
                                 </span>
                             </td>

--- a/WebAPP/Classes/Message.Class.js
+++ b/WebAPP/Classes/Message.Class.js
@@ -15,67 +15,67 @@ export class Message {
     }
 
     static warning(message) {
-        $("#osy-warning").html(`<div class="alert alert-warning fade in">
-                                        <button class="close" data-dismiss="alert">×</button>
-                                        <i class="fa-fw fa fa-warning"></i>
+        $("#osy-warning").html(`<div class="alert alert-warning fade in" role="alert">
+                                        <button class="close" data-dismiss="alert" aria-label="Close">×</button>
+                                        <i class="fa-fw fa fa-warning" aria-hidden="true"></i>
                                         <strong>Warning!</strong> `+ message + `
                                     </div>`);
     }
 
     static success(message) {
-        $("#osy-success").html(`<div class="alert alert-success fade in">
-                                        <button class="close" data-dismiss="alert">×</button>
-                                        <i class="fa-fw fa fa-check"></i>
+        $("#osy-success").html(`<div class="alert alert-success fade in" role="status">
+                                        <button class="close" data-dismiss="alert" aria-label="Close">×</button>
+                                        <i class="fa-fw fa fa-check" aria-hidden="true"></i>
                                         <strong>Success!</strong> `+ message + `
                                     </div>`);
     }
 
     static info(message) {
-        $("#osy-info").html(`<div class="alert alert-info fade in">
-                                        <button class="close" data-dismiss="alert">×</button>
-                                        <i class="fa-fw fa fa-info"></i>
+        $("#osy-info").html(`<div class="alert alert-info fade in" role="status">
+                                        <button class="close" data-dismiss="alert" aria-label="Close">×</button>
+                                        <i class="fa-fw fa fa-info" aria-hidden="true"></i>
                                         <strong>Info!</strong> `+ message + `
                                     </div>`);
     }
 
     static danger(message) {
-        $("#osy-danger").html(`<div class="alert alert-danger fade in">
-                                        <button class="close" data-dismiss="alert">×</button>
-                                        <i class="fa-fw fa fa-times"></i>
+        $("#osy-danger").html(`<div class="alert alert-danger fade in" role="alert">
+                                        <button class="close" data-dismiss="alert" aria-label="Close">×</button>
+                                        <i class="fa-fw fa fa-times" aria-hidden="true"></i>
                                         <strong>Error!</strong> `+ message + `
                                     </div>`);
     }
 
     static warningOsy(message) {
         $("#osy-warning-transparent").html(`
-                                    <div class="alert alert-warning-osy fade in">
-                                        <button class="close" data-dismiss="alert">×</button>
-                                        <i class="fa-fw fa fa-warning fa-2x warning"></i>
+                                    <div class="alert alert-warning-osy fade in" role="alert">
+                                        <button class="close" data-dismiss="alert" aria-label="Close">×</button>
+                                        <i class="fa-fw fa fa-warning fa-2x warning" aria-hidden="true"></i>
                                         <strong>Warning!</strong> <i style="color:grey">`+ message + `</i>
                                     </div>`);
     }
 
     static successOsy(message) {
         $("#osy-success-transparent").html(`
-                                    <div class="alert alert-success-osy fade in">
-                                        <button class="close" data-dismiss="alert">×</button>
-                                        <i class="fa-fw fa fa-check fa-2x success"></i>
+                                    <div class="alert alert-success-osy fade in" role="status">
+                                        <button class="close" data-dismiss="alert" aria-label="Close">×</button>
+                                        <i class="fa-fw fa fa-check fa-2x success" aria-hidden="true"></i>
                                         <strong>Success!</strong><i style="color:grey">`+ message + `</i>
                                     </div>`);
     }
 
     static infoOsy(message) {
-        $("#osy-info-transparent").html(`<div class="alert alert-info-osy fade in">
-                                        <button class="close" data-dismiss="alert">×</button>
-                                        <i class="fa-fw fa fa-info fa-2x info"></i>
+        $("#osy-info-transparent").html(`<div class="alert alert-info-osy fade in" role="status">
+                                        <button class="close" data-dismiss="alert" aria-label="Close">×</button>
+                                        <i class="fa-fw fa fa-info fa-2x info" aria-hidden="true"></i>
                                         <strong>Info!</strong> <i style="color:grey">`+ message + `</i>
                                     </div>`);
     }
 
     static dangerOsy(message) {
-        $("#osy-danger-transparent").html(`<div class="alert alert-danger-osy fade in">
-                                        <button class="close" data-dismiss="alert">×</button>
-                                        <i class="fa-fw fa fa-exclamation-triangle fa-2x danger"></i>
+        $("#osy-danger-transparent").html(`<div class="alert alert-danger-osy fade in" role="alert">
+                                        <button class="close" data-dismiss="alert" aria-label="Close">×</button>
+                                        <i class="fa-fw fa fa-exclamation-triangle fa-2x danger" aria-hidden="true"></i>
                                         <strong>Error!</strong> <i style="color:grey">`+ message + `</i>
                                     </div>`);
     }
@@ -262,8 +262,8 @@ export class Message {
 
     static resMessage(message) {
         $("#res-message").html(
-            `<div class="alert alert-osy-second-color fade in">
-                <button class="close" data-dismiss="alert">×</button>
+            `<div class="alert alert-osy-second-color fade in" role="status">
+                <button class="close" data-dismiss="alert" aria-label="Close">×</button>
                  <i style="color:grey">`+ message + `
             </div>`);
     }

--- a/WebAPP/index.html
+++ b/WebAPP/index.html
@@ -86,7 +86,8 @@
 	</head>
 
 	<body class=" minified smart-style-4  fixed-header ">
-		<div id="loadermain" style="display: none;">
+		<a href="#content" class="sr-only sr-only-focusable">Skip to main content</a>
+		<div id="loadermain" style="display: none;" role="status" aria-live="polite" aria-label="Loading">
             <div class="loader "></div>
 			<h4></h4>
 		</div>
@@ -101,17 +102,17 @@
 		<aside id="left-panel"></aside>
 		
 		<!-- #MAIN PANEL -->
-		<div id="main" role="main">	
-			<div id="osy-danger"></div>	
-			<div id="osy-warning"></div>	
-			<div id="osy-info"></div>	
-			<div id="osy-success"></div>	
+		<div id="main" role="main">
+			<div id="osy-danger"              role="alert"  aria-live="assertive" aria-atomic="true"></div>
+			<div id="osy-warning"             role="alert"  aria-live="polite"    aria-atomic="true"></div>
+			<div id="osy-info"                role="status" aria-live="polite"    aria-atomic="true"></div>
+			<div id="osy-success"             role="status" aria-live="polite"    aria-atomic="true"></div>
 
-			<div id="osy-danger-transparent"></div>	
-			<div id="osy-warning-transparent"></div>	
-			<div id="osy-info-transparent"></div>	
-			<div id="osy-success-transparent"></div>
-			<div id="osy-default-transparent"></div>
+			<div id="osy-danger-transparent"  role="alert"  aria-live="assertive" aria-atomic="true"></div>
+			<div id="osy-warning-transparent" role="alert"  aria-live="polite"    aria-atomic="true"></div>
+			<div id="osy-info-transparent"    role="status" aria-live="polite"    aria-atomic="true"></div>
+			<div id="osy-success-transparent" role="status" aria-live="polite"    aria-atomic="true"></div>
+			<div id="osy-default-transparent" role="status" aria-live="polite"    aria-atomic="true"></div>
 					
 			<div class="osy-content pace-done" id="content"></div>
 


### PR DESCRIPTION
While going through the UI, I noticed a few accessibility gaps that could make **MUIOGO** difficult to use for people who rely on screen readers or keyboard navigation. This PR is a first pass at addressing the most obvious ones.

All of the changes are **purely additive** — there are **no visual changes, no framework changes, and no new dependencies**.

---

### What’s included

**`index.html`**

* Added a *skip-to-content* link for keyboard users
* Added `role="alert/status"` and `aria-live="assertive/polite"` to all 9 alert containers so screen readers announce new messages
* Added `role="status"` and `aria-live="polite"` to the loading spinner

**`Navbar.html`**

* Added `aria-label` and `aria-hidden="true"` to icon-only buttons (versions, collapse menu, fullscreen, sound toggle)
* Fixed a small typo: **"Trun sounds off/on" → "Turn sounds off/on"**

**`Sidebar.html`**

* Added `aria-label="Main navigation"` to the `<nav>` element
* Added `role="menubar"` to the navigation list
* Made the sidebar collapse span keyboard-accessible with `role="button"`, `tabindex="0"`, and an `aria-label`

**`Home.html`**

* Added `aria-labelledby` and `aria-modal="true"` to both modal dialogs
* Added `aria-label="Close"` to modal close buttons (previously just showed `×` to screen readers)
* Added `aria-label`s to the toolbar buttons (help, restore, import)
* Added an accessible label for the search input

**`Message.Class.js`**

* Added `role="alert"` / `role="status"` to dynamically injected alert divs
* Added `aria-label="Close"` to close buttons
* Marked decorative icons with `aria-hidden="true"`

**`Html.Class.js`**

* Added `role="button"`, `tabindex="0"`, and descriptive `aria-label`s to the six interactive `<span>` elements in the model list (select, description, configure, backup, copy, delete)
* Also fixed a small string concatenation artifact that was producing malformed HTML in two of those spans

---

### What this PR doesn’t change

* jqWidgets and Wijmo grids (they already have their own accessibility layers)
* `$.SmartMessageBox`, `$.bigBox`, and `$.smallBox` notifications — these are third-party and would likely need a separate effort
* No visual/UI changes

---

### Testing

I verified that all existing jQuery selectors (`selectCS`, `editPS`, `deleteModel`, `copyCS`, `backupCS`, `descriptionPS`, `data-ps`) and related API endpoints still work as expected.

---
