### PR TITLE
fix: add curl preflight check to start.sh before server launch

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -31,6 +31,15 @@ if [ ! -x "$PYTHON" ]; then
     exit 1
 fi
 
+if ! command -v curl >/dev/null 2>&1; then
+    echo "ERROR: curl is required to launch MUIOGO but was not found on this system."
+    echo "Install it and re-run:"
+    echo "  Ubuntu / Debian : sudo apt-get install curl"
+    echo "  Alpine          : apk add curl"
+    echo "  macOS           : brew install curl"
+    exit 1
+fi
+
 echo "Starting MUIOGO on ${URL}"
 cd "$PROJECT_ROOT"
 "$PYTHON" API/app.py &


### PR DESCRIPTION


## Summary
- **What changed:** Added a `command -v curl` check in `scripts/start.sh` before the server launches
- **Why:** If `curl` isn't installed, the readiness poll silently fails, times out after 30s, and kills a perfectly healthy server with a misleading error. The user has no idea curl is even involved. This check catches it upfront and tells you exactly what to install

## Related issues
- [x] Issue exists and is linked
- Closes #280

## Validation
- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

Reproduced the bug using a `python:3.11-alpine` Docker container (bash installed, curl absent). Started a real HTTP server on port 5002, ran the exact poll block from `start.sh` — server was alive and healthy but got killed after timeout:

```
curl NOT FOUND
Server PID: 8
[0s] Waiting for server...
...
[7s] Waiting for server...
ERROR: MUIOGO did not become ready within 8s.
>>> cleanup() killed SERVER_PID=8 <<<
```

With the fix, the script exits immediately before the server even starts:
```
ERROR: curl is required to launch MUIOGO but was not found on this system.
Install it and re-run:
  Ubuntu / Debian : sudo apt-get install curl
  Alpine          : apk add curl
  macOS           : brew install curl
```

## Documentation
- [x] Docs updated in this PR (or not applicable) — no docs needed, the error message itself is the guidance

## Scope check
- [x] No unrelated refactors
- [x] Implemented from a feature branch (`fix/start-sh-curl-preflight`)
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)