### PR TITLE
test: add pytest smoke tests for core API endpoints

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Development and testing dependencies
+# Install with: pip install -r requirements-dev.txt
+# Runtime dependencies are in requirements.txt
+
+pytest>=8.0
+pytest-flask>=1.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,144 @@
+"""
+Pytest fixtures for the MUIOGO API test suite.
+
+The Flask application in API/app.py is not structured as a factory, so the app
+instance is imported once per test session with TESTING enabled. Each test
+receives a fresh Flask test client whose file system operations are redirected
+to a per-test temporary directory via monkeypatching of Config.DATA_STORAGE.
+No test touches the real WebAPP/DataStorage directory.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the Flask application and its internal modules importable.
+API_DIR = Path(__file__).parent.parent / "API"
+sys.path.insert(0, str(API_DIR))
+
+
+@pytest.fixture(scope="session")
+def flask_app():
+    """
+    Import and return the Flask application with TESTING mode enabled.
+
+    Session-scoped so the app is initialised only once. Blueprint registration
+    and module-level imports (including Config) happen here.
+    """
+    from app import app as flask_application  # noqa: PLC0415
+
+    flask_application.config["TESTING"] = True
+    flask_application.config["SECRET_KEY"] = "test-secret-key-not-for-production"
+    return flask_application
+
+
+@pytest.fixture
+def data_storage(tmp_path):
+    """
+    Create an isolated DataStorage directory containing the minimal files
+    that the API expects to exist at startup.
+
+    Parameters.json uses empty arrays for every parameter group so that
+    CaseClass and Osemosys.__init__ can iterate over them without side effects.
+    Variables.json is an empty mapping so deleteCaseRun's view-cleanup loop
+    is a no-op.
+    """
+    storage = tmp_path / "DataStorage"
+    storage.mkdir()
+
+    parameters = {
+        group: []
+        for group in [
+            "R", "RY", "RT", "RE", "RS",
+            "RYT", "RYC", "RYE", "RYTC", "RYTM",
+            "RYTCM", "RYTE", "RYTEM", "RYTTs", "RYCTs",
+            "RYTs", "RYDtb", "RYSeDt", "RYS", "RYTSM",
+            "RTSM", "RYCn", "RYTCn",
+        ]
+    }
+    (storage / "Parameters.json").write_text(json.dumps(parameters))
+    (storage / "Variables.json").write_text(json.dumps({}))
+
+    return storage
+
+
+@pytest.fixture
+def case_fixture(data_storage):
+    """
+    Create a minimal valid case directory under data_storage.
+
+    The structure matches what Osemosys.__init__ and route handlers expect:
+      <storage>/<case_name>/
+        genData.json
+        res/
+        view/
+          resData.json
+          viewDefinitions.json
+
+    Returns the case name string so tests can pass it in request payloads.
+    """
+    case_name = "test_case"
+    case_dir = data_storage / case_name
+    case_dir.mkdir()
+
+    gen_data = {
+        "osy-casename": case_name,
+        "osy-desc": "A test case",
+        "osy-version": 1.0,
+        "osy-years": ["2020", "2025"],
+        "osy-scenarios": [{"ScenarioId": "SC_0", "Active": True}],
+        "osy-tech": [],
+        "osy-emis": [],
+        "osy-comm": [],
+        "osy-stg": [],
+        "osy-ts": [],
+        "osy-se": [],
+        "osy-dt": [],
+        "osy-dtb": [],
+        "osy-mo": "1",
+        "osy-constraints": [],
+    }
+    (case_dir / "genData.json").write_text(json.dumps(gen_data))
+
+    (case_dir / "res").mkdir()
+
+    view_dir = case_dir / "view"
+    view_dir.mkdir()
+    (view_dir / "resData.json").write_text(json.dumps({"osy-cases": []}))
+    (view_dir / "viewDefinitions.json").write_text(json.dumps({"osy-views": {}}))
+
+    return case_name
+
+
+@pytest.fixture
+def client(flask_app, data_storage, monkeypatch):
+    """
+    Flask test client with Config.DATA_STORAGE redirected to a temporary
+    directory. No active session is set. Use this for unauthenticated requests
+    or cases where the test sets up session state explicitly.
+    """
+    import Classes.Base.Config as Config  # noqa: PLC0415
+
+    monkeypatch.setattr(Config, "DATA_STORAGE", data_storage)
+    with flask_app.test_client() as test_client:
+        yield test_client
+
+
+@pytest.fixture
+def authed_client(flask_app, data_storage, case_fixture, monkeypatch):
+    """
+    Flask test client with Config.DATA_STORAGE redirected to a temporary
+    directory and the Flask session pre-set to case_fixture.
+
+    Yields a (client, case_name) tuple so tests have easy access to the
+    active case name when constructing request payloads.
+    """
+    import Classes.Base.Config as Config  # noqa: PLC0415
+
+    monkeypatch.setattr(Config, "DATA_STORAGE", data_storage)
+    with flask_app.test_client() as test_client:
+        with test_client.session_transaction() as sess:
+            sess["osycase"] = case_fixture
+        yield test_client, case_fixture

--- a/tests/test_case_routes.py
+++ b/tests/test_case_routes.py
@@ -1,0 +1,151 @@
+"""
+Smoke tests for the case management blueprint (CaseRoute).
+
+GET  /getCases      -- scans DataStorage and returns a list of case directory names
+POST /getDesc       -- reads osy-desc from a case's genData.json
+POST /copyCase      -- copies a case directory; guarded by session match
+POST /deleteCase    -- removes a case directory; guarded by session match
+POST /getResultCSV  -- lists CSV files in a case run's csv/ subdirectory
+"""
+
+import json
+
+
+class TestGetCases:
+    def test_returns_empty_list_when_storage_has_no_cases(self, client):
+        response = client.get("/getCases")
+
+        assert response.status_code == 200
+        assert response.get_json() == []
+
+    def test_returns_case_name_when_case_directory_exists(self, client, case_fixture):
+        response = client.get("/getCases")
+
+        assert response.status_code == 200
+        assert case_fixture in response.get_json()
+
+
+class TestGetDesc:
+    def test_returns_description_for_existing_case(self, client, case_fixture):
+        response = client.post(
+            "/getDesc",
+            json={"casename": case_fixture},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["desc"] == "A test case"
+
+    def test_missing_case_returns_404(self, client):
+        response = client.post(
+            "/getDesc",
+            json={"casename": "no_such_case"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 404
+
+
+class TestCopyCase:
+    def test_authorized_copy_succeeds(self, authed_client):
+        test_client, case_name = authed_client
+
+        response = test_client.post(
+            "/copyCase",
+            json={"casename": case_name},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.get_json()["status_code"] == "success"
+
+    def test_no_active_session_returns_403(self, client, case_fixture):
+        response = client.post(
+            "/copyCase",
+            json={"casename": case_fixture},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 403
+
+    def test_session_case_mismatch_returns_403(self, authed_client):
+        test_client, _ = authed_client
+
+        response = test_client.post(
+            "/copyCase",
+            json={"casename": "different_case"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 403
+
+    def test_copy_destination_already_exists_returns_warning(
+        self, authed_client, data_storage
+    ):
+        test_client, case_name = authed_client
+        # Pre-create the destination so copytree would fail.
+        (data_storage / (case_name + "_copy")).mkdir()
+
+        response = test_client.post(
+            "/copyCase",
+            json={"casename": case_name},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.get_json()["status_code"] == "warning"
+
+
+class TestDeleteCase:
+    def test_authorized_delete_succeeds(self, authed_client):
+        test_client, case_name = authed_client
+
+        response = test_client.post(
+            "/deleteCase",
+            json={"casename": case_name},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.get_json()["status_code"] == "success_session"
+
+    def test_no_active_session_returns_403(self, client, case_fixture):
+        response = client.post(
+            "/deleteCase",
+            json={"casename": case_fixture},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 403
+
+
+class TestGetResultCSV:
+    def test_returns_csv_filenames_when_directory_exists(
+        self, client, case_fixture, data_storage
+    ):
+        csv_dir = data_storage / case_fixture / "res" / "run1" / "csv"
+        csv_dir.mkdir(parents=True)
+        (csv_dir / "TotalCapacityAnnual.csv").touch()
+        (csv_dir / "NewCapacity.csv").touch()
+
+        response = client.post(
+            "/getResultCSV",
+            json={"casename": case_fixture, "caserunname": "run1"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        csv_files = response.get_json()
+        assert "TotalCapacityAnnual.csv" in csv_files
+        assert "NewCapacity.csv" in csv_files
+
+    def test_missing_csv_directory_returns_empty_list(self, client, case_fixture):
+        response = client.post(
+            "/getResultCSV",
+            json={"casename": case_fixture, "caserunname": "nonexistent_run"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.get_json() == []

--- a/tests/test_datafile_routes.py
+++ b/tests/test_datafile_routes.py
@@ -1,0 +1,119 @@
+"""
+Smoke tests for the data-file blueprint (DataFileRoute).
+
+POST /createCaseRun  -- creates a run subdirectory and registers it in resData.json
+POST /deleteCaseRun  -- removes a run (full or results-only) and updates resData.json
+
+Solver-invoking endpoints (/run, /batchRun) are intentionally excluded; they
+require platform-specific binaries and belong in a separate integration suite.
+"""
+
+import json
+
+
+def _create_run_directory(data_storage, case_name, run_name):
+    """Create a minimal case-run directory with an empty csv/ subdirectory."""
+    run_dir = data_storage / case_name / "res" / run_name
+    run_dir.mkdir(parents=True)
+    (run_dir / "csv").mkdir()
+    return run_dir
+
+
+def _register_run_in_resdata(data_storage, case_name, run_name):
+    """Append a run entry to the case's resData.json."""
+    res_data_path = data_storage / case_name / "view" / "resData.json"
+    res_data = json.loads(res_data_path.read_text())
+    res_data["osy-cases"].append({"Case": run_name, "Scenarios": []})
+    res_data_path.write_text(json.dumps(res_data))
+
+
+class TestCreateCaseRun:
+    def test_new_run_is_created_successfully(self, client, case_fixture):
+        run_data = {"Case": "run1", "Scenarios": []}
+
+        response = client.post(
+            "/createCaseRun",
+            json={
+                "casename": case_fixture,
+                "caserunname": "run1",
+                "data": run_data,
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.get_json()["status_code"] == "success"
+
+    def test_duplicate_run_name_returns_exist_status(
+        self, client, case_fixture, data_storage
+    ):
+        _create_run_directory(data_storage, case_fixture, "run1")
+
+        run_data = {"Case": "run1", "Scenarios": []}
+        response = client.post(
+            "/createCaseRun",
+            json={
+                "casename": case_fixture,
+                "caserunname": "run1",
+                "data": run_data,
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.get_json()["status_code"] == "exist"
+
+
+class TestDeleteCaseRun:
+    def test_full_delete_removes_run_and_resdata_entry(
+        self, client, case_fixture, data_storage
+    ):
+        _create_run_directory(data_storage, case_fixture, "run1")
+        _register_run_in_resdata(data_storage, case_fixture, "run1")
+
+        response = client.post(
+            "/deleteCaseRun",
+            json={
+                "casename": case_fixture,
+                "caserunname": "run1",
+                "resultsOnly": False,
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.get_json()["status_code"] == "success"
+
+    def test_results_only_clears_run_contents_and_returns_success(
+        self, client, case_fixture, data_storage
+    ):
+        run_dir = _create_run_directory(data_storage, case_fixture, "run1")
+        # Place a dummy result file so the cleanup loop has something to process.
+        (run_dir / "results.txt").write_text("solver output")
+        _register_run_in_resdata(data_storage, case_fixture, "run1")
+
+        response = client.post(
+            "/deleteCaseRun",
+            json={
+                "casename": case_fixture,
+                "caserunname": "run1",
+                "resultsOnly": True,
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.get_json()["status_code"] == "success"
+
+    def test_nonexistent_run_returns_404(self, client, case_fixture):
+        response = client.post(
+            "/deleteCaseRun",
+            json={
+                "casename": case_fixture,
+                "caserunname": "run_does_not_exist",
+                "resultsOnly": False,
+            },
+            content_type="application/json",
+        )
+
+        assert response.status_code == 404

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,55 @@
+"""
+Smoke tests for session management endpoints.
+
+GET  /getSession  -- returns the name of the currently active case or null
+POST /setSession  -- sets the active case; validates the case directory exists
+"""
+
+
+class TestGetSession:
+    def test_returns_null_when_no_session_is_active(self, client):
+        response = client.get("/getSession")
+
+        assert response.status_code == 200
+        assert response.get_json()["session"] is None
+
+    def test_returns_case_name_when_session_is_active(self, authed_client):
+        test_client, case_name = authed_client
+
+        response = test_client.get("/getSession")
+
+        assert response.status_code == 200
+        assert response.get_json()["session"] == case_name
+
+
+class TestSetSession:
+    def test_valid_case_name_stores_session(self, client, case_fixture):
+        response = client.post(
+            "/setSession",
+            json={"case": case_fixture},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.get_json()["osycase"] == case_fixture
+
+    def test_null_case_clears_active_session(self, authed_client):
+        test_client, _ = authed_client
+
+        response = test_client.post(
+            "/setSession",
+            json={"case": None},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        assert response.get_json()["osycase"] is None
+
+    def test_nonexistent_case_directory_returns_404(self, client):
+        response = client.post(
+            "/setSession",
+            json={"case": "case_that_does_not_exist"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 404


### PR DESCRIPTION
## Context

Closes #314

The project has no automated test coverage. `requirements.txt` contains no testing framework, there are no test files in the repository, and the CI pipeline only validates PR structure. Any change to a route handler or the file-system layer can introduce a regression that only manual testing would catch.

This PR adds a foundational pytest suite using Flask's built-in test client. It covers the session, case, and data-file route blueprints, and establishes the fixture pattern and import conventions that future test PRs can extend without repeating setup work.

---

## Changes

**`requirements-dev.txt`** (new)
Development dependencies kept separate from runtime `requirements.txt`. Install with `pip install -r requirements-dev.txt`.

**`tests/conftest.py`** (new)
Five fixtures:
- `flask_app` (session-scoped) — imports `API/app.py` once with `TESTING=True`
- `data_storage` — creates an isolated `tmp_path/DataStorage` with minimal `Parameters.json` and `Variables.json`; no test touches the real `WebAPP/DataStorage`
- `case_fixture` — builds a minimal valid case directory (`genData.json`, `res/`, `view/resData.json`, `view/viewDefinitions.json`)
- `client` — `flask_app.test_client()` with `Config.DATA_STORAGE` monkeypatched per-test
- `authed_client` — same as `client` but with the Flask session pre-set to the fixture case name

`app.py` is not a factory function. The fixture imports it once at session scope. `Config.DATA_STORAGE` is a module-level attribute read at request time, so `monkeypatch.setattr` is sufficient isolation with no production code changes required.

**`tests/test_session.py`** (new)
Covers `GET /getSession` and `POST /setSession`: empty session, active session reflected, valid case stores session, null clears session, nonexistent case returns 404.

**`tests/test_case_routes.py`** (new)
Covers `GET /getCases`, `POST /getDesc`, `POST /copyCase`, `POST /deleteCase`, `POST /getResultCSV`. Includes 403 guard tests for session absence and case-name mismatch on copy and delete.

**`tests/test_datafile_routes.py`** (new)
Covers `POST /createCaseRun` and `POST /deleteCaseRun` (full removal, results-only mode, 404 for nonexistent run). Solver-invoking endpoints (`/run`, `/batchRun`) are excluded; they require platform-specific binaries and belong in a separate integration suite.

---

## Testing

```bash
pip install -r requirements-dev.txt
pytest tests/ -v
```

```
22 passed in 0.44s
```

Verified on Python 3.12. No files written to `WebAPP/DataStorage` during the run (confirmed by inspecting directory timestamps after the full suite).

---

## Impact

- No production source file is modified.
- `requirements.txt` is unchanged.
- The `monkeypatch` + `tmp_path` pattern established in `conftest.py` can be reused directly by contributors adding tests for upload, viewdata, or S3 sync routes.
- Enables a follow-up CI workflow PR to add a single `pytest tests/` step to a GitHub Actions matrix job across Python 3.10–3.12.

---

## Related issues and PRs reviewed

None found after search.

Overlap classification: none