### PR TITLE
fix: stop Home handlers from stacking on refresh

### DIFF
--- a/WebAPP/App/Controller/Home.js
+++ b/WebAPP/App/Controller/Home.js
@@ -95,7 +95,8 @@ export default class Home {
             })
         });
 
-        $("#cases").on('click', '.editPS', function(e) {
+        $("#cases").off('click.homeEdit', '.editPS');
+        $("#cases").on('click.homeEdit', '.editPS', function(e) {
             e.preventDefault();
             e.stopImmediatePropagation();
             var casename = $(this).attr('data-ps');
@@ -150,7 +151,8 @@ export default class Home {
         });
 
         //get descrition
-        $(document).delegate(".descriptionPS","click",function(e){
+        $("#cases").off('click.homeDescription', '.descriptionPS');
+        $("#cases").on('click.homeDescription', '.descriptionPS', function(e){
             //e.stopImmediatePropagation();
             var titleps = $(this).attr('data-ps');
             Base.getCaseDesc(titleps)
@@ -212,7 +214,8 @@ export default class Home {
         });
 
         //Search cases
-        $('#CaseSearch').keyup(function () {
+        $('#CaseSearch').off('keyup.homeSearch');
+        $('#CaseSearch').on('keyup.homeSearch', function () {
             var query = $.trim($('#CaseSearch').val()).toLowerCase();
             //console.log('query ', query)
             $('.selectCS').each(function () {
@@ -223,7 +226,8 @@ export default class Home {
             });
         })
 
-        $("#showLog").click(function (e) {
+        $("#showLog").off('click.homeLog');
+        $("#showLog").on('click.homeLog', function (e) {
             e.preventDefault();
             $('#definition').html(`
                 <h5>${DEF[model.pageID].title}</h5>


### PR DESCRIPTION
## Summary

- What changed:
  - made the remaining rebinding-prone Home handlers idempotent
  - `editPS` now uses namespaced `off/on`
  - `descriptionPS` now binds on `#cases` with namespaced `off/on` instead of `document.delegate(...)`
  - `#CaseSearch` now uses namespaced `off/on`
  - `#showLog` now uses namespaced `off/on`
- Why:
  - resolves the remaining Home refresh handler accumulation tracked in #311
  - after repeated Home refreshes, one click/key event should trigger one action

## Linked issue

- Closes #311

## Existing related work reviewed

- Issues/PRs reviewed: #310, #311, #312

## Overlap assessment

- Classification: narrower fix
- Overlapping items: #312
- Why this is not duplicate/superseded:
  - #312 already cleaned up the Home handlers needed for selection, copy, and delete
  - this PR fixes the remaining handlers that still stacked after repeated Home refreshes

## Why this PR should proceed

- The remaining Home-page issue after #312 was still real:
  - `#showLog` could toggle incorrectly after repeated refreshes
  - search/description/edit handlers could accumulate across repeated Home refreshes
- This PR fixes that without reopening the broader copy/delete work.

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [ ] Evidence attached (logs/screenshots/output as relevant)

Validation performed:
- `node --check WebAPP/App/Controller/Home.js`
- manual test on the feature branch:
  - repeated model clicks no longer destabilize `#showLog`
  - search behaves normally after repeated refreshes
  - description and configure/edit actions fire once as expected

## Documentation

- [x] Docs updated in this PR (or not applicable)
- [x] Any setup/workflow changes reflected in repo docs

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)
