### PR TITLE
fix: stop overwriting source DataFrames in validateInputs()

### DIFF
--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -1412,8 +1412,8 @@ class DataFile(Osemosys):
             df_merge7.drop(columns=['Sum_y'],axis=1, inplace=True)
 
             ################################################################################################ df za provjeru 8
-            df_TAALL = df_TAALL.groupby(['r','t'])['TotalTechnologyAnnualActivityLowerLimit'].sum().reset_index().rename(columns={'TotalTechnologyAnnualActivityLowerLimit':'Sum_TotalTechnologyAnnualActivityLowerLimit'})
-            df_merge8 = df_TMPAUL.merge(df_TAALL, on=['r','t'], how='left')
+            df_TAALL_sum = df_TAALL.groupby(['r','t'])['TotalTechnologyAnnualActivityLowerLimit'].sum().reset_index().rename(columns={'TotalTechnologyAnnualActivityLowerLimit':'Sum_TotalTechnologyAnnualActivityLowerLimit'})
+            df_merge8 = df_TMPAUL.merge(df_TAALL_sum, on=['r','t'], how='left')
             df_merge8['TotalTechnologyModelPeriodActivityUpperLimit'] = df_merge8['TotalTechnologyModelPeriodActivityUpperLimit'].fillna(self.defaultValue['TMPAU'])
             df_merge8 = df_merge8[df_merge8['Sum_TotalTechnologyAnnualActivityLowerLimit'].notna()]
 
@@ -1442,8 +1442,8 @@ class DataFile(Osemosys):
             ########################################################################################### C H E C K 2
             print("CHECK 2. Check if YearSplits sums to 1 for y in YEAR")
             msg+="CHECK 2. Check if YearSplits sums to 1 for y in YEAR\n"
-            df_YS = df_YS.groupby(['r','y'])['YearSplit'].sum().reset_index()
-            df_check2 = df_YS[(df_YS["YearSplit"] != 1)]
+            df_YS_sum = df_YS.groupby(['r','y'])['YearSplit'].sum().reset_index()
+            df_check2 = df_YS_sum[(df_YS_sum["YearSplit"] != 1)]
             if not df_check2.empty:
                 print("CHECK 2: Error")
                 print(df_check2)
@@ -1567,8 +1567,8 @@ class DataFile(Osemosys):
             ########################################################################################### C H E C K 9
             print("CHECK 9. Checking if Specified Demand Profile sums to 1 for (f, y)")
             msg+="CHECK 9. Checking if Specified Demand Profile sums to 1 for (f, y)\n"
-            df_SDP = df_SDP.groupby(['r','f','y'])['SpecifiedDemandProfile'].sum().reset_index()
-            df_check9 = df_SDP[(df_SDP["SpecifiedDemandProfile"] > 1.001) | (df_SDP["SpecifiedDemandProfile"] < 0.999)]
+            df_SDP_total = df_SDP.groupby(['r','f','y'])['SpecifiedDemandProfile'].sum().reset_index()
+            df_check9 = df_SDP_total[(df_SDP_total["SpecifiedDemandProfile"] > 1.001) | (df_SDP_total["SpecifiedDemandProfile"] < 0.999)]
 
             if not df_check9.empty:
                 print("CHECK 9: Error")


### PR DESCRIPTION
## Description:

**Fixes #197** 

This PR resolves a structural bug in `DataFileClass.py` where three core `DataFrames (df_TAALL, df_YS, and df_SDP)` were being overwritten by their aggregated versions mid-function. This mutation destroyed row-level data (dropping columns like 'y' and 'l') required for subsequent merges and checks.

## Changes:

-   df_TAALL: Aggregated result is now stored in df_TAALL_sum. Updated df_merge8 to join on the summed version.

-  df_YS: Aggregated result is now stored in df_YS_sum. This prevents the loss of the timeslice (l) column used in later row-level merges.

 -  df_SDP: Aggregated result is now stored in df_SDP_total. Fixed Check 9 to filter against the aggregated total rather than the original row-level data.

## Testing Performed:

-  Structural Validation: Added temporary logging to confirm that original DataFrames retain their full schema (e.g., 'l' in df_YS.columns returns True) after the aggregation steps.

- Logic Validation: Manually triggered validation via the UI using the "CLEWs Demo." Confirmed that "CHECK 2" and "CHECK 9" still correctly identify and report errors when data does not sum to 1.0.

- No Side Effects: Verified that subsequent merges (like df_merge8) now have access to the correctly named columns.

## Screenshots:

<img width="1365" height="639" alt="Screenshot 2026-03-08 141154" src="https://github.com/user-attachments/assets/d6510769-99d4-4007-8ea4-904514ecbb8a" />
<img width="1365" height="516" alt="Screenshot 2026-03-08 134035" src="https://github.com/user-attachments/assets/01a3ccae-57de-47c9-b238-3fc7e4165e19" />
