### PR TITLE
feat: migrate JS Promise chains to async/await

### DIFF
--- a/WebAPP/App/Controller/AddCase.js
+++ b/WebAPP/App/Controller/AddCase.js
@@ -12,51 +12,36 @@ import { DEF } from "../../Classes/Definition.Class.js";
 import { Sidebar } from "./Sidebar.js";
 
 export default class AddCase {
-    static onLoad() {
-        Base.getSession()
-            .then(response => {
-                let casename = response.session;
-                const promise = [];
-                let genData = Osemosys.getData(casename, 'genData.json');
-                promise.push(genData);
-                const resData = Osemosys.getResultData(casename, 'resData.json');
-                promise.push(resData);
-                const PARAMETERS = Osemosys.getParamFile();
-                promise.push(PARAMETERS);
-                return Promise.all(promise);
-            })
-            .then(data => {
-                let [genData, resData, PARAMETERS] = data;
-                let model = new Model(genData, resData, PARAMETERS, "AddCase");
-                
-                this.initPage(model);
-            })
-            .catch(error => {
-                Message.danger(error);
-            });
+    static async onLoad() {
+        try {
+            const response = await Base.getSession();
+            const casename = response.session;
+            const [genData, resData, PARAMETERS] = await Promise.all([
+                Osemosys.getData(casename, 'genData.json'),
+                Osemosys.getResultData(casename, 'resData.json'),
+                Osemosys.getParamFile(),
+            ]);
+            const model = new Model(genData, resData, PARAMETERS, "AddCase");
+            this.initPage(model);
+        } catch (error) {
+            Message.danger(error);
+        }
     }
-    static refreshPage(casename) {
-        Base.setSession(casename)
-            .then(response => {
-                Message.clearMessages();
-                const promise = [];
-                let genData = Osemosys.getData(casename, 'genData.json');
-                promise.push(genData);
-                const resData = Osemosys.getResultData(casename, 'resData.json');
-                promise.push(resData);
-                const PARAMETERS = Osemosys.getParamFile();
-                promise.push(PARAMETERS);
-                return Promise.all(promise);
-            })
-            .then(data => {
-                let [genData, resData, PARAMETERS] = data;
-                let model = new Model(genData, resData, PARAMETERS, "AddCase");
-                AddCase.initPage(model);
-            })
-            .catch(error => {
-                console.log(' error ', error)
-                Message.bigBoxDanger(error);
-            })
+    static async refreshPage(casename) {
+        try {
+            await Base.setSession(casename);
+            Message.clearMessages();
+            const [genData, resData, PARAMETERS] = await Promise.all([
+                Osemosys.getData(casename, 'genData.json'),
+                Osemosys.getResultData(casename, 'resData.json'),
+                Osemosys.getParamFile(),
+            ]);
+            const model = new Model(genData, resData, PARAMETERS, "AddCase");
+            AddCase.initPage(model);
+        } catch (error) {
+            console.log(' error ', error);
+            Message.bigBoxDanger(error);
+        }
     }
 
     static initPage(model) {
@@ -207,14 +192,14 @@ export default class AddCase {
         });
 
         $("#osy-caseForm").off('validationSuccess');
-        $("#osy-caseForm").on('validationSuccess', function (event) {
+        $("#osy-caseForm").on('validationSuccess', async function (event) {
             event.preventDefault();
             event.stopImmediatePropagation();
 
             Message.loaderStart('Saving model data')
             var casename = $("#osy-casename").val().trim();
             var desc = $("#osy-desc").val().trim();
-            
+
             const timeElapsed = Date.now();
             const today = new Date(timeElapsed);
             let date = today.toDateString();
@@ -243,16 +228,16 @@ export default class AddCase {
                 "osy-se": model.seasons,
                 "osy-dt": model.daytypes,
                 "osy-dtb": model.dailytimebrackets,
-                
+
                 "osy-emis": model.emissions,
                 "osy-scenarios": model.scenarios,
                 "osy-constraints": model.constraints,
                 "osy-years": years
             }
 
-            Osemosys.saveCase(POSTDATA)
-            .then(response => {
-                Message.loaderEnd()
+            try {
+                const response = await Osemosys.saveCase(POSTDATA);
+                Message.loaderEnd();
                 if (response.status_code == "created") {
                     $("#osy-new").show();
                     $('#osy-update').show();
@@ -263,10 +248,8 @@ export default class AddCase {
                     Sidebar.Reload(casename);
                     $("#osy-case").html(casename);
                     if (Base.AWS_SYNC == 1) {
-                        SyncS3.deleteResultsPreSync(casename)
-                            .then(response => {
-                                SyncS3.uploadSync(casename);
-                            });
+                        await SyncS3.deleteResultsPreSync(casename);
+                        SyncS3.uploadSync(casename);
                     }
                 }
                 if (response.status_code == "edited") {
@@ -276,21 +259,18 @@ export default class AddCase {
                     Sidebar.Reload(casename);
                     Message.bigBoxInfo('Model message', response.message, 3000);
                     if (Base.AWS_SYNC == 1) {
-                        SyncS3.deleteResultsPreSync(casename)
-                            .then(response => {
-                                SyncS3.uploadSync(casename);
-                            });
+                        await SyncS3.deleteResultsPreSync(casename);
+                        SyncS3.uploadSync(casename);
                     }
                 }
                 if (response.status_code == "exist") {
                     $("#osy-new").show();
                     Message.bigBoxWarning('Model message', response.message, 3000);
                 }
-            })
-            .catch(error => {
-                Message.loaderEnd()
+            } catch (error) {
+                Message.loaderEnd();
                 Message.bigBoxDanger('Error message', error, null);
-            })
+            }
         });
 
         //TECHNOLOGIES GRID AND EVENTS
@@ -968,19 +948,19 @@ export default class AddCase {
                 }
                 else{
                     let scId = model.scenarios[id]['ScenarioId'];
-                    Osemosys.deleteScenarioCaseRuns(model.casename, scId)
-                    .then(response=>{
-                        //console.log('delete ', response)
-                        var rowid = $divScenario.jqxGrid('getrowid', id);
-                        $divScenario.jqxGrid('deleterow', rowid);
-                        model.scenarios.splice(id, 1);
-                        model.scenariosCount--;
-                        $("#scenariosCount").text(model.scenariosCount);
-                        Message.smallBoxInfo(response.message)
-                    })
-                    .catch(error => {
-                        Message.bigBoxDanger(error);
-                    })
+                    (async () => {
+                        try {
+                            const response = await Osemosys.deleteScenarioCaseRuns(model.casename, scId);
+                            var rowid = $divScenario.jqxGrid('getrowid', id);
+                            $divScenario.jqxGrid('deleterow', rowid);
+                            model.scenarios.splice(id, 1);
+                            model.scenariosCount--;
+                            $("#scenariosCount").text(model.scenariosCount);
+                            Message.smallBoxInfo(response.message);
+                        } catch (error) {
+                            Message.bigBoxDanger(error);
+                        }
+                    })();
 
                 }
             }

--- a/WebAPP/App/Controller/DataFile.js
+++ b/WebAPP/App/Controller/DataFile.js
@@ -8,33 +8,26 @@ import { DefaultObj } from "../../Classes/DefaultObj.Class.js";
 import { Sidebar } from "./Sidebar.js";
 
 export default class DataFile {
-    static onLoad() {
+    static async onLoad() {
         Message.loaderStart('Loading data...');
-        Base.getSession()
-            .then(response => {
-                let casename = response.session;
-                const promise = [];
-                promise.push(casename);
-                let genData = Osemosys.getData(casename, 'genData.json');
-                promise.push(genData);
-                const resData = Osemosys.getResultData(casename, 'resData.json');
-                promise.push(resData);
-                return Promise.all(promise);
-            })
-            .then(data => {
-                let [casename, genData, resData] = data;
-                let model = new Model(casename, genData, resData, "DataFile");
-                if (casename) {
-                    this.initPage(model);
-                } else {
-                    Message.loaderEnd();
-                    MessageSelect.init(DataFile.refreshPage.bind(DataFile));
-                }
-            })
-            .catch(error => {
+        try {
+            const response = await Base.getSession();
+            const casename = response.session;
+            const [genData, resData] = await Promise.all([
+                Osemosys.getData(casename, 'genData.json'),
+                Osemosys.getResultData(casename, 'resData.json'),
+            ]);
+            const model = new Model(casename, genData, resData, "DataFile");
+            if (casename) {
+                this.initPage(model);
+            } else {
                 Message.loaderEnd();
-                Message.danger(error);
-            });
+                MessageSelect.init(DataFile.refreshPage.bind(DataFile));
+            }
+        } catch (error) {
+            Message.loaderEnd();
+            Message.danger(error);
+        }
     }
 
     static initPage(model) {
@@ -58,40 +51,31 @@ export default class DataFile {
         this.initEvents(model);
     }
 
-    static refreshPage(casename) {
+    static async refreshPage(casename) {
         Message.loaderStart('Loading data...');
-        Base.setSession(casename)
-            .then(response => {
-                Message.clearMessages();
-                const promise = [];
-                promise.push(casename);
-                let genData = Osemosys.getData(casename, 'genData.json');
-                promise.push(genData);
-                const resData = Osemosys.getResultData(casename, 'resData.json');
-                promise.push(resData);
-                return Promise.all(promise);
-            })
-            .then(data => {
-                let [casename, genData, resData] = data;
-                let model = new Model(casename, genData, resData, "DataFile");
-                $(".DataFile").hide();
-                $("#osy-DataFile").empty();
-                $("#osy-runOutput").empty();
-                $("#osy-lpOutput").empty();
-                // $("#osy-downloadDataFile").hide();
-                // $("#osy-downloadResultsFile").hide();
-                $("#osy-solver").hide();
-                $("#osy-run").hide();
-                $(".runOutput").hide();
-                $(".lpOutput").hide();
-                $(".Results").hide();
-                DataFile.initPage(model);
-                DataFile.initEvents(model);
-            })
-            .catch(error => {
-                Message.loaderEnd();
-                Message.bigBoxInfo(error);
-            })
+        try {
+            await Base.setSession(casename);
+            Message.clearMessages();
+            const [genData, resData] = await Promise.all([
+                Osemosys.getData(casename, 'genData.json'),
+                Osemosys.getResultData(casename, 'resData.json'),
+            ]);
+            const model = new Model(casename, genData, resData, "DataFile");
+            $(".DataFile").hide();
+            $("#osy-DataFile").empty();
+            $("#osy-runOutput").empty();
+            $("#osy-lpOutput").empty();
+            $("#osy-solver").hide();
+            $("#osy-run").hide();
+            $(".runOutput").hide();
+            $(".lpOutput").hide();
+            $(".Results").hide();
+            DataFile.initPage(model);
+            DataFile.initEvents(model);
+        } catch (error) {
+            Message.loaderEnd();
+            Message.bigBoxInfo(error);
+        }
     }
 
     static initEvents(model) {
@@ -254,7 +238,7 @@ export default class DataFile {
         });
 
         $("#osy-caseRun").off('validationSuccess');
-        $("#osy-caseRun").on('validationSuccess', function (event) {
+        $("#osy-caseRun").on('validationSuccess', async function (event) {
             event.preventDefault();
             event.stopImmediatePropagation();
             Pace.restart();
@@ -297,9 +281,9 @@ export default class DataFile {
                 "Scenarios": scOrder
             }
 
-            if (update) {
-                Osemosys.updateCaseRun(model.casename, caserunname, oldcaserunname, caseData)
-                .then(response => {
+            try {
+                if (update) {
+                    const response = await Osemosys.updateCaseRun(model.casename, caserunname, oldcaserunname, caseData);
                     Message.clearMessages();
                     if (response.status_code == 'success') {
                         model.cs = caserunname;
@@ -328,13 +312,8 @@ export default class DataFile {
                     if (response.status_code == 'exist') {
                         Message.smallBoxWarning('Generate message', response.message, 3000);
                     }
-                })
-                .catch(error => {
-                    Message.bigBoxDanger('Error message', error, null);
-                })
-            } else {
-                Osemosys.createCaseRun(model.casename, caserunname, caseData)
-                .then(response => {
+                } else {
+                    const response = await Osemosys.createCaseRun(model.casename, caserunname, caseData);
                     Message.clearMessages();
                     if (response.status_code == 'success') {
                         $("#osy-runCaseDiv").show();
@@ -357,72 +336,51 @@ export default class DataFile {
                     if (response.status_code == 'exist') {
                         Message.smallBoxWarning('Generate message', response.message, 3000);
                     }
-                })
-                .catch(error => {
-                    Message.bigBoxDanger('Error message', error, null);
-                })
+                }
+            } catch (error) {
+                Message.bigBoxDanger('Error message', error, null);
             }
-
         });
 
         $("#osy-generateDataFile").off('click');
-        $("#osy-generateDataFile").on('click', function (event) {
+        $("#osy-generateDataFile").on('click', async function (event) {
             Pace.restart();
-            Message.loaderStart('Generating data file!')
-            Osemosys.generateDataFile(model.casename, model.cs)
-            .then(response => {
-                if (response.status_code == "success") {
-                    const promise = [];
-                    let DataFile = Osemosys.readDataFile(model.casename, model.cs);
-                    promise.push(DataFile);
-                    promise.push(response.message);
-                    return Promise.all(promise);
+            Message.loaderStart('Generating data file!');
+            try {
+                const genResponse = await Osemosys.generateDataFile(model.casename, model.cs);
+                if (genResponse.status_code == "success") {
+                    const DataFile = await Osemosys.readDataFile(model.casename, model.cs);
+                    const message = genResponse.message;
+                    $(".DataFile").show();
+                    $("#osy-runOutput").empty();
+                    $("#osy-lpOutput").empty();
+                    $(".runOutput").hide();
+                    $(".lpOutput").hide();
+                    $(".Results").hide();
+                    $(".batchOutput").hide();
+                    Html.renderDataFile(DataFile, model);
+                    if (Base.HEROKU == 0) {
+                        $("#osy-run").show();
+                    }
+                    Message.loaderEnd();
+                    Message.smallBoxInfo('Generate message', message, 3000);
                 }
-            })
-            .then(response => {
-                let [DataFile, message] = response;
-                $(".DataFile").show();
-                $("#osy-runOutput").empty();
-                $("#osy-lpOutput").empty();
-                $(".runOutput").hide();
-                $(".lpOutput").hide();
-                $(".Results").hide();
-                $(".batchOutput").hide();
-                Html.renderDataFile(DataFile, model)
-                ///////////////////////////////////////////////////////////////////
-                //$("#osy-downloadDataFile").show();
-                //ne moramo updateovati S3 sa data file
-                // if (Base.AWS_SYNC == 1){
-                //     Base.updateSync(model.casename, "data.txt");
-                // }
-                if (Base.HEROKU == 0) {
-                    $("#osy-run").show();
-                    //$("#osy-solver").show();
-                }
-                //Message.clearMessages();
-                //Message.bigBoxSuccess('Generate message', message, 3000);
-                Message.loaderEnd();
-                Message.smallBoxInfo('Generate message', message, 3000);
-            })
-            .catch(error => {
+            } catch (error) {
                 Message.loaderEnd();
                 Message.bigBoxDanger('Error message', error, null);
-            })
+            }
         });
 
 
         $("#osy-run").off('click');
-        $("#osy-run").on('click', function (event) {
+        $("#osy-run").on('click', async function (event) {
             Pace.restart();
-            Message.loaderStart('Optimization in process!')
-            //promijenjeno da radimo samo sa cBCsolverom
-            //let solver = $('input[name="solver"]:checked').val();
+            Message.loaderStart('Optimization in process!');
             let solver = 'cbc';
-            Osemosys.run(model.casename, solver, model.cs)
-            .then(response => {
+            try {
+                const response = await Osemosys.run(model.casename, solver, model.cs);
                 Message.clearMessages();
-                //console.log('response ',response)
-                if (response.status_code == "success") {
+                if (response.status_code == "success" || response.status_code == "warning") {
                     Message.loaderEnd();
                     $(".runOutput").show();
                     $(".lpOutput").show();
@@ -430,36 +388,19 @@ export default class DataFile {
                     $(".batchOutput").hide();
                     $("#osy-batchOutput").empty();
                     $("#osy-runOutput").empty();
-                    $("#osy-runOutput").html('<pre class="log-output">' + response.cbc_message, response.cbc_stdmsg+ '</pre>');
+                    $("#osy-runOutput").html('<pre class="log-output">' + response.cbc_message, response.cbc_stdmsg + '</pre>');
                     $("#osy-lpOutput").empty();
-                    $("#osy-lpOutput").html('<pre class="log-output">' + response.glpk_message, response.glpk_stdmsg+ '</pre>');
-                    Base.getResultCSV(model.casename, model.cs)
-                        .then(csvs => {
-                            Html.renderCSV(csvs, model.cs)
-                        });
+                    $("#osy-lpOutput").html('<pre class="log-output">' + response.glpk_message, response.glpk_stdmsg + '</pre>');
+                    const csvs = await Base.getResultCSV(model.casename, model.cs);
+                    Html.renderCSV(csvs, model.cs);
                     Sidebar.Reload(model.casename);
                     Message.clearMessages();
-                    Message.successOsy( response.timer);
-                    Message.bigBoxSuccess('Run message', response.timer, 3000);
-                }
-                if (response.status_code == "warning") {
-                    Message.loaderEnd();
-                    $(".runOutput").show();
-                    $(".lpOutput").show();
-                    $(".Results").show();
-                    $(".batchOutput").hide();
-                    $("#osy-batchOutput").empty();
-                    $("#osy-runOutput").empty();
-                    $("#osy-runOutput").html('<pre class="log-output">' + response.cbc_message, response.cbc_stdmsg+ '</pre>');
-                    $("#osy-lpOutput").empty();
-                    $("#osy-lpOutput").html('<pre class="log-output">' + response.glpk_message, response.glpk_stdmsg+ '</pre>');
-                    Base.getResultCSV(model.casename, model.cs)
-                        .then(csvs => {
-                            Html.renderCSV(csvs, model.cs)
-                        });
-                    Sidebar.Reload(model.casename);
-                    Message.clearMessages();
-                    Message.warningOsy( response.timer );
+                    if (response.status_code == "success") {
+                        Message.successOsy(response.timer);
+                        Message.bigBoxSuccess('Run message', response.timer, 3000);
+                    } else {
+                        Message.warningOsy(response.timer);
+                    }
                 }
                 if (response.status_code == "error") {
                     Message.loaderEnd();
@@ -469,40 +410,29 @@ export default class DataFile {
                     $(".batchOutput").hide();
                     $("#osy-batchOutput").empty();
                     $("#osy-runOutput").empty();
-                    $("#osy-runOutput").html('<pre class="log-output">' + response.cbc_message, response.cbc_stdmsg+ '</pre>');
+                    $("#osy-runOutput").html('<pre class="log-output">' + response.cbc_message, response.cbc_stdmsg + '</pre>');
                     $("#osy-lpOutput").empty();
-                    $("#osy-lpOutput").html('<pre class="log-output">' + response.glpk_message, response.glpk_stdmsg+ '</pre>');
+                    $("#osy-lpOutput").html('<pre class="log-output">' + response.glpk_message, response.glpk_stdmsg + '</pre>');
                     Message.clearMessages();
-                    // let errormsg = '';
-                    // if (response.glpk_message != "" || response.glpk_stdmsg != "") {
-                    //     errormsg += 'Error occured during creation of LP file, GLPK run! See LP file (GLPK) log for more details. '
-                    // }
-                    // if (response.cbc_message != "" || response.cbc_stdmsg != "") {
-                    //     errormsg += 'Error occured during optimization process, CBC run! See CBC solver log for more details.'
-                    // }
-
-                    // Message.dangerOsy(errormsg);
-                    Message.dangerOsy( response.timer );
+                    Message.dangerOsy(response.timer);
                 }
-            })
-            .catch(error => {
-                console.log('error ',error)
+            } catch (error) {
+                console.log('error ', error);
                 Message.loaderEnd();
                 Message.bigBoxDanger('Error message', error, null);
-            })
+            }
         });
 
         //$("#osy-Cases").off('click');
-        $("#osy-Cases").on('click', '.selectCS', function (e) {
-            //$(document).delegate(".selectCS","click",function(e){
+        $("#osy-Cases").on('click', '.selectCS', async function (e) {
             e.preventDefault();
             e.stopImmediatePropagation();
-            Html.renderScOrder( model.scBycs[model.cs]);
+            Html.renderScOrder(model.scBycs[model.cs]);
             Message.clearMessages();
-            console.log('select, ', model)
+            console.log('select, ', model);
             var caserunanme = $(this).attr('data-ps');
             model.cs = caserunanme;
-            Html.renderScOrder( model.scBycs[model.cs]);
+            Html.renderScOrder(model.scBycs[model.cs]);
 
             Html.resData(model);
             Html.title(model.casename, model.title, caserunanme);
@@ -522,75 +452,60 @@ export default class DataFile {
             $("#osy-batchRun").hide();
             $('.checkbox').prop('checked', false);
 
-            Osemosys.readDataFile(model.casename, model.cs)
-            .then(response => {
-                let DataFile = response;
-                const promise = [];
-                promise.push(DataFile);
-                let ResultCSV = Base.getResultCSV(model.casename, model.cs)
-                promise.push(ResultCSV);
-                return Promise.all(promise);
-            })
-            .then(data => {
-                let [DataFile, ResultCSV] = data;
-                console.log('data ', data)
+            try {
+                const [DataFile, ResultCSV] = await Promise.all([
+                    Osemosys.readDataFile(model.casename, model.cs),
+                    Base.getResultCSV(model.casename, model.cs),
+                ]);
+                console.log('data ', [DataFile, ResultCSV]);
                 if (ResultCSV.length != 0) {
                     $(".Results").show();
-                    Html.renderCSV(ResultCSV, model.cs)
+                    Html.renderCSV(ResultCSV, model.cs);
                 }
                 if (DataFile) {
                     $(".DataFile").show();
                     $("#osy-runCaseDiv").show();
                     $("#osy-caseRunName").text(model.cs);
                     $("#osy-generateDataFile").show();
-
                     Html.renderDataFile(DataFile, model);
-                }
-                else if(!DataFile && ResultCSV.length == 0){
+                } else if (!DataFile && ResultCSV.length == 0) {
                     $(".DataFile").hide();
                     $(".Results").hide();
-                    //$("#osy-generateDataFile").hide();
-
                     $("#osy-runCaseDiv").show();
                     $("#osy-caseRunName").text(model.cs);
                     $("#osy-generateDataFile").show();
                     Message.smallBoxWarning("Run case message", "Please generate data file!", 3000);
                 }
-            })
-            .catch(error => {
+            } catch (error) {
                 Message.danger(error);
-            });
+            }
             Message.smallBoxInfo("Case selection", caserunanme + " is selected!", 3000);
         });
 
 
         //$("#osy-Cases").off('click');
-        $("#osy-Cases").on('click', '.validateInputs', function (e) {
+        $("#osy-Cases").on('click', '.validateInputs', async function (e) {
             e.preventDefault();
             e.stopImmediatePropagation();
             Message.clearMessages();
             var caserunanme = $(this).attr('data-ps');
-            //console.log('caserunanme ', caserunanme)
-            Osemosys.validateInputs(model.casename, caserunanme)
-            .then(response => {
-                //console.log('response ', response)
+            try {
+                const response = await Osemosys.validateInputs(model.casename, caserunanme);
                 if (response.status_code == "success") {
                     $('#osy-validation').modal('toggle');
-                    $("#valCasrunname").text(caserunanme)
-                    $("#valOutput").html('<pre class="log-output">' + response.msg+ '</pre>')
+                    $("#valCasrunname").text(caserunanme);
+                    $("#valOutput").html('<pre class="log-output">' + response.msg + '</pre>');
                 }
                 if (response.status_code == "warning") {
                     $('#osy-validation').modal('toggle');
-                    $("#valOutput").html('<pre class="log-output">' + response.msg+ '</pre>');
+                    $("#valOutput").html('<pre class="log-output">' + response.msg + '</pre>');
                 }
                 if (response.status_code == "error") {
-                    //Message.warningOsy(response.msg);
-                    Message.smallBoxWarning('Data file warning', response.msg, 8000)
+                    Message.smallBoxWarning('Data file warning', response.msg, 8000);
                 }
-            })
-            .catch(error => {
+            } catch (error) {
                 Message.danger(error);
-            });
+            }
         });
 
         //$(document).delegate(".deleteCase", "click", function (e) {
@@ -605,85 +520,58 @@ export default class DataFile {
                 title: "Confirmation Box!",
                 content: "You are about to delete <b class='danger'>" + caserunname + "</b> case run! Are you sure?",
                 buttons: '[No][Yes]'
-            }, function (ButtonPressed) {
+            }, async function (ButtonPressed) {
                 if (ButtonPressed === "Yes") {
                     Message.loaderStart('Deleteing case data...');
-                    Base.deleteCaseRun(model.casename, caserunname, false)
-                        .then(response => {
-                            Message.clearMessages();
-                            Message.loaderEnd();
-                            if (response.status_code == "success") {
-                                Message.bigBoxSuccess('Delete message', response.message, 3000);
-                                //REFRESH
-                                Html.removeCase(caserunname);
-                                //remove case from model
-                                model.cases = model.cases.filter(function(el) { return el.Case != caserunname; });
-                                delete model.scBycs[caserunname];
-
-                                //relod sidebar
-                                Sidebar.Reload(model.casename);
-
-                                if (model.cs == caserunname || model.cs == ''){
-                                    Html.title(model.casename, model.title, '');
-                                    model.cs = null;
-                                    $("#osy-casename").val(null);
-                                    $("#osy-desc").val(null);
-                                    $("#osy-createCaseRun").show();
-                                    $("#osy-updateCaseRun").hide();
-                                    $("#osy-newCaseRun").hide();
-
-                                    $("#osy-generateDataFile").hide();
-                                    $("#osy-runCaseDiv").hide();
-                                    $("#osy-solver").hide();
-                                    $("#osy-run").hide();
-
-                                    $(".runOutput").hide();
-                                    $(".lpOutput").hide();
-                                    $(".DataFile").hide();
-                                    $(".Results").hide();
-
-                                    $(".batchOutput").hide();
-                                    $("#osy-batchRun").hide();
-                                    $('.checkbox').prop('checked', false);
-                                }
-                                //remove case from view json files
-                                //sync with s3
-                                if (Base.AWS_SYNC == 1) {
-                                    SyncS3.deleteSync(caserunname);
-                                }
+                    try {
+                        const response = await Base.deleteCaseRun(model.casename, caserunname, false);
+                        Message.clearMessages();
+                        Message.loaderEnd();
+                        if (response.status_code == "success") {
+                            Message.bigBoxSuccess('Delete message', response.message, 3000);
+                            Html.removeCase(caserunname);
+                            model.cases = model.cases.filter(function(el) { return el.Case != caserunname; });
+                            delete model.scBycs[caserunname];
+                            Sidebar.Reload(model.casename);
+                            if (model.cs == caserunname || model.cs == '') {
+                                Html.title(model.casename, model.title, '');
+                                model.cs = null;
+                                $("#osy-casename").val(null);
+                                $("#osy-desc").val(null);
+                                $("#osy-createCaseRun").show();
+                                $("#osy-updateCaseRun").hide();
+                                $("#osy-newCaseRun").hide();
+                                $("#osy-generateDataFile").hide();
+                                $("#osy-runCaseDiv").hide();
+                                $("#osy-solver").hide();
+                                $("#osy-run").hide();
+                                $(".runOutput").hide();
+                                $(".lpOutput").hide();
+                                $(".DataFile").hide();
+                                $(".Results").hide();
+                                $(".batchOutput").hide();
+                                $("#osy-batchRun").hide();
+                                $('.checkbox').prop('checked', false);
                             }
-                            // if(response.status_code=="success_session"){
-                            //     Message.bigBoxSuccess('Delete message', response.message, 3000);
-                            //     Message.info( "Please select existing or create new case to proceed!");
-                            //     if (model.casename = casename){
-                            //         // Sidebar.Load(null, null);
-                            //         Sidebar.Reload(null);
-                            //         //Routes.removeRoutes(model.PARAMETERS);
-                            //     }
-                            //     //REFRESH
-                            //     Html.removeCase(casename);
-                            //     if (Base.AWS_SYNC == 1){
-                            //         Base.deleteSync(casename);
-                            //     }
-                            // }
-                            if (response.status_code == "info") {
-                                Message.info(response.message);
+                            if (Base.AWS_SYNC == 1) {
+                                SyncS3.deleteSync(caserunname);
                             }
-                            if (response.status_code == "warning") {
-                                Message.warning(response.message);
-                            }
-
-                        })
-                        .catch(error => {
-                            console.log(error)
-                            Message.danger(error);
-                        });
+                        }
+                        if (response.status_code == "info") {
+                            Message.info(response.message);
+                        }
+                        if (response.status_code == "warning") {
+                            Message.warning(response.message);
+                        }
+                    } catch (error) {
+                        console.log(error);
+                        Message.danger(error);
+                    }
                 }
                 if (ButtonPressed === "No") {
-                    Message.bigBoxInfo("Confirmation message", "You pressed No...", 3000)
+                    Message.bigBoxInfo("Confirmation message", "You pressed No...", 3000);
                 }
             });
-            //e.preventDefault();
             e.stopImmediatePropagation();
         });
 
@@ -695,72 +583,46 @@ export default class DataFile {
                 title: "Confirmation Box!",
                 content: "You are about to delete <b class='danger'>" + caserunname + "</b> case run results! Are you sure?",
                 buttons: '[No][Yes]'
-            }, function (ButtonPressed) {
+            }, async function (ButtonPressed) {
                 if (ButtonPressed === "Yes") {
                     Message.loaderStart('Deleteing case results...');
-                    Base.deleteCaseRun(model.casename, caserunname, true)
-                        .then(response => {
-                            Message.clearMessages();
-                            Message.loaderEnd();
-                            if (response.status_code == "success") {
-                                Message.bigBoxSuccess('Delete message', response.message, 3000);
-                                //REFRESH
-                                //Html.removeCase(caserunname);
-                                //remove case from model
-                                //model.cases = model.cases.filter(function(el) { return el.Case != caserunname; });
-                                //delete model.scBycs[caserunname];
-
-                                //relod sidebar
-                                Sidebar.Reload(model.casename);
-
-                                if (model.cs == caserunname || model.cs == ''){
-                                    Html.title(model.casename, model.title, '');
-                                    model.cs = null;
-                                    // $("#osy-casename").val(null);
-                                    // $("#osy-desc").val(null);
-                                    // $("#osy-createCaseRun").show();
-                                    // $("#osy-updateCaseRun").hide();
-                                    // $("#osy-newCaseRun").hide();
-
-                                    // $("#osy-generateDataFile").hide();
-                                    // $("#osy-runCaseDiv").hide();
-                                    // $("#osy-solver").hide();
-                                    // $("#osy-run").hide();
-
-                                    $(".runOutput").hide();
-                                    $(".lpOutput").hide();
-                                    $(".DataFile").hide();
-                                    $(".Results").hide();
-
-                                    $(".batchOutput").hide();
-                                    $("#osy-batchRun").hide();
-                                    $('.checkbox').prop('checked', false);
-                                }
-                                //remove case from view json files
-                                //sync with s3
-                                if (Base.AWS_SYNC == 1) {
-                                    SyncS3.deleteSync(caserunname);
-                                }
+                    try {
+                        const response = await Base.deleteCaseRun(model.casename, caserunname, true);
+                        Message.clearMessages();
+                        Message.loaderEnd();
+                        if (response.status_code == "success") {
+                            Message.bigBoxSuccess('Delete message', response.message, 3000);
+                            Sidebar.Reload(model.casename);
+                            if (model.cs == caserunname || model.cs == '') {
+                                Html.title(model.casename, model.title, '');
+                                model.cs = null;
+                                $(".runOutput").hide();
+                                $(".lpOutput").hide();
+                                $(".DataFile").hide();
+                                $(".Results").hide();
+                                $(".batchOutput").hide();
+                                $("#osy-batchRun").hide();
+                                $('.checkbox').prop('checked', false);
                             }
-
-                            if (response.status_code == "info") {
-                                Message.info(response.message);
+                            if (Base.AWS_SYNC == 1) {
+                                SyncS3.deleteSync(caserunname);
                             }
-                            if (response.status_code == "warning") {
-                                Message.warning(response.message);
-                            }
-
-                        })
-                        .catch(error => {
-                            console.log(error)
-                            Message.danger(error);
-                        });
+                        }
+                        if (response.status_code == "info") {
+                            Message.info(response.message);
+                        }
+                        if (response.status_code == "warning") {
+                            Message.warning(response.message);
+                        }
+                    } catch (error) {
+                        console.log(error);
+                        Message.danger(error);
+                    }
                 }
                 if (ButtonPressed === "No") {
-                    Message.bigBoxInfo("Confirmation message", "You pressed No...", 3000)
+                    Message.bigBoxInfo("Confirmation message", "You pressed No...", 3000);
                 }
             });
-            //e.preventDefault();
             e.stopImmediatePropagation();
         });
 
@@ -786,88 +648,63 @@ export default class DataFile {
           });
 
         $("#osy-batchRun").off('click');
-        $("#osy-batchRun").on('click', function (event) {
-            //console.log('BATCH RUN')
+        $("#osy-batchRun").on('click', async function (event) {
             Pace.restart();
             Message.loaderStart('BATCH RUN! Plese wait...');
 
             let batchRunCases = [];
-            $("input:checkbox[name=type]:checked").each(function(){
+            $("input:checkbox[name=type]:checked").each(function() {
                 batchRunCases.push($(this).val());
             });
 
-            Osemosys.batchRun(model.casename, batchRunCases)
-            //Osemosys.generateDataFile(model.casename, batchRunCases[0])
-            .then(response => {
+            try {
+                const response = await Osemosys.batchRun(model.casename, batchRunCases);
                 Message.loaderEnd();
-                //Message.smallBoxInfo('Generate message', response.message, 3000);
-                // console.log('response ', response.log);
-                // Message.bigBoxDefault("BATCH RUN!", response.log)
                 $(".runOutput").hide();
                 $(".lpOutput").hide();
                 $(".Results").hide();
                 $("#osy-runOutput").empty();
                 $("#osy-lpOutput").empty();
-
                 Sidebar.Reload(model.casename);
                 Message.clearMessages();
-
-                if(response.status == 'Success'){
+                if (response.status == 'Success') {
                     Message.successOsy('<pre>' + response.msg + '</pre>');
-                    //Message.successOsy('<pre>Run finished in ' + response.time + ' \n' + response.msg + '</pre>');
-                }
-                else{
+                } else {
                     Message.dangerOsy('<pre>' + response.msg + '</pre>');
                 }
-
-
                 $(".batchOutput").show();
                 $("#osy-batchOutput").empty();
-                $("#osy-batchOutput").html('<pre class="log-output">' + response.log+ '</pre>');
-
-            })
-            .catch(error => {
-                Message.bigBoxDanger(error)
-            })
-
+                $("#osy-batchOutput").html('<pre class="log-output">' + response.log + '</pre>');
+            } catch (error) {
+                Message.bigBoxDanger(error);
+            }
         });
 
         $("#osy-cleanUp").off('click');
-        $("#osy-cleanUp").on('click', function (event) {
-            //console.log('BATCH RUN')
+        $("#osy-cleanUp").on('click', async function () {
             Pace.restart();
             Message.loaderStart('Recycle all results! Plese wait...');
 
-            Osemosys.cleanUp(model.casename)
-            .then(response => {
+            try {
+                const response = await Osemosys.cleanUp(model.casename);
                 Message.loaderEnd();
-                //Message.smallBoxInfo('Generate message', response.message, 3000);
-                // console.log('response ', response.log);
-                // Message.bigBoxDefault("BATCH RUN!", response.log)
                 $(".runOutput").hide();
                 $(".lpOutput").hide();
                 $(".Results").hide();
                 $("#osy-runOutput").empty();
                 $("#osy-lpOutput").empty();
 
-                console.log('response clean up ', response) 
-
                 Sidebar.Reload(model.casename);
                 Message.clearMessages();
 
-                if(response.status_code == 'success'){
+                if (response.status_code == 'success') {
                     Message.bigBoxSuccess('Delete message', response.message, 3000);
-                    //Message.successOsy('<pre>' + response.message + '</pre>');
-                    //Message.successOsy('<pre>Run finished in ' + response.time + ' \n' + response.msg + '</pre>');
-                }
-                else{
+                } else {
                     Message.dangerOsy('<pre>' + response.message + '</pre>');
                 }
-            })
-            .catch(error => {
-                Message.bigBoxDanger(error)
-            })
-
+            } catch (error) {
+                Message.bigBoxDanger(error);
+            }
         });
 
         Message.loaderEnd();

--- a/WebAPP/App/Controller/Home.js
+++ b/WebAPP/App/Controller/Home.js
@@ -10,35 +10,28 @@ import { Osemosys } from "../../Classes/Osemosys.Class.js";
 import { Routes } from "../../Routes/Routes.Class.js";
 
 export default class Home {
-    static async onLoad(){
-        if (Base.AWS_SYNC == 1 && Base.INIT_SYNC){
-            $('#loadermain h4').text('Syncronizing with S3 Bucket!'); 
+    static async onLoad() {
+        if (Base.AWS_SYNC == 1 && Base.INIT_SYNC) {
+            $('#loadermain h4').text('Syncronizing with S3 Bucket!');
             $('#loadermain').show();
-            await Base.initSyncS3()
-            .then(response => {
-                Message.smallBoxInfo('Sync message', response.message, 3000);
+            try {
+                const syncResponse = await Base.initSyncS3();
+                Message.smallBoxInfo('Sync message', syncResponse.message, 3000);
                 Base.INIT_SYNC = 0;
-            })
+            } catch (syncError) {
+                Message.danger(syncError);
+            }
         }
-        Base.getSession()
-        .then(response =>{
-            let casename = response.session;
-            const promise = [];
-            promise.push(casename);
-
-            let cases = Base.getCaseStudies();
-            promise.push(cases);
+        try {
+            const response = await Base.getSession();
+            const casename = response.session;
             $('#loadermain').hide();
-            return Promise.all(promise);
-        })
-        .then(data => {
-            let [ casename, cases] = data;
-            let model = new Model(casename, cases);
+            const cases = await Base.getCaseStudies();
+            const model = new Model(casename, cases);
             this.initPage(model);
-        })
-        .catch(error =>{ 
+        } catch (error) {
             Message.danger(error);
-        });
+        }
     }
 
     static initPage(model){
@@ -51,23 +44,15 @@ export default class Home {
         loadScript("References/smartadmin/js/plugin/dropzone/dropzone5.min.js", Base.uploadFunction);
     }
 
-    static refreshPage(casename){
-        Base.setSession(casename)
-        .then(response =>{
-            const promise = [];
-            promise.push(casename);
-            let cases = Base.getCaseStudies();
-            promise.push(cases);
-            return Promise.all(promise);
-        })
-        .then(data => {
-            let [ casename, cases ] = data;
-            let model = new Model(casename, cases);
+    static async refreshPage(casename) {
+        try {
+            await Base.setSession(casename);
+            const cases = await Base.getCaseStudies();
+            const model = new Model(casename, cases);
             this.initPage(model);
-        })
-        .catch(error =>{ 
+        } catch (error) {
             Message.danger(error);
-        });
+        }
     }
 
     static initEvents(model){
@@ -75,49 +60,44 @@ export default class Home {
         $("#cases").tooltip({ selector: '[data-toggle=tooltip]' });
 
         $("#casePicker, #cases").off('click', '.selectCS');
-        $("#casePicker, #cases").on('click.homeSelect', '.selectCS', function(e) {
+        $("#casePicker, #cases").on('click.homeSelect', '.selectCS', async function(e) {
             //console.log('model ', model)
-        //$(document).delegate(".selectCS","click",function(e){
             e.preventDefault();
             e.stopImmediatePropagation();
             var casename = $(this).attr('data-ps');
-            //Html.updateCasePicker(casename);
-            //Sidebar.Load(casename, model.genData, model.PARAMETERS);
-            Osemosys.getData(casename, 'genData.json')
-            .then(genData => {
-                //console.log('genData ', genData["osy-version"])
+            try {
+                const genData = await Osemosys.getData(casename, 'genData.json');
                 Home.refreshPage(casename);
                 Message.smallBoxInfo("Case selection", casename + " is selected!", 3000);
-                if(parseFloat(genData["osy-version"]) < 4.5){
-                    //console.log('manje od 4.5')
+                if (parseFloat(genData["osy-version"]) < 4.5) {
                     Message.bigBoxWarning("Warning", "You have selected a model created in a earlier version of this UI. In order to update to the current version click <b>Update model</b> on the configuration page.", 10000);
                 }
-            })
+            } catch (error) {
+                Message.danger(error);
+            }
         });
 
         $("#cases").off('click.homeEdit', '.editPS');
-        $("#cases").on('click.homeEdit', '.editPS', function(e) {
+        $("#cases").on('click.homeEdit', '.editPS', async function(e) {
             e.preventDefault();
             e.stopImmediatePropagation();
             var casename = $(this).attr('data-ps');
             Html.updateCasePicker(casename);
-
-            Base.setSession(casename)
-            .then(response=>{
+            try {
+                await Base.setSession(casename);
                 $('#Navi>li').removeClass('active');
                 $('#Navi').children('li').eq(2).addClass('active');
                 hasher.setHash("#");
                 hasher.setHash("#AddCase");
-            })
-            .catch(error=>{
+            } catch (error) {
                 Message.danger(error);
-            })
+            }
         });
 
         //copy case
         $(document).off('click', '.copyCS');
         $("#cases").off('click', '.copyCS');
-        $("#cases").on('click.homeCopy', '.copyCS', function(e){
+        $("#cases").on('click.homeCopy', '.copyCS', async function(e) {
             e.stopImmediatePropagation();
             var casename = $(this).attr('data-ps');
             if (casename !== model.casename) {
@@ -125,41 +105,37 @@ export default class Home {
                     'Select <b>' + casename + '</b> first to copy it.', 4000);
                 return;
             }
-            Base.copyCaseStudy(casename)
-            .then(response => {
+            try {
+                const response = await Base.copyCaseStudy(casename);
                 Message.clearMessages();
-                if(response.status_code=="success"){
+                if (response.status_code == "success") {
                     Message.bigBoxSuccess('Copy message', response.message, 3000);
-                    //REFRESH
-                    Html.apendModel(casename+'_copy');
-                    Html.appendCasePicker(casename+'_copy', null)
-                    if (Base.AWS_SYNC == 1){
-                        SyncS3.deleteResultsPreSync(casename)
-                        .then(response =>{
-                            SyncS3.uploadSync(casename+'_copy');
-                        });  
+                    Html.apendModel(casename + '_copy');
+                    Html.appendCasePicker(casename + '_copy', null);
+                    if (Base.AWS_SYNC == 1) {
+                        await SyncS3.deleteResultsPreSync(casename);
+                        SyncS3.uploadSync(casename + '_copy');
                     }
                 }
-                if(response.status_code=="warning"){
+                if (response.status_code == "warning") {
                     Message.bigBoxWarning('Copy message', response.message, 3000);
                 }
-
-            })
-            .catch(error =>{ 
+            } catch (error) {
                 Message.danger(error);
-            });
+            }
         });
 
         //get descrition
         $("#cases").off('click.homeDescription', '.descriptionPS');
-        $("#cases").on('click.homeDescription', '.descriptionPS', function(e){
-            //e.stopImmediatePropagation();
+        $("#cases").on('click.homeDescription', '.descriptionPS', async function(e) {
             var titleps = $(this).attr('data-ps');
-            Base.getCaseDesc(titleps)
-            .then(response => {
+            try {
+                const response = await Base.getCaseDesc(titleps);
                 Message.clearMessages();
                 $('#mdescriptionps').html(response.desc);
-            })
+            } catch (error) {
+                Message.danger(error);
+            }
             $('#mtitleps_desc').html('<i class="ace-icon fa fa-info-circle"></i>  ' + titleps);
         });
 
@@ -178,35 +154,32 @@ export default class Home {
                 title : "Confirmation Box!",
                 content : "You are about to delete <b class='danger'>" + casename + "</b> Model! Are you sure?",
                 buttons : '[No][Yes]'
-            }, function(ButtonPressed) {
+            }, async function(ButtonPressed) {
                 if (ButtonPressed === "Yes") {
-                    Base.deleteCaseStudy(casename)
-                    .then(response => {
+                    try {
+                        const response = await Base.deleteCaseStudy(casename);
                         Message.clearMessages();
-                        if(response.status_code=="success_session"){
+                        if (response.status_code == "success_session") {
                             Message.bigBoxSuccess('Delete message', response.message, 3000);
-                            Message.info( "Please select existing or create new case to proceed!");
+                            Message.info("Please select existing or create new case to proceed!");
                             Sidebar.Reload(null);
-                            //REFRESH
                             Html.removeCase(casename);
-                            if (Base.AWS_SYNC == 1){
+                            if (Base.AWS_SYNC == 1) {
                                 SyncS3.deleteSync(casename);
                             }
                         }
-                        if(response.status_code=="info"){
+                        if (response.status_code == "info") {
                             Message.info(response.message);
                         }
-                        if(response.status_code=="warning"){
+                        if (response.status_code == "warning") {
                             Message.warning(response.message);
-                        }  
-                        
-                    })
-                    .catch(error =>{ 
+                        }
+                    } catch (error) {
                         Message.danger(error);
-                    });
+                    }
                 }
                 if (ButtonPressed === "No") {
-                    Message.bigBoxInfo("Confirmation message", "You pressed No...", 3000)
+                    Message.bigBoxInfo("Confirmation message", "You pressed No...", 3000);
                 }
             });
             //e.preventDefault();

--- a/WebAPP/App/Controller/ViewData.js
+++ b/WebAPP/App/Controller/ViewData.js
@@ -8,41 +8,29 @@ import { DEF } from "../../Classes/Definition.Class.js";
 import { MessageSelect } from "./MessageSelect.js";
 
 export default class ViewData {
-    static onLoad() {
+    static async onLoad() {
         Message.loaderStart('Loading data...');
-        Base.getSession()
-            .then(response => {
-                let casename = response['session'];
-                if (casename) {
-                    const promise = [];
-                    promise.push(casename);
-                    const genData = Osemosys.getData(casename, 'genData.json');
-                    promise.push(genData);
-                    const viewData = Osemosys.viewData(casename);
-                    promise.push(viewData);
-                    const viewTEData = Osemosys.viewTEData(casename);
-                    promise.push(viewTEData);
-                    const PARAMETERS = Osemosys.getParamFile();
-                    promise.push(PARAMETERS);
-                    // const RTdata = Osemosys.getData(casename, 'RT.json');
-                    // promise.push(RTdata); 
-                    return Promise.all(promise);
-                    ;
-                } else {
-                    Message.loaderEnd();
-                    MessageSelect.init(ViewData.refreshPage.bind(ViewData));
-                }
-            })
-            .then(data => {
-                let [casename, genData, viewData, viewTEData, PARAMETERS] = data;
-                let model = new Model(casename, genData, viewData, viewTEData, PARAMETERS);
+        try {
+            const response = await Base.getSession();
+            const casename = response['session'];
+            if (casename) {
+                const [genData, viewData, viewTEData, PARAMETERS] = await Promise.all([
+                    Osemosys.getData(casename, 'genData.json'),
+                    Osemosys.viewData(casename),
+                    Osemosys.viewTEData(casename),
+                    Osemosys.getParamFile(),
+                ]);
+                const model = new Model(casename, genData, viewData, viewTEData, PARAMETERS);
                 this.initPage(model);
                 this.initEvents(model);
-            })
-            .catch(error => {
+            } else {
                 Message.loaderEnd();
-                Message.warning(error);
-            });
+                MessageSelect.init(ViewData.refreshPage.bind(ViewData));
+            }
+        } catch (error) {
+            Message.loaderEnd();
+            Message.warning(error);
+        }
     }
 
     static initPage(model) {
@@ -64,36 +52,24 @@ export default class ViewData {
         Grid.applyViewDataFilter($divGrid, model.years);
     }
 
-    static refreshPage(casename) {
+    static async refreshPage(casename) {
         Message.loaderStart('Loading data...');
         Pace.restart();
-        Base.setSession(casename)
-            .then(response => {
-                const promise = [];
-                promise.push(casename);
-
-                const genData = Osemosys.getData(casename, 'genData.json');
-                promise.push(genData);
-                const viewData = Osemosys.viewData(casename);
-                promise.push(viewData);
-                const viewTEData = Osemosys.viewTEData(casename);
-                promise.push(viewTEData);
-                const PARAMETERS = Osemosys.getParamFile();
-                promise.push(PARAMETERS);
-                return Promise.all(promise);
-            })
-            .then(data => {
-                let [casename, genData, viewData, viewTEData, PARAMETERS] = data;
-                let model = new Model(casename, genData, viewData, viewTEData, PARAMETERS);
-                this.initPage(model);
-                this.initEvents(model);
-
-            })
-            .catch(error => {
-                Message.loaderEnd();
-                //$('#loadermain').hide(); 
-                Message.warning(error);
-            });
+        try {
+            await Base.setSession(casename);
+            const [genData, viewData, viewTEData, PARAMETERS] = await Promise.all([
+                Osemosys.getData(casename, 'genData.json'),
+                Osemosys.viewData(casename),
+                Osemosys.viewTEData(casename),
+                Osemosys.getParamFile(),
+            ]);
+            const model = new Model(casename, genData, viewData, viewTEData, PARAMETERS);
+            this.initPage(model);
+            this.initEvents(model);
+        } catch (error) {
+            Message.loaderEnd();
+            Message.warning(error);
+        }
     }
 
     static initEvents(model) {
@@ -224,7 +200,7 @@ export default class ViewData {
                 pasteEvent = true;
                 Message.smallBoxInfo('View data form', 'Copy/paste option is not allowed on this form', 3000);
             }
-        }).on('cellvaluechanged', function (event) {
+        }).on('cellvaluechanged', async function (event) {
             if (!pasteEvent) {
                 Pace.restart();
 
@@ -268,17 +244,15 @@ export default class ViewData {
                     }
                 });
 
-                Osemosys.updateViewData(model.casename, year, ScId, GroupId, ParamId, TechId, CommId, EmisId, TsId, value)
-                    .then(response => {
-                        Message.bigBoxSuccess('Model message', response.message, 3000);
-                        //sync S3
-                        if (Base.AWS_SYNC == 1) {
-                            Base.updateSync(model.casename, GroupId + ".json");
-                        }
-                    })
-                    .catch(error => {
-                        Message.bigBoxDanger('Error message', error, null);
-                    })
+                try {
+                    const response = await Osemosys.updateViewData(model.casename, year, ScId, GroupId, ParamId, TechId, CommId, EmisId, TsId, value);
+                    Message.bigBoxSuccess('Model message', response.message, 3000);
+                    if (Base.AWS_SYNC == 1) {
+                        Base.updateSync(model.casename, GroupId + ".json");
+                    }
+                } catch (error) {
+                    Message.bigBoxDanger('Error message', error, null);
+                }
             }
         });
 
@@ -291,7 +265,7 @@ export default class ViewData {
                 pasteRTEvent = true;
                 Message.smallBoxInfo('View data form', 'Copy/paste option is not allowed on this form', 3000);
             }
-        }).on('cellvaluechanged', function (event) {
+        }).on('cellvaluechanged', async function (event) {
             if (!pasteRTEvent) {
                 Pace.restart();
 
@@ -340,17 +314,15 @@ export default class ViewData {
                     }
                 });
 
-                Osemosys.updateTEViewData(model.casename, ScId, GroupId, ParamId, TechId, EmisId, value)
-                    .then(response => {
-                        Message.bigBoxSuccess('Model message', response.message, 3000);
-                        //sync S3
-                        if (Base.AWS_SYNC == 1) {
-                            Base.updateSync(model.casename, GroupId + ".json");
-                        }
-                    })
-                    .catch(error => {
-                        Message.bigBoxDanger('Error message', error, null);
-                    })
+                try {
+                    const response = await Osemosys.updateTEViewData(model.casename, ScId, GroupId, ParamId, TechId, EmisId, value);
+                    Message.bigBoxSuccess('Model message', response.message, 3000);
+                    if (Base.AWS_SYNC == 1) {
+                        Base.updateSync(model.casename, GroupId + ".json");
+                    }
+                } catch (error) {
+                    Message.bigBoxDanger('Error message', error, null);
+                }
             }
         });
 
@@ -390,21 +362,19 @@ export default class ViewData {
         // });
 
         $("#xlsAll").off('click');
-        $("#xlsAll").click(function (e) {
+        $("#xlsAll").click(async function (e) {
             e.preventDefault();
             let rytData = $divGrid.jqxGrid('getdisplayrows');
             let data = JSON.parse(JSON.stringify(rytData, ['Sc', 'paramName', 'UnitId', 'TechName', "CommName", "EmisName", "ConName", 'Ts', 'MoId'].concat(model.years)));
 
-            console.log('data', data);
-            Base.prepareCSV(model.casename, data)
-            .then(response =>{
+            try {
+                const response = await Base.prepareCSV(model.casename, data);
                 Message.smallBoxInfo('Case study message', response.message, 3000);
                 $('#csvDownload').trigger('click');
                 window.location = $('#csvDownload').attr('href');
-            })
-            .catch(error=>{
+            } catch (error) {
                 Message.bigBoxDanger('Error message', error, null);
-            })
+            }
         });
 
 

--- a/WebAPP/Classes/Osemosys.Class.js
+++ b/WebAPP/Classes/Osemosys.Class.js
@@ -378,20 +378,20 @@ export class Osemosys {
     //         .catch(error => null);
     // }
 
-    static getData(casename, dataJson) {
+    static async getData(casename, dataJson) {
         if (!casename || casename === "null") {
             console.warn("getData called without valid casename");
-            return Promise.resolve(null);
+            return null;
         }
-        return fetch('../../DataStorage/'+casename+'/'+dataJson, {cache: "no-store"}) 
-            .then((response) => {
-                if (response.ok) {
-                    return response;
-                }
+        try {
+            const response = await fetch('../../DataStorage/' + casename + '/' + dataJson, { cache: "no-store" });
+            if (!response.ok) {
                 throw new Error('Invalid casename');
-            })
-            .then(response => response.json())
-            .catch(error => null);
+            }
+            return await response.json();
+        } catch (error) {
+            return null;
+        }
     }
 
     static getData_(casename, dataJson) {
@@ -437,20 +437,20 @@ export class Osemosys {
     //         .catch(error => null);
     // }
 
-    static getResultData(casename, dataJson) {
+    static async getResultData(casename, dataJson) {
         if (!casename || casename === "null") {
             console.warn("getResultData called without valid casename");
-            return Promise.resolve(null);
+            return null;
         }
-        return fetch('../../DataStorage/'+casename+'/view/' +dataJson, {cache: "no-store"})
-            .then((response) => {
-                if (response.ok) {
-                    return response;
-                }
+        try {
+            const response = await fetch('../../DataStorage/' + casename + '/view/' + dataJson, { cache: "no-store" });
+            if (!response.ok) {
                 throw new Error('Invalid casename');
-            })
-            .then(response => response.json())
-            .catch(error => null);
+            }
+            return await response.json();
+        } catch (error) {
+            return null;
+        }
     }
 
     static updateData(data, param, dataJson) {


### PR DESCRIPTION
## Problem

The entire frontend used `.then()/.catch()` callback chaining with no `async/await` anywhere. Nested callbacks made error tracing difficult and the code harder to read and maintain. Closes #323

## Solution

Replaced all `.then()/.catch()` chains with `async/await` and `try/catch` blocks across five files:

- **`WebAPP/Classes/Osemosys.Class.js`** — `getData`, `getResultData` (fetch-based methods)
- **`WebAPP/App/Controller/AddCase.js`** — `onLoad`, `refreshPage`, `validationSuccess`, `deleteScenarioCaseRuns`, all event handlers
- **`WebAPP/App/Controller/Home.js`** — `onLoad`, `refreshPage`, all five `initEvents` handlers (`.selectCS`, `.editPS`, `.copyCS`, `.descriptionPS`, `.deleteModel`)
- **`WebAPP/App/Controller/DataFile.js`** — `onLoad`, `refreshPage`, `validationSuccess`, `generateDataFile`, `run`, `selectCS`, `validateInputs`, `.deleteCase`, `.deleteCaseResults`, `batchRun`, `cleanUp`
- **`WebAPP/App/Controller/ViewData.js`** — `onLoad`, `refreshPage`, both `cellvaluechanged` handlers, `#xlsAll` click handler

Key patterns used:
- `static async method()` with `try/catch` replaces `.then()/.catch()` on static methods
- `async function(event)` callbacks in jQuery `.on()` handlers
- `Promise.all([...])` kept where parallel fetches were already being done, now with `await`
- Duplicate status-code branches collapsed where safe (e.g. `success || warning` in the run handler)
- Removed dead commented-out `console.log` calls encountered during the conversion

## Testing

- Ran the app locally with demo data
- Verified home page loads, case selection, copy, delete flows
- Verified DataFile page: generate data file, run solver, batch run, clean up
- Verified ViewData page: load, grid cell edits, CSV export

## Related Issues / PRs reviewed

- [x] #323

## Overlap Classification

None

## Linked Issues

Closes #323