### PR TITLE
Security/api hardening

### DIFF
--- a/API/app.py
+++ b/API/app.py
@@ -6,6 +6,7 @@ import secrets
 from flask import Flask, jsonify, request, session, render_template
 from flask_cors import CORS
 from datetime import timedelta
+from werkzeug.exceptions import RequestEntityTooLarge
 # from pathlib import Path
 
 #import json
@@ -56,7 +57,10 @@ if not secret_key:
 app.config['SECRET_KEY'] = secret_key
 app.config['SESSION_COOKIE_HTTPONLY'] = True
 app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
-app.config["MAX_CONTENT_LENGTH"] = None
+
+# Upload size limit — configurable via env var (in MB), default 50 MB
+_max_upload_mb = int(os.environ.get("MUIOGO_MAX_UPLOAD_MB", 50))
+app.config["MAX_CONTENT_LENGTH"] = _max_upload_mb * 1024 * 1024
 
 app.register_blueprint(upload_api)
 app.register_blueprint(case_api)
@@ -85,6 +89,38 @@ def add_headers(response):
 #     response = jsonify(error.to_dict())
 #     response.status_code = error.status_code
 #     return response
+
+# -------------------------
+# Standardized JSON error handlers
+# -------------------------
+@app.errorhandler(400)
+def handle_bad_request(e):
+    return jsonify({
+        'message': 'Bad request.',
+        'status_code': 'error'
+    }), 400
+
+@app.errorhandler(404)
+def handle_not_found(e):
+    return jsonify({
+        'message': 'Resource not found.',
+        'status_code': 'error'
+    }), 404
+
+@app.errorhandler(413)
+def handle_file_too_large(e):
+    return jsonify({
+        'message': f'File too large. Maximum upload size is {_max_upload_mb} MB.',
+        'status_code': 'error'
+    }), 413
+
+@app.errorhandler(500)
+def handle_internal_error(e):
+    app.logger.exception("Internal server error")
+    return jsonify({
+        'message': 'Internal server error.',
+        'status_code': 'error'
+    }), 500
 
 #entry point to frontend
 @app.route("/", methods=['GET'])
@@ -145,6 +181,7 @@ if __name__ == '__main__':
         print(f"Mode: {mode}")
         print(f"Host: {host}")
         print(f"Port: {current_port}")
+        print(f"Max upload: {_max_upload_mb} MB")
         print(f"Open: http://{access_host}:{current_port}")
 
     if Config.HEROKU_DEPLOY == 0: 

--- a/API/app.py
+++ b/API/app.py
@@ -6,7 +6,6 @@ import secrets
 from flask import Flask, jsonify, request, session, render_template
 from flask_cors import CORS
 from datetime import timedelta
-from werkzeug.exceptions import RequestEntityTooLarge
 # from pathlib import Path
 
 #import json
@@ -97,21 +96,21 @@ def add_headers(response):
 def handle_bad_request(e):
     return jsonify({
         'message': 'Bad request.',
-        'status_code': 'error'
+        'status': 'error'
     }), 400
 
 @app.errorhandler(404)
 def handle_not_found(e):
     return jsonify({
         'message': 'Resource not found.',
-        'status_code': 'error'
+        'status': 'error'
     }), 404
 
 @app.errorhandler(413)
 def handle_file_too_large(e):
     return jsonify({
         'message': f'File too large. Maximum upload size is {_max_upload_mb} MB.',
-        'status_code': 'error'
+        'status': 'error'
     }), 413
 
 @app.errorhandler(500)
@@ -119,7 +118,7 @@ def handle_internal_error(e):
     app.logger.exception("Internal server error")
     return jsonify({
         'message': 'Internal server error.',
-        'status_code': 'error'
+        'status': 'error'
     }), 500
 
 #entry point to frontend


### PR DESCRIPTION
## Summary

### What changed
- Added configurable upload size limit using Flask `MAX_CONTENT_LENGTH`
- Default upload limit set to **50 MB**
- Upload limit configurable via `MUIOGO_MAX_UPLOAD_MB`
- Added standardized JSON error handlers for:
  - 400 (Bad Request)
  - 404 (Resource Not Found)
  - 413 (File Too Large)
  - 500 (Internal Server Error)
- Prevented stack traces from being exposed to clients
- Added startup log displaying configured upload limit

### Why
- Prevent unlimited file uploads which may cause memory issues
- Ensure API responses are consistent and frontend-friendly
- Improve API security by hiding internal stack traces
- Improve operational visibility through startup logging

---

Closes #283

---

## Validation

- [x] Upload size limited using `MAX_CONTENT_LENGTH`
- [x] Default upload limit is **50 MB**
- [x] Error handlers return JSON responses
- [x] Internal server errors logged but not exposed
- [x] Upload limit displayed on server startup

---

---

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Base branch: `EAPD-DRB/MUIOGO main`