### PR TITLE
fix: resolve ReferenceError in RESViewer.refreshPage on model switch …

### DIFF
--- a/WebAPP/App/Controller/RESViewer.js
+++ b/WebAPP/App/Controller/RESViewer.js
@@ -60,8 +60,7 @@ export default class RESViewer {
                 settings.Desc = $("#useDesc").is(":checked");
 
                 let DemandComms = DataModel.getDemandComms(RYCdata, genData['osy-years']);
-                let model = new Model(casename, genData, DemandComms, settings);
-                modelNew.cmbTechs = model.cmbTechs;
+                let modelNew = new Model(casename, genData, DemandComms, settings);
                 this.initPage(modelNew);
                 this.initEvents(modelNew);
             })


### PR DESCRIPTION
Rename local variable from `model` to `modelNew` to match existing references on lines 64-66. The mismatch caused a ReferenceError crash whenever users switched models via the dropdown on the RES Viewer page.

## Summary
- **What changed:** Renamed `let model` to `let modelNew` in `RESViewer.refreshPage()` (line 63) and removed the dead `modelNew.cmbTechs = model.cmbTechs` assignment (line 64)
- **Why:** `refreshPage()` referenced `modelNew` on lines 64-66 but the variable was declared as `model` — a copy-paste error. This caused a `ReferenceError` crash every time a user switched models on the RES Viewer page.

## Related issues
- [x] Issue exists and is linked
- Closes #297

## Validation
- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

**Steps to validate:**
1. Open the app, ensure two models exist
2. Select the first model, navigate to **Model diagram** (RES Viewer)
3. Use the **Select model** dropdown to switch to the second model
4. **Before fix:** `ReferenceError: modelNew is not defined` in console, diagram fails
5. **After fix:** Diagram reloads correctly with the new model's data

## Documentation
- [x] Docs updated in this PR (or not applicable)

## Scope check
- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)
