### PR TITLE
governance: restore normal issue intake forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -27,60 +27,32 @@ body:
     id: environment
     attributes:
       label: Environment
-      description: OS, Python version, branch/commit.
+      description: OS, Python version, branch or commit if relevant.
     validations:
       required: true
   - type: textarea
     id: evidence
     attributes:
       label: Logs or screenshots
-      description: Paste relevant output.
+      description: Paste relevant output or links to screenshots.
     validations:
       required: false
   - type: textarea
-    id: related_issues
+    id: related_work
     attributes:
-      label: Related issues reviewed
-      description: List related issues reviewed before opening this issue. Use issue numbers like #123, or write `None found after search`.
-    validations:
-      required: true
-  - type: textarea
-    id: related_prs
-    attributes:
-      label: Related PRs reviewed
-      description: List related PRs reviewed before opening this issue. Use PR numbers like #123, or write `None found after search`.
-    validations:
-      required: true
-  - type: dropdown
-    id: overlap
-    attributes:
-      label: Overlap classification
-      description: Choose the best overlap classification for this issue.
-      options:
-        - none
-        - duplicate
-        - alternative approach
-        - complementary follow-up
-        - narrower fix
-        - superseding
-    validations:
-      required: true
-  - type: textarea
-    id: still_needed
-    attributes:
-      label: Why this issue is still needed
-      description: If related work exists, explain why this issue should still be tracked separately. If not, briefly explain why it should be tracked now.
+      label: Related work checked
+      description: List anything relevant you checked before opening this issue. Use issue/PR numbers like #123, or write `None found after search`.
     validations:
       required: true
   - type: dropdown
     id: proposed_track
     attributes:
       label: Proposed track
-      description: Maintainers will assign the final track label.
+      description: Optional. Maintainers will assign the final track label.
       options:
         - Track: Cross-Platform
         - Track: OG Onboarding
         - Track: Integration
         - Track: Stability
     validations:
-      required: true
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,5 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Project support guide
     url: https://github.com/EAPD-DRB/MUIOGO/blob/main/SUPPORT.md
     about: Read support guidance and reporting expectations.
-

--- a/.github/ISSUE_TEMPLATE/feature_task.yml
+++ b/.github/ISSUE_TEMPLATE/feature_task.yml
@@ -31,53 +31,25 @@ body:
     id: dependencies
     attributes:
       label: Dependencies and constraints
-      description: Upstream/downstream constraints, blocked items, external dependencies.
+      description: Upstream or downstream constraints, blocked items, or external dependencies.
     validations:
       required: false
   - type: textarea
-    id: related_issues
+    id: related_work
     attributes:
-      label: Related issues reviewed
-      description: List related issues reviewed before opening this issue. Use issue numbers like #123, or write `None found after search`.
-    validations:
-      required: true
-  - type: textarea
-    id: related_prs
-    attributes:
-      label: Related PRs reviewed
-      description: List related PRs reviewed before opening this issue. Use PR numbers like #123, or write `None found after search`.
-    validations:
-      required: true
-  - type: dropdown
-    id: overlap
-    attributes:
-      label: Overlap classification
-      description: Choose the best overlap classification for this issue.
-      options:
-        - none
-        - duplicate
-        - alternative approach
-        - complementary follow-up
-        - narrower fix
-        - superseding
-    validations:
-      required: true
-  - type: textarea
-    id: still_needed
-    attributes:
-      label: Why this issue is still needed
-      description: If related work exists, explain why this issue should still be tracked separately. If not, briefly explain why it should be tracked now.
+      label: Related work checked
+      description: List anything relevant you checked before opening this issue. Use issue/PR numbers like #123, or write `None found after search`.
     validations:
       required: true
   - type: dropdown
     id: proposed_track
     attributes:
       label: Proposed track
-      description: Maintainers will assign the final track label.
+      description: Optional. Maintainers will assign the final track label.
       options:
         - Track: Cross-Platform
         - Track: OG Onboarding
         - Track: Integration
         - Track: Stability
     validations:
-      required: true
+      required: false


### PR DESCRIPTION
## Summary

- What changed:
  - re-enabled blank issues as a temporary fallback in `.github/ISSUE_TEMPLATE/config.yml`
  - simplified `bug_report.yml` to a minimal bug-report form
  - simplified `feature_task.yml` to a minimal task form
- Why:
  - GitHub is currently only showing `Question or blocker`, which makes normal bug/task intake awkward
  - this restores usable issue intake first, with a blank-issue fallback in case a form breaks again

## Linked issue

- Related #255

## Existing related work reviewed

- Issues/PRs reviewed: #255, #299
- If none found, write: None found after search

## Overlap assessment

- Classification: complementary follow-up
- Overlapping items: #299
- Why this is not duplicate/superseded:
  - `#299` introduced the intake structure
  - this PR is a follow-up usability fix to make normal bug/task issue creation visible and usable again

## Why this PR should proceed

- It restores normal GitHub issue intake without undoing the overall intake model.
- It keeps the repo usable while the intake forms stabilize.

