### PR TITLE
fix: add session ownership checks to DataFileRoute mutation endpoints

### DIFF
--- a/API/Routes/DataFile/DataFileRoute.py
+++ b/API/Routes/DataFile/DataFileRoute.py
@@ -12,6 +12,12 @@ def generateDataFile():
         casename = request.json['casename']
         caserunname = request.json['caserunname']
 
+        active_case = session.get('osycase')
+        if not active_case:
+            return jsonify({'message': 'No active session.', 'status_code': 'error'}), 403
+        if casename != active_case:
+            return jsonify({'message': 'Unauthorised: case does not match active session.', 'status_code': 'error'}), 403
+
         if casename != None:
             txtFile = DataFile(casename)
             txtFile.generateDatafile(caserunname)
@@ -30,6 +36,12 @@ def createCaseRun():
         caserunname = request.json['caserunname']
         data = request.json['data']
 
+        active_case = session.get('osycase')
+        if not active_case:
+            return jsonify({'message': 'No active session.', 'status_code': 'error'}), 403
+        if casename != active_case:
+            return jsonify({'message': 'Unauthorised: case does not match active session.', 'status_code': 'error'}), 403
+
         if casename != None:
             caserun = DataFile(casename)
             response = caserun.createCaseRun(caserunname, data)
@@ -45,6 +57,12 @@ def updateCaseRun():
         caserunname = request.json['caserunname']
         oldcaserunname = request.json['oldcaserunname']
         data = request.json['data']
+
+        active_case = session.get('osycase')
+        if not active_case:
+            return jsonify({'message': 'No active session.', 'status_code': 'error'}), 403
+        if casename != active_case:
+            return jsonify({'message': 'Unauthorised: case does not match active session.', 'status_code': 'error'}), 403
 
         if casename != None:
             caserun = DataFile(casename)
@@ -63,6 +81,12 @@ def deleteCaseRun():
 
         if not casename:
             return jsonify({'message': 'No model selected.', 'status_code': 'error'}), 400
+
+        active_case = session.get('osycase')
+        if not active_case:
+            return jsonify({'message': 'No active session.', 'status_code': 'error'}), 403
+        if casename != active_case:
+            return jsonify({'message': 'Unauthorised: case does not match active session.', 'status_code': 'error'}), 403
 
         casePath = Path(Config.DATA_STORAGE, casename, 'res', caserunname)
         if not resultsOnly:
@@ -88,6 +112,12 @@ def deleteScenarioCaseRuns():
     try:
         scenarioId = request.json['scenarioId']
         casename = request.json['casename']
+
+        active_case = session.get('osycase')
+        if not active_case:
+            return jsonify({'message': 'No active session.', 'status_code': 'error'}), 403
+        if casename != active_case:
+            return jsonify({'message': 'Unauthorised: case does not match active session.', 'status_code': 'error'}), 403
 
         if casename != None:
             caserun = DataFile(casename)
@@ -234,13 +264,20 @@ def batchRun():
         start = time.time()
         modelname = request.json['modelname']
         cases = request.json['cases']
+        solver = request.json.get('solver', 'CBC')
+
+        active_case = session.get('osycase')
+        if not active_case:
+            return jsonify({'message': 'No active session.', 'status_code': 'error'}), 403
+        if modelname != active_case:
+            return jsonify({'message': 'Unauthorised: case does not match active session.', 'status_code': 'error'}), 403
 
         if modelname != None:
             txtFile = DataFile(modelname)
             for caserun in cases:
                 txtFile.generateDatafile(caserun)
 
-            response = txtFile.batchRun( 'CBC', cases) 
+            response = txtFile.batchRun(solver, cases)
         end = time.time()  
         response['time'] = end-start 
         return jsonify(response), 200
@@ -251,6 +288,12 @@ def batchRun():
 def cleanUp():
     try:
         modelname = request.json['modelname']
+
+        active_case = session.get('osycase')
+        if not active_case:
+            return jsonify({'message': 'No active session.', 'status_code': 'error'}), 403
+        if modelname != active_case:
+            return jsonify({'message': 'Unauthorised: case does not match active session.', 'status_code': 'error'}), 403
 
         if modelname != None:
             model = DataFile(modelname)


### PR DESCRIPTION
## Summary

Fixes #275.

Seven routes in `DataFileRoute.py` accepted `casename`/`modelname` from the request body with no validation against the active session, allowing any caller — including unauthenticated ones — to mutate or destroy another user's case data.

**Routes fixed:**
- `generateDataFile` — writes solver input files for any case
- `createCaseRun` — creates run records in any case
- `updateCaseRun` — overwrites run config in any case
- `deleteCaseRun` — `shutil.rmtree` on any case's run directory
- `deleteScenarioCaseRuns` — deletes scenario data in any case
- `batchRun` — runs solver against any case
- `cleanUp` — deletes result files in any case

The fix applies the same 4-line ownership guard already used correctly in `CaseRoute.py` (`copyCase`, `deleteCase`):

```python
active_case = session.get('osycase')
if not active_case:
    return jsonify({'message': 'No active session.', 'status_code': 'error'}), 403
if casename != active_case:
    return jsonify({'message': 'Unauthorised: case does not match active session.', 'status_code': 'error'}), 403
```

**Also fixes `batchRun` hardcoding `solver='CBC'`** — now reads `solver` from the request body (defaulting to `'CBC'` for backwards compatibility), matching the behaviour of the existing `/run` endpoint. This was a silent failure for GLPK users on batch runs.

## Changes

- `API/Routes/DataFile/DataFileRoute.py` — only file modified

## Test plan

- [ ] Call any patched route with no active session → expect `403 {"message": "No active session."}`
- [ ] Call any patched route with a `casename` that doesn't match `session['osycase']` → expect `403 {"message": "Unauthorised..."}`
- [ ] Call any patched route with the correct `casename` in an active session → expect normal `200` response
- [ ] Call `/batchRun` with `{"solver": "GLPK", ...}` → confirm GLPK is passed through instead of CBC