### PR TITLE
Fix numpy incompatibility with Python 3.13 and 3.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ itsdangerous==2.2.0
 Jinja2==3.1.4
 jmespath==1.0.1
 MarkupSafe==2.1.5
-numpy==1.26.4
+numpy>=2.0.0
 openpyxl==3.1.4
 packaging==24.0
 pandas==2.2.2


### PR DESCRIPTION
numpy==1.26.4 causes a segmentation fault on Python 3.13+ due to
invalid values in core math functions (nextafter, log10). Updated
to numpy>=2.0.0 which supports Python 3.13 and 3.14.

Fixes #343

## Linked issue
- Closes #343
- Related: None

## Existing related work reviewed
- Issues/PRs reviewed: Searched for "numpy" and "segmentation fault" in open and closed issues
- None found after search

## Overlap assessment
- Classification: New fix, no overlap
- Overlapping items: None
- Why this is not duplicate/superseded: First report and first fix for this specific crash on Python 3.13 and 3.14

## Why this PR should proceed
numpy==1.26.4 is incompatible with Python 3.13 and 3.14. Any contributor
or user on a modern Python installation cannot run the app at all — it
crashes with a segmentation fault before the Flask server starts. This is
a one-line fix in requirements.txt with no side effects on supported
Python versions.

## Summary
- What changed: numpy==1.26.4 updated to numpy>=2.0.0 in requirements.txt
- Why: numpy 1.26.4 causes a segmentation fault on Python 3.13 and 3.14
  due to invalid values in nextafter and log10. numpy 2.0.0+ supports
  modern Python versions and resolves the crash completely.

## Validation
- [x] Tests added/updated (not applicable for dependency version fix)
- [x] Validation steps documented
- [x] Evidence attached

Validation steps:
1. Clone the repository
2. Run: pip install -r requirements.txt
3. Run: python API/app.py
4. App serves successfully on http://127.0.0.1:5002 with no errors

Evidence:
- Before fix: segmentation fault on startup with numpy==1.26.4 on Python 3.14
- After fix: app starts and serves correctly with numpy>=2.0.0 on Python 3.14
- Tested on: Windows 11, Python 3.14

## Documentation
- [x] Docs updated in this PR (not applicable)
- [x] Setup/workflow changes reflected in repo docs (not applicable)

## Scope check
- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream OSeMOSYS/MUIO dependency
- [x] Base repo/branch is EAPD-DRB/MUIOGO:main (not upstream)

## Exception rationale
Not applicable.