### PR TITLE
Draft: PoC - Canonical CLEWS Result Extraction for OG-Core Integration

### DIFF
--- a/API/Integration/clews_to_og_poc.py
+++ b/API/Integration/clews_to_og_poc.py
@@ -1,3 +1,5 @@
+import json
+from numbers import Number
 from pathlib import Path
 
 import pandas as pd
@@ -9,6 +11,48 @@ def _resolve_variable_name(csv_path: str, variable_name: str | None) -> str:
     if variable_name:
         return variable_name
     return Path(csv_path).stem
+
+
+def _infer_case_and_run_names(
+    run_root: str | Path | None,
+    case_name: str | None,
+    run_name: str | None,
+) -> tuple[str | None, str | None]:
+    if run_root is None:
+        return case_name, run_name
+
+    run_root_path = Path(run_root)
+    resolved_run = run_name or run_root_path.name
+    resolved_case = case_name
+    if resolved_case is None and run_root_path.parent.name == "res":
+        resolved_case = run_root_path.parent.parent.name
+    return resolved_case, resolved_run
+
+
+def _to_json_scalar(value):
+    if hasattr(value, "item"):
+        value = value.item()
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return value
+
+
+def _sorted_unique(values) -> list:
+    normalized = [_to_json_scalar(value) for value in values]
+    if all(isinstance(value, Number) for value in normalized):
+        return sorted(normalized)
+    return sorted(normalized, key=str)
+
+
+def _display_path(path: str | Path, run_root: str | Path | None) -> str:
+    path_obj = Path(path)
+    if run_root is None:
+        return str(path_obj)
+
+    try:
+        return str(path_obj.relative_to(Path(run_root)))
+    except ValueError:
+        return str(path_obj)
 
 
 def load_clews_result_csv(
@@ -74,3 +118,125 @@ def poc_pivot_clews_data(
     matrix.index.name = "Year"
     matrix.columns.name = "Technology"
     return matrix
+
+
+def build_clews_input_manifest(
+    csv_path: str,
+    run_root: str | Path | None = None,
+    variable_name: str | None = None,
+    case_name: str | None = None,
+    run_name: str | None = None,
+) -> dict:
+    normalized = load_clews_result_csv(csv_path, variable_name)
+    resolved_name = _resolve_variable_name(csv_path, variable_name)
+    expected_dims = Config.VARIABLES_C[resolved_name]
+    resolved_case, resolved_run = _infer_case_and_run_names(
+        run_root, case_name, run_name
+    )
+
+    input_record = {
+        "variable_name": resolved_name,
+        "source_csv": _display_path(csv_path, run_root),
+        "dimensions": expected_dims,
+        "value_column": resolved_name,
+        "row_count": int(len(normalized)),
+        "dimension_members": {
+            dim: _sorted_unique(normalized[dim].dropna().unique().tolist())
+            for dim in expected_dims
+        },
+    }
+    if "y" in normalized.columns:
+        input_record["years"] = _sorted_unique(normalized["y"].dropna().unique().tolist())
+
+    return {
+        "schema_version": "0.1",
+        "case_name": resolved_case,
+        "run_name": resolved_run,
+        "inputs": [input_record],
+    }
+
+
+def build_coupled_run_summary(
+    csv_path: str,
+    run_root: str | Path,
+    variable_name: str | None = None,
+    case_name: str | None = None,
+    run_name: str | None = None,
+) -> dict:
+    matrix = poc_pivot_clews_data(csv_path, variable_name)
+    resolved_name = _resolve_variable_name(csv_path, variable_name)
+    run_root_path = Path(run_root)
+    integration_dir = run_root_path / "integration"
+    resolved_case, resolved_run = _infer_case_and_run_names(
+        run_root_path, case_name, run_name
+    )
+
+    return {
+        "schema_version": "0.1",
+        "case_name": resolved_case,
+        "run_name": resolved_run,
+        "workflow": "coupled",
+        "status": "ready_for_ogcore_adapter",
+        "source_results_dir": _display_path(Path(csv_path).parent, run_root_path),
+        "integration_dir": _display_path(integration_dir, run_root_path),
+        "generated_files": {
+            "clews_input_manifest": _display_path(
+                integration_dir / "clews_input_manifest.json", run_root_path
+            ),
+            "coupled_run_summary": _display_path(
+                integration_dir / "coupled_run_summary.json", run_root_path
+            ),
+        },
+        "variables": [resolved_name],
+        "transforms": [
+            {
+                "variable_name": resolved_name,
+                "output_kind": "year_by_technology_matrix",
+                "years": _sorted_unique(matrix.index.tolist()),
+                "technologies": _sorted_unique(matrix.columns.tolist()),
+                "year_count": int(len(matrix.index)),
+                "technology_count": int(len(matrix.columns)),
+            }
+        ],
+    }
+
+
+def write_coupled_integration_outputs(
+    csv_path: str,
+    run_root: str | Path,
+    variable_name: str | None = None,
+    case_name: str | None = None,
+    run_name: str | None = None,
+) -> dict[str, Path]:
+    run_root_path = Path(run_root)
+    integration_dir = run_root_path / "integration"
+    integration_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest = build_clews_input_manifest(
+        csv_path,
+        run_root=run_root_path,
+        variable_name=variable_name,
+        case_name=case_name,
+        run_name=run_name,
+    )
+    summary = build_coupled_run_summary(
+        csv_path,
+        run_root=run_root_path,
+        variable_name=variable_name,
+        case_name=case_name,
+        run_name=run_name,
+    )
+
+    manifest_path = integration_dir / "clews_input_manifest.json"
+    summary_path = integration_dir / "coupled_run_summary.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    summary_path.write_text(
+        json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8"
+    )
+
+    return {
+        "manifest_path": manifest_path,
+        "summary_path": summary_path,
+    }

--- a/API/Integration/clews_to_og_poc.py
+++ b/API/Integration/clews_to_og_poc.py
@@ -1,29 +1,76 @@
-import pandas as pd
 from pathlib import Path
-import json
 
-def poc_pivot_clews_data(csv_path: str, variable_id: str = "ANC"):
-    
-    #Proof of Concept: In-memory ETL transformation for CLEWS to OG-Core.
-    #Demonstrates pivoting long-format RYT data into a time-series matrix.
-    
-    print(f"[*] Extracting data from {csv_path}...")
-    try:
-        
-        df = pd.read_csv(csv_path)
-        value_column = df.columns[-1] 
-        print("[*] Pivoting RYT data into time-series matrix")
-        matrix = df.pivot_table(
-            index='y', 
-            columns='t', 
-            values=value_column, 
-            aggfunc='sum'
-        ).fillna(0)
-        matrix.index.name = 'Year'
-        print("\n[+] In-Memory Matrix Ready for OG-Core Ingestion")
-        print(matrix.head())
-        return matrix
-    
-    except Exception as e:
-        print(f"[!] Error: {e}")
-        return None
+import pandas as pd
+
+from Classes.Base import Config
+
+
+def _resolve_variable_name(csv_path: str, variable_name: str | None) -> str:
+    if variable_name:
+        return variable_name
+    return Path(csv_path).stem
+
+
+def load_clews_result_csv(
+    csv_path: str, variable_name: str | None = None
+) -> pd.DataFrame:
+    """
+    Load and validate a repository-style CLEWS result CSV.
+
+    The PoC intentionally relies on repository metadata rather than guessed
+    CLEWS-to-OG-Core mappings. It validates that the CSV contains the expected
+    OSeMOSYS dimensions and one numeric value column matching the variable name.
+    """
+
+    resolved_name = _resolve_variable_name(csv_path, variable_name)
+    expected_dims = Config.VARIABLES_C.get(resolved_name)
+    if expected_dims is None:
+        raise ValueError(f"Unsupported CLEWS result variable: {resolved_name}")
+
+    df = pd.read_csv(csv_path)
+    required_columns = expected_dims + [resolved_name]
+    missing_columns = [column for column in required_columns if column not in df.columns]
+    if missing_columns:
+        raise ValueError(
+            f"Missing expected columns for {resolved_name}: {missing_columns}"
+        )
+
+    normalized = df[required_columns].copy()
+    normalized[resolved_name] = pd.to_numeric(normalized[resolved_name], errors="raise")
+    return normalized
+
+
+def poc_pivot_clews_data(
+    csv_path: str, variable_name: str | None = None
+) -> pd.DataFrame:
+    """
+    Proof of concept for repository-grounded CLEWS result extraction.
+
+    For variables that include both `y` and `t` dimensions, collapse any extra
+    dimensions by summing over `(y, t)` and return a year-by-technology matrix.
+    """
+
+    normalized = load_clews_result_csv(csv_path, variable_name)
+    resolved_name = _resolve_variable_name(csv_path, variable_name)
+    expected_dims = Config.VARIABLES_C[resolved_name]
+
+    if "y" not in expected_dims or "t" not in expected_dims:
+        raise ValueError(
+            f"{resolved_name} cannot be pivoted by this PoC because it does not "
+            "include both 'y' and 't' dimensions."
+        )
+
+    grouped = (
+        normalized.groupby(["y", "t"], as_index=False)[resolved_name]
+        .sum()
+        .sort_values(["y", "t"])
+    )
+    matrix = (
+        grouped.pivot(index="y", columns="t", values=resolved_name)
+        .fillna(0)
+        .sort_index()
+        .sort_index(axis=1)
+    )
+    matrix.index.name = "Year"
+    matrix.columns.name = "Technology"
+    return matrix

--- a/API/Integration/clews_to_og_poc.py
+++ b/API/Integration/clews_to_og_poc.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from pathlib import Path
+import json
+
+def poc_pivot_clews_data(csv_path: str, variable_id: str = "ANC"):
+    
+    #Proof of Concept: In-memory ETL transformation for CLEWS to OG-Core.
+    #Demonstrates pivoting long-format RYT data into a time-series matrix.
+    
+    print(f"[*] Extracting data from {csv_path}...")
+    try:
+        
+        df = pd.read_csv(csv_path)
+        value_column = df.columns[-1] 
+        print("[*] Pivoting RYT data into time-series matrix")
+        matrix = df.pivot_table(
+            index='y', 
+            columns='t', 
+            values=value_column, 
+            aggfunc='sum'
+        ).fillna(0)
+        matrix.index.name = 'Year'
+        print("\n[+] In-Memory Matrix Ready for OG-Core Ingestion")
+        print(matrix.head())
+        return matrix
+    
+    except Exception as e:
+        print(f"[!] Error: {e}")
+        return None

--- a/API/tests/test_clews_to_og_poc.py
+++ b/API/tests/test_clews_to_og_poc.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import tempfile
 import unittest
@@ -8,7 +9,12 @@ REPO_API = Path(__file__).resolve().parents[1]
 if str(REPO_API) not in sys.path:
     sys.path.insert(0, str(REPO_API))
 
-from Integration.clews_to_og_poc import load_clews_result_csv, poc_pivot_clews_data
+from Integration.clews_to_og_poc import (
+    build_clews_input_manifest,
+    load_clews_result_csv,
+    poc_pivot_clews_data,
+    write_coupled_integration_outputs,
+)
 
 
 class ClewsToOgPocTests(unittest.TestCase):
@@ -61,6 +67,74 @@ class ClewsToOgPocTests(unittest.TestCase):
 
             with self.assertRaisesRegex(ValueError, "Missing expected columns"):
                 poc_pivot_clews_data(str(csv_path))
+
+    def test_build_clews_input_manifest_describes_validated_input(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_root = Path(tmpdir) / "Kenya" / "res" / "run_001"
+            csv_dir = run_root / "csv"
+            csv_dir.mkdir(parents=True)
+            csv_path = csv_dir / "CapitalInvestment.csv"
+            csv_path.write_text(
+                "r,t,y,CapitalInvestment\n"
+                "RE1,SOLAR,2025,10\n"
+                "RE1,WIND,2025,5\n"
+                "RE1,SOLAR,2026,3\n",
+                encoding="utf-8",
+            )
+
+            manifest = build_clews_input_manifest(str(csv_path), run_root=run_root)
+
+            self.assertEqual(manifest["case_name"], "Kenya")
+            self.assertEqual(manifest["run_name"], "run_001")
+            self.assertEqual(manifest["schema_version"], "0.1")
+            self.assertEqual(len(manifest["inputs"]), 1)
+            record = manifest["inputs"][0]
+            self.assertEqual(record["source_csv"], "csv/CapitalInvestment.csv")
+            self.assertEqual(record["dimensions"], ["r", "t", "y"])
+            self.assertEqual(record["row_count"], 3)
+            self.assertEqual(record["years"], [2025, 2026])
+            self.assertEqual(record["dimension_members"]["t"], ["SOLAR", "WIND"])
+
+    def test_write_coupled_integration_outputs_generates_manifest_and_summary(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            run_root = Path(tmpdir) / "Kenya" / "res" / "run_001"
+            csv_dir = run_root / "csv"
+            csv_dir.mkdir(parents=True)
+            csv_path = csv_dir / "CapitalInvestment.csv"
+            csv_path.write_text(
+                "r,t,y,CapitalInvestment\n"
+                "RE1,SOLAR,2025,10\n"
+                "RE1,SOLAR,2025,2\n"
+                "RE1,WIND,2025,5\n"
+                "RE1,SOLAR,2026,3\n",
+                encoding="utf-8",
+            )
+
+            written = write_coupled_integration_outputs(str(csv_path), run_root=run_root)
+
+            manifest_path = written["manifest_path"]
+            summary_path = written["summary_path"]
+            self.assertTrue(manifest_path.exists())
+            self.assertTrue(summary_path.exists())
+            self.assertEqual(manifest_path.parent, run_root / "integration")
+
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(
+                summary["generated_files"]["clews_input_manifest"],
+                "integration/clews_input_manifest.json",
+            )
+            self.assertEqual(summary["workflow"], "coupled")
+            self.assertEqual(summary["status"], "ready_for_ogcore_adapter")
+            self.assertEqual(summary["source_results_dir"], "csv")
+            self.assertEqual(summary["variables"], ["CapitalInvestment"])
+            self.assertEqual(
+                summary["transforms"][0]["output_kind"], "year_by_technology_matrix"
+            )
+            self.assertEqual(summary["transforms"][0]["years"], [2025, 2026])
+            self.assertEqual(summary["transforms"][0]["technologies"], ["SOLAR", "WIND"])
+            self.assertEqual(manifest["inputs"][0]["source_csv"], "csv/CapitalInvestment.csv")
 
 
 if __name__ == "__main__":

--- a/API/tests/test_clews_to_og_poc.py
+++ b/API/tests/test_clews_to_og_poc.py
@@ -1,0 +1,67 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_API = Path(__file__).resolve().parents[1]
+if str(REPO_API) not in sys.path:
+    sys.path.insert(0, str(REPO_API))
+
+from Integration.clews_to_og_poc import load_clews_result_csv, poc_pivot_clews_data
+
+
+class ClewsToOgPocTests(unittest.TestCase):
+    def test_load_clews_result_csv_validates_expected_columns(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = Path(tmpdir) / "CapitalInvestment.csv"
+            csv_path.write_text(
+                "r,t,y,CapitalInvestment\n"
+                "RE1,SOLAR,2025,10.5\n"
+                "RE1,WIND,2025,12.0\n",
+                encoding="utf-8",
+            )
+
+            df = load_clews_result_csv(str(csv_path))
+
+            self.assertEqual(
+                list(df.columns), ["r", "t", "y", "CapitalInvestment"]
+            )
+            self.assertEqual(df["CapitalInvestment"].tolist(), [10.5, 12.0])
+
+    def test_poc_pivot_clews_data_builds_year_by_technology_matrix(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = Path(tmpdir) / "CapitalInvestment.csv"
+            csv_path.write_text(
+                "r,t,y,CapitalInvestment\n"
+                "RE1,SOLAR,2025,10\n"
+                "RE1,SOLAR,2025,2\n"
+                "RE1,WIND,2025,5\n"
+                "RE1,SOLAR,2026,3\n",
+                encoding="utf-8",
+            )
+
+            matrix = poc_pivot_clews_data(str(csv_path))
+
+            self.assertEqual(matrix.index.tolist(), [2025, 2026])
+            self.assertEqual(matrix.columns.tolist(), ["SOLAR", "WIND"])
+            self.assertEqual(matrix.loc[2025, "SOLAR"], 12.0)
+            self.assertEqual(matrix.loc[2025, "WIND"], 5.0)
+            self.assertEqual(matrix.loc[2026, "SOLAR"], 3.0)
+            self.assertEqual(matrix.loc[2026, "WIND"], 0.0)
+
+    def test_poc_pivot_clews_data_rejects_missing_dimensions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = Path(tmpdir) / "CapitalInvestment.csv"
+            csv_path.write_text(
+                "r,y,CapitalInvestment\n"
+                "RE1,2025,10\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "Missing expected columns"):
+                poc_pivot_clews_data(str(csv_path))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Linked issue

- Related #348

## Existing related work reviewed

- Issues/PRs reviewed: #15, #23, #24, #122, #251
## Overlap assessment

- Classification: complementary source-side PoC
- Overlapping items:
  - #24 explores ETL semantics, converging orchestration, and async execution
  - #251 explores OG-Core-side macroeconomic ingestion and validation
- Why this is not duplicate/superseded:
  - This draft PR proves one smaller backend primitive: reading repository-style CLEWS result CSVs and transforming them into a deterministic, year-indexed canonical structure.
  - It does **not** define final CLEWS-to-OG-Core semantic mappings.
  - It does **not** implement coupled or converging execution logic.
  - It does **not** introduce OG-Core-side ingestion routes.

## Why this PR should proceed

- Contributor 1 work needs a reliable source-side data contract before higher-level coupling decisions can be made safely.
- This draft PR de-risks that boundary by showing that current CLEWS-style outputs can be parsed and reshaped in memory using repository-grounded assumptions rather than guessed cross-model mappings.
- It provides a reviewable PoC for extraction/canonicalization while keeping scope intentionally small.

## Summary

- What changed:
  - Added `API/Integration/clews_to_og_poc.py` with a first in-memory transformation from long-format CLEWS-style CSV data into a year-indexed matrix.
- Why:
  - To establish a minimal PoC for source-side result extraction/canonicalization using current repository outputs.
  - Not to finalize CLEWS-to-OG-Core semantic mappings or the full coupling design.

## Validation

- [ ] Tests added/updated (draft PoC; planned in follow-up work)
- [x] Validation steps documented
- [ ] Evidence attached (can be added in a follow-up update)

Validation steps:

1. Use an existing CLEWS-style CSV that includes a `y` column and a numeric value column.
2. Run `poc_pivot_clews_data(<csv_path>)`.
3. Verify that the returned frame is indexed by year and preserves numeric values in memory without writing guessed OG-Core parameters.

## Documentation

- [x] Docs updated in this PR (not applicable for this draft PoC)
- [x] Any setup/workflow changes reflected in repo docs (not applicable for this draft PoC)

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

### Update

This PR now generates two minimal integration artifacts in addition to CSV validation and reshaping:

- `integration/clews_input_manifest.json`
- `integration/coupled_run_summary.json`

These files record the source CSV used, variable metadata, dimensions, years, generated file locations, and the current transformation output shape. The goal is to make the PoC closer to a real integration boundary rather than only an in-memory dataframe transformation.