### PR TITLE
[Task] Refactor: Replace print() statements with structured logging

### DIFF
--- a/API/Classes/Base/Config.py
+++ b/API/Classes/Base/Config.py
@@ -34,6 +34,13 @@ def validate_path(base_dir, user_input):
 #load environment variables
 load_dotenv()
 
+import logging
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format='%(asctime)s [%(levelname)s] %(name)s: %(message)s'
+)
+
 SYSTEM = platform.system()
 
 # S3_BUCKET = os.environ.get("S3_BUCKET")

--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -4,6 +4,7 @@ from zipfile import ZipFile
 from pathlib import Path
 from werkzeug.utils import secure_filename
 import os, time, json, glob
+import logging
 
 from threading import Thread
 
@@ -11,6 +12,7 @@ from Classes.Base import Config
 from Classes.Base.FileClass import File
 
 upload_api = Blueprint('UploadRoute', __name__)
+logger = logging.getLogger(__name__)
 
 #File extension checking
 def allowed_filename(filename):
@@ -188,12 +190,12 @@ class Download(Thread):
         self.zippedFile = zippedFile
 
     def run(self):
-        print("wait few seconds for download to finish")
+        logger.info("wait few seconds for download to finish")
         time.sleep(20)
-        #print(self.request)
+        #logger.debug(self.request)
         #remove zipped file
         os.remove(self.zippedFile)
-        print("Deletion of zip archive done!")
+        logger.info("Deletion of zip archive done!")
 
 
 @upload_api.route("/backupCase", methods=['GET'])

--- a/API/app.py
+++ b/API/app.py
@@ -140,12 +140,12 @@ if __name__ == '__main__':
     def print_startup_info(host, current_port, server_name):
         mode = 'local' if Config.HEROKU_DEPLOY == 0 else 'heroku'
         access_host = '127.0.0.1' if host == '0.0.0.0' else host
-        print("MUIOGO API starting...")
-        print(f"Server: {server_name}")
-        print(f"Mode: {mode}")
-        print(f"Host: {host}")
-        print(f"Port: {current_port}")
-        print(f"Open: http://{access_host}:{current_port}")
+        logging.info("MUIOGO API starting...")
+        logging.info(f"Server: {server_name}")
+        logging.info(f"Mode: {mode}")
+        logging.info(f"Host: {host}")
+        logging.info(f"Port: {current_port}")
+        logging.info(f"Open: http://{access_host}:{current_port}")
 
     if Config.HEROKU_DEPLOY == 0: 
         #localhost


### PR DESCRIPTION
This PR replaces the unstructured `print()` statements in the API with Python's standard `logging` module. This allows for log level filtering (INFO, DEBUG, ERROR) and structured formatting containing timestamps, severity, and module names.

Closes #316

Changes included:
- Centralized `logging.basicConfig` in `API/Classes/Base/Config.py`.
- Replaced `print()` in `app.py` server startup logs with `logging.info()`.
- Replaced `print()` in `UploadRoute.py` thread processes with a module logger.