### PR TITLE
Use atomic writes for resData.json to prevent corruption on crash

### DIFF
--- a/API/Classes/Base/FileClass.py
+++ b/API/Classes/Base/FileClass.py
@@ -47,3 +47,21 @@ class File:
             raise IOError
         except OSError:
             raise OSError
+
+    @staticmethod
+    def writeFileAtomic(data, path):
+        import os
+        import tempfile
+        path = str(path)
+        dir_name = os.path.dirname(path) or '.'
+        fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix='.tmp')
+        try:
+            with os.fdopen(fd, 'w') as f:
+                f.write(json.dumps(data, ensure_ascii=True, indent=4, sort_keys=False))
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, path)
+        except Exception as e:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+            raise e

--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -798,11 +798,11 @@ class DataFile(Osemosys):
                 os.makedirs(caseRunPath)
                 os.makedirs(csvPath)
                 if not os.path.exists(resDataPath):
-                    File.writeFile( data, resDataPath)
+                    File.writeFileAtomic( data, resDataPath)
                 else:
                     resData = File.readFile(resDataPath)
                     resData['osy-cases'].append(data)
-                    File.writeFile( resData, resDataPath)
+                    File.writeFileAtomic( resData, resDataPath)
                 response = {
                     "message": "You have created a case run!",
                     "status_code": "success"
@@ -831,7 +831,7 @@ class DataFile(Osemosys):
                         cs['Scenarios'].remove(sc)
 
 
-            File.writeFile(resData, self.resDataPath)
+            File.writeFileAtomic(resData, self.resDataPath)
             response = {
                 "message": "You have deleted scenario from caseruns!",
                 "status_code": "success"
@@ -865,7 +865,7 @@ class DataFile(Osemosys):
                     if case['Case'] == oldcaserunname:
                         resData['osy-cases'][i] = data
 
-                File.writeFile( resData, resDataPath)
+                File.writeFileAtomic( resData, resDataPath)
                 response = {
                     "message": "You have updated a case run!",
                     "status_code": "success"
@@ -881,7 +881,7 @@ class DataFile(Osemosys):
                     if case['Case'] == oldcaserunname:
                         resData['osy-cases'][i] = data
 
-                File.writeFile( resData, resDataPath)
+                File.writeFileAtomic( resData, resDataPath)
                 response = {
                     "message": "You have updated a case run!",
                     "status_code": "success"
@@ -934,7 +934,7 @@ class DataFile(Osemosys):
                     if obj['Case'] == caserunname:
                         resData['osy-cases'].remove(obj)
 
-                File.writeFile( resData, self.resDataPath)
+                File.writeFileAtomic( resData, self.resDataPath)
 
             #delete from view folder
             for group, array in self.VARIABLES.items():


### PR DESCRIPTION
### Summary

What changed: Replaced direct File.writeFile calls with a new File.writeFileAtomic method for all writes to resData.json
Why: Direct writes using open(path, 'w') are not crash-safe. If the process is interrupted mid-write, the file is left partially written and unparseable. The atomic pattern writes to a .tmp file first and uses os.replace() to swap it in, guaranteeing the target is either fully updated or unchanged.

### Related issues
Closes #258 (narrowed-down version)

### Validation 
Manual validation: interrupt a write mid-operation, confirm original file is preserved

### Documentation

 Not applicable, internal implementation change, no API changes

### Scope check
- No unrelated refactors
- Implemented from a feature branch
- Change is deliverable without upstream dependency
- Base branch is EAPD-DRB/MUIOGO:main