### PR TITLE
Fix incorrect exception handling in FileClass write methods

### DIFF
--- a/API/Classes/Base/FileClass.py
+++ b/API/Classes/Base/FileClass.py
@@ -21,7 +21,7 @@ class File:
             with open(path, mode="w") as f:
                 f.write(json.dumps(data, ensure_ascii=True, indent=4, sort_keys=False))
         except (IOError, IndexError):
-            raise IndexError
+            raise
         except OSError:
             raise OSError
 
@@ -31,7 +31,7 @@ class File:
             with open(path, mode="w") as f:
                 f.write(json.dumps(data))
         except (IOError, IndexError):
-            raise IndexError
+            raise
         except OSError:
             raise OSError
 


### PR DESCRIPTION
Closes #353

This fixes an issue where write failures were being re-raised as IndexError.

The current implementation catches IOError but replaces it with IndexError, which makes debugging harder and breaks error handling in callers expecting filesystem-related exceptions.

Updated the exception handling to use a bare raise so the original exception type and traceback are preserved.

Applied the same fix to both writeFile and writeFileUJson.