### PR TITLE
Detect and recover interrupted solver runs using run_state.json

### DIFF
--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -2093,6 +2093,41 @@ class DataFile(Osemosys):
                 lock.acquire()
                 caserunname = caserun
 
+            # Detect interrupted previous run
+            run_state_path = Path(Config.DATA_STORAGE, self.case, 'res', caserunname, 'run_state.json')
+            is_alive = False
+            if run_state_path.exists():
+                prev_state = File.readFile(run_state_path)
+                pid = prev_state.get('pid')
+                if pid:
+                    try:
+                        os.kill(pid, 0)
+                        is_alive = True
+                    except OSError:
+                        is_alive = False
+                    if not is_alive:
+                        # Previous run was interrupted
+                        File.writeFileAtomic({
+                            'status': 'interrupted',
+                            'case': self.case,
+                            'caserun': caserunname,
+                            'pid': pid
+                        }, run_state_path)
+                        return {
+                            'status_code': 'interrupted',
+                            'message': f'Previous run for "{caserunname}" was interrupted. Please restart.'
+                        }
+
+            # Write fresh state
+            File.writeFileAtomic({
+                'status': 'running',
+                'case': self.case,
+                'caserun': caserunname,
+                'pid': os.getpid(),
+                'solver': solver,
+                'started_at': time.time()
+            }, run_state_path)
+
             start_time = time.time()
             txtOut = ""
             self.dataFile = Path(Config.DATA_STORAGE, self.case, 'res',caserunname,'data.txt')
@@ -2254,17 +2289,19 @@ class DataFile(Osemosys):
                     "status_code": statusFlag,
                     "caserun": caserunname
                 } 
+            if run_state_path.exists():
+                run_state_path.unlink()
 
-           
             if lock is not None:
                 lock.release()
-
-            return response
+            return response 
             # urllib.request.urlretrieve(self.dataFile, dataFile)
 
         except Exception as ex:
-            print(ex) # do whatever you want for debugging.
-            raise    # re-raise exception.
+            if run_state_path.exists():
+                run_state_path.unlink()
+            print(ex)
+            raise
         except(IOError, IndexError):
             raise IndexError
         except OSError:


### PR DESCRIPTION
## Linked issue

- Closes #325
- Related #302

## Existing related work reviewed
#257/#259/#186/#302

## Overlap assessment
- Classification: New feature
- Overlapping items: #186, #257/#259
- Why this is not duplicate: #186 introduced a full job management system. #257/#259 address timeout enforcement. This PR only adds passive interruption detection with zero architectural change.

## Why this PR should proceed
- Directly addresses SeaCelo's suggestion in #301 about interrupted runs
- Builds naturally on #302 atomic writes
- Minimal, surgical, no breaking changes

## Summary
What changed: Added interruption detection to DataFileClass.run(). Writes run_state.json atomically before solver starts, checks PID liveness on next run request, cleans up on completion or exception.
Why: If the server restarts or laptop sleeps mid-run, the run is silently lost. This change detects that state and informs the user.

## Validation 
- Not applicable,  no automated test suite for this flow
- Manual validation: start a run, kill the process, restart app, trigger /run again — returns status_code: interrupted 

## Scope check

- [ ] No unrelated refactors
- [ ] Implemented from a feature branch
- [ ] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [ ] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream) 
