### PR TITLE
fix: add session validation to ViewDataRoute endpoints

### DIFF
--- a/API/Routes/Case/ViewDataRoute.py
+++ b/API/Routes/Case/ViewDataRoute.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, session
 from Classes.Case.OsemosysClass import Osemosys
 
 viewdata_api = Blueprint('ViewDataRoute', __name__)
@@ -7,6 +7,9 @@ viewdata_api = Blueprint('ViewDataRoute', __name__)
 def viewData():
     try:
         casename = request.json['casename']
+        active_case = session.get('osycase')
+        if not active_case or casename != active_case:
+            return jsonify({'message': 'Unauthorised: case does not match active session.', 'status_code': 'error'}), 403
         if casename != None:
             osy = Osemosys(casename)
             data = {}
@@ -24,6 +27,9 @@ def viewData():
 def viewTEData():
     try:
         casename = request.json['casename']
+        active_case = session.get('osycase')
+        if not active_case or casename != active_case:
+            return jsonify({'message': 'Unauthorised: case does not match active session.', 'status_code': 'error'}), 403
         if casename != None:
             osy = Osemosys(casename)
             data = {}
@@ -41,6 +47,9 @@ def updateViewData():
     try:
         #casename, updateType, groupId, paramId, TechId, CommId, EmisId, Timeslice
         casename = request.json['casename']
+        active_case = session.get('osycase')
+        if not active_case or casename != active_case:
+            return jsonify({'message': 'Unauthorised: case does not match active session.', 'status_code': 'error'}), 403
         #updateType = request.json['updateType']
         year = request.json['year']
         ScId = request.json['ScId']
@@ -74,6 +83,9 @@ def updateTEViewData():
     try:
         #casename, updateType, groupId, paramId, TechId, CommId, EmisId, Timeslice
         casename = request.json['casename']
+        active_case = session.get('osycase')
+        if not active_case or casename != active_case:
+            return jsonify({'message': 'Unauthorised: case does not match active session.', 'status_code': 'error'}), 403
         scId = request.json['scId']
         groupId = request.json['groupId']
         paramId = request.json['paramId']


### PR DESCRIPTION
## Summary
- All 4 endpoints in `ViewDataRoute.py` were accepting `casename` from request data without validating it against the active session, allowing unauthorized access to other cases' data
- Added the same inline session ownership check already used in `CaseRoute.py` (`session.get('osycase')`) to `/viewData`, `/viewTEData`, `/updateViewData`, and `/updateTEViewData`
- Returns `403` with a JSON error message if `casename` doesn't match the session case

Closes #347

## Test plan
- [ ] Confirm that requests with a `casename` matching the active session (`osycase`) succeed as before
- [ ] Confirm that requests with a mismatched `casename` return `403 Unauthorised`
- [ ] Confirm that requests with no active session return `403`

🤖 Generated with [Claude Code](https://claude.com/claude-code)