### PR TITLE
Replace zf.extractall with safe_extractall

### DIFF
--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -16,7 +16,7 @@ def safe_extractall(zf, extract_to):
     extract_to = Path(extract_to).resolve()
     for member in zf.infolist():
         member_path = (extract_to / member.filename).resolve()
-        if not str(member_path).startswith(str(extract_to)):
+        if not str(member_path).startswith(str(extract_to) + os.sep):
             raise PermissionError(f"Invalid path in ZIP: {member.filename}")
         zf.extract(member, extract_to)
 

--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -12,6 +12,14 @@ from Classes.Base.FileClass import File
 
 upload_api = Blueprint('UploadRoute', __name__)
 
+def safe_extractall(zf, extract_to):
+    extract_to = Path(extract_to).resolve()
+    for member in zf.infolist():
+        member_path = (extract_to / member.filename).resolve()
+        if not str(member_path).startswith(str(extract_to)):
+            raise PermissionError(f"Invalid path in ZIP: {member.filename}")
+        zf.extract(member, extract_to)
+
 #File extension checking
 def allowed_filename(filename):
     return '.' in filename and filename.rsplit('.',1)[1] in Config.ALLOWED_EXTENSIONS
@@ -275,7 +283,7 @@ def uploadCaseUnchunked_old():
                                 name = data.get('osy-version', None)
 
                                 if name == '1.0' or name == '2.0':
-                                    zf.extractall(os.path.join(Config.EXTRACT_FOLDER))
+                                    safe_extractall(zf, Config.EXTRACT_FOLDER)
 
                                     #add res view folders with json default files
                                     configPath = Path(Config.DATA_STORAGE, 'Variables.json')
@@ -322,7 +330,7 @@ def uploadCaseUnchunked_old():
                                 elif name == '3.0': 
                                     #potrebno dodati tech groups
                                     #case = data.get('osy-casename', None)
-                                    zf.extractall(os.path.join(Config.EXTRACT_FOLDER))
+                                    safe_extractall(zf, Config.EXTRACT_FOLDER)
                                     genDataPath = Path(Config.DATA_STORAGE, casename, 'genData.json')
                                     genData = File.readParamFile(genDataPath)
                                     genData["osy-techGroups"] = []
@@ -341,7 +349,7 @@ def uploadCaseUnchunked_old():
                                         "casename": casename
                                     })
                                 elif name == '4.0' or name == '4.5' or name == '4.9': 
-                                    zf.extractall(os.path.join(Config.EXTRACT_FOLDER))
+                                    safe_extractall(zf, Config.EXTRACT_FOLDER)
                                     # potrebno updatevoati YearSplit u verziji 5.0 su dinamicki
                                     #update for dynamic timeslicec
                                     updateTimeslices(casename)
@@ -357,7 +365,7 @@ def uploadCaseUnchunked_old():
                                     })
 
                                 # elif name == '4.9': 
-                                #     zf.extractall(os.path.join(Config.EXTRACT_FOLDER))
+                                #     safe_extractall(zf, Config.EXTRACT_FOLDER)
                                 #     # potrebno updatevoati YearSplit u verziji 5.0 su dinamicki
                                 #     #update for dynamic timeslicec
                                 #     updateTimeslices(casename)
@@ -369,7 +377,7 @@ def uploadCaseUnchunked_old():
                                 #         })
 
                                 elif name == '5.0': 
-                                    zf.extractall(os.path.join(Config.EXTRACT_FOLDER))
+                                    safe_extractall(zf, Config.EXTRACT_FOLDER)
                                     updateViewDefintions(casename)
                                     msg.append({
                                         "message": "Model " + casename +" have been uploaded!",
@@ -453,7 +461,7 @@ def handle_full_zip(file, filepath=None):
                     #     TVOJA ORIGINALNA LOGIKA
                     # ---------------------------
                     if name == '1.0' or name == '2.0':
-                        zf.extractall(os.path.join(Config.EXTRACT_FOLDER))
+                        safe_extractall(zf, Config.EXTRACT_FOLDER)
                         configPath = Path(Config.DATA_STORAGE, 'Variables.json')
                         vars = File.readParamFile(configPath)
                         viewDef = {}
@@ -482,7 +490,7 @@ def handle_full_zip(file, filepath=None):
                             "casename": casename
                         })
                     elif name == '3.0':
-                        zf.extractall(os.path.join(Config.EXTRACT_FOLDER))
+                        safe_extractall(zf, Config.EXTRACT_FOLDER)
                         genDataPath = Path(Config.DATA_STORAGE, casename, 'genData.json')
                         genData = File.readParamFile(genDataPath)
                         genData["osy-techGroups"] = []
@@ -498,7 +506,7 @@ def handle_full_zip(file, filepath=None):
                             "casename": casename
                         })
                     elif name in ['4.0', '4.5', '4.9']:
-                        zf.extractall(os.path.join(Config.EXTRACT_FOLDER))
+                        safe_extractall(zf, Config.EXTRACT_FOLDER)
                         updateTimeslices(casename)
                         updateStorageSet(casename)
                         updateViewDefintions(casename)
@@ -509,7 +517,7 @@ def handle_full_zip(file, filepath=None):
                             "casename": casename
                         })
                     elif name == '5.0':
-                        zf.extractall(os.path.join(Config.EXTRACT_FOLDER))
+                        safe_extractall(zf, Config.EXTRACT_FOLDER)
                         updateViewDefintions(casename)
                         msg.append({
                             "message": "Model " + casename +" have been uploaded!",


### PR DESCRIPTION
## Linked issue
- Closes #321 


## Existing related work reviewed
- Issues/PRs reviewed: #94 (path traversal + extractall mention), #70 (ZIP extraction traversal)
- If none found, write: None found after search

## Overlap assessment
- Classification: Partial overlap
- Why this is not duplicate/superseded: Neither #94, #70, nor PR #213 address per-member path validation during extraction. This PR specifically fixes the extractall calls that remain unguarded after PR #213.

## Why this PR should proceed
- All 8 `zf.extractall()` calls in the active upload path (`handle_full_zip`, called by `/uploadCase`) extract without validating member paths. A ZIP with crafted member paths like `../../app.py` can overwrite local project files. This is a concrete, reproducible bug on the primary upload endpoint.

## Summary
- What changed: Added `safe_extractall()` helper that validates each ZIP member resolves within `EXTRACT_FOLDER` before extracting. Replaced all 8 unguarded `zf.extractall(os.path.join(Config.EXTRACT_FOLDER))` calls in `uploadCaseUnchunked_old` and `handle_full_zip` with `safe_extractall(zf, Config.EXTRACT_FOLDER)`.
- Why: `zf.extractall()` does not check member paths. A malicious ZIP shared by an untrusted source could write files outside `DataStorage/` and corrupt the local installation. `EXTRACT_FOLDER` resolves to `BASE_DIR` (project root), making the blast radius the entire installation directory.

## Validation
- [x] Tests added/updated (or not applicable) — not applicable, no test suite exists (tracked in #14, #227, #289)
- [x] Validation steps documented
- [ ] Evidence attached (logs/screenshots/output as relevant)

**Validation steps:**
1. Create a ZIP with a member path containing `../` (e.g. `../../test_escape.txt`)
2. Upload via the model import UI
3. Before fix: file is written outside `DataStorage/`
4. After fix: upload returns `{"error": "Invalid path in ZIP: ../../test_escape.txt"}` with HTTP 400
5. Normal valid model ZIPs (versions 1.0–5.0) upload and extract correctly

## Documentation
- [x] Docs updated in this PR (or not applicable) — not applicable
- [x] Any setup/workflow changes reflected in repo docs — not applicable

## Scope check
- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

## Exception rationale
-
