### PR TITLE
fix(start): use Python for launcher readiness probe

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -42,10 +42,26 @@ cleanup() {
     fi
 }
 
+probe_ready() {
+    "$PYTHON" -c '
+import sys
+import urllib.request
+
+url = sys.argv[1]
+
+try:
+    with urllib.request.urlopen(url, timeout=2) as response:
+        status = getattr(response, "status", 200)
+        raise SystemExit(0 if 200 <= status < 400 else 1)
+except Exception:
+    raise SystemExit(1)
+' "$URL"
+}
+
 trap cleanup INT TERM
 
 elapsed=0
-while ! curl -fsS "$URL" >/dev/null 2>&1; do
+while ! probe_ready; do
     if ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
         echo "ERROR: MUIOGO server exited before becoming ready."
         exit 1


### PR DESCRIPTION
## Summary

- What changed: Replaced the `curl`-based readiness poll in `scripts/start.sh` with a Python stdlib HTTP probe using the same interpreter the launcher already depends on.
- Why: The previous launcher required `curl` just to detect when the local server was ready. On systems without `curl`, the poll failed repeatedly, timed out, and killed a healthy server. This change removes the extra dependency entirely and keeps readiness detection inside the existing Python runtime.

## Related issues

- [x] Issue exists and is linked
- Closes #280
- Related to #282
