### PR TITLE
Fix file handle leak in readDataFile using context manager

### DIFF
--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -1072,7 +1072,7 @@ class DataFile(Osemosys):
             if os.path.exists(dataFilePath):
                 f = open(dataFilePath, mode="r", encoding='utf-8-sig')
                 data =  f.read()
-                f.close
+                f.close()
             else:
                 data = None
 


### PR DESCRIPTION
## Linked issue

- Closes #328 

## Existing related work reviewed
None found after search

Overlap assessment:
- Classification: Bug Fix
- Overlapping items: None identified
- Why this is not duplicate/superseded:
  This PR fixes an incorrect file close call (`f.close`) in readDataFile which prevents the file descriptor from closing.

Why this PR should proceed:
- Fixes improper file closing in readDataFile.
- Prevents potential file descriptor leaks.

Summary 
- What changed:
  Replaced `f.close` with `f.close()` in readDataFile.

- Why:
  `f.close` only references the method and does not execute it, leaving the file open.

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

## Documentation

- [x] Docs updated in this PR (or not applicable)
- [ ] Any setup/workflow changes reflected in repo docs

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

## Exception rationale

