### PR TITLE
fix(backupCase): store relative paths in ZIP archive

### DIFF
--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -213,10 +213,10 @@ def backupCase():
 
                 for filename in filenames:
                     if filename != 'lp.lp':
-                        #create complete filepath of file in directory
                         filePath = os.path.join(folderName, filename)
-                        # Add file to zip
-                        zipObj.write(filePath)      
+                        # store relative path so ZIP is portable across machines
+                        arcname = os.path.join(case, os.path.relpath(filePath, str(casePath)))
+                        zipObj.write(filePath, arcname=arcname)
 
             #osemosys 2.1 backup only input files
             # for filename in os.listdir(str(casePath)):

--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -1,7 +1,7 @@
 import shutil
 from flask import Blueprint, request, jsonify, send_file, after_this_request
 from zipfile import ZipFile
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from werkzeug.utils import secure_filename
 import os, time, json, glob
 
@@ -214,8 +214,10 @@ def backupCase():
                 for filename in filenames:
                     if filename != 'lp.lp':
                         filePath = os.path.join(folderName, filename)
-                        # store relative path so ZIP is portable across machines
-                        arcname = os.path.join(case, os.path.relpath(filePath, str(casePath)))
+                        # PurePosixPath enforces forward-slash separators in the ZIP
+                        # regardless of host OS, required by the ZIP spec and ensures
+                        # Windows-created backups restore correctly on Linux/macOS.
+                        arcname = str(PurePosixPath(case) / os.path.relpath(filePath, str(casePath)).replace('\\', '/'))
                         zipObj.write(filePath, arcname=arcname)
 
             #osemosys 2.1 backup only input files


### PR DESCRIPTION
## Linked issue

- Closes #330

## Existing related work reviewed

- Issues/PRs reviewed: None found after search
- If none found, write: None found after search

## Overlap assessment

- Classification: Bug fix (non-portable ZIP entry paths in `backupCase`)
- Overlapping items: None identified
- Why this is not duplicate/superseded: This PR fixes current `main` behavior in `API/Routes/Upload/UploadRoute.py` where ZIP entries include host-specific path prefixes when `arcname` is omitted.

## Why this PR should proceed

- Backup archives must be portable across machines and install paths.
- Current behavior embeds host-specific absolute paths (e.g. `/home/user/MUIOGO/WebAPP/DataStorage/MyModel/genData.json`) inside the ZIP, breaking restore on any other machine or directory.
- The fix is minimal, low-risk, and scoped to two lines in one route.

## Summary

- What changed: `backupCase` now passes `arcname=os.path.join(case, os.path.relpath(filePath, str(casePath)))` to `zipObj.write()` so entries are stored as `CLEWs Demo/genData.json` instead of absolute paths.
- Why: Makes backup ZIPs portable and consistent with the `casename` derivation in `handle_full_zip` restore logic.

## Validation

- [ ] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

Validation evidence:
- Before fix (reproduced): entries like `Project/UN/MUIOGO/WebAPP/DataStorage/CLEWs Demo/...`
<img width="606" height="366" alt="image" src="https://github.com/user-attachments/assets/28358240-002b-4de5-89a6-defe0190953e" />

- After fix: entries like `CLEWs Demo/export.csv`, `CLEWs Demo/genData.json`, ...
<img width="338" height="521" alt="image" src="https://github.com/user-attachments/assets/da528e3a-a888-49d6-b698-500cdcf3c373" />

## Documentation

- [x] Docs updated in this PR (or not applicable) - no doc changes needed for this bug fix
- [x] Any setup/workflow changes reflected in repo docs -no workflow changes

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)