### PR TITLE
feat: add model duplicate/clone functionality

### DIFF
--- a/API/Routes/Case/CaseRoute.py
+++ b/API/Routes/Case/CaseRoute.py
@@ -104,6 +104,62 @@ def copy():
     except OSError:
         raise OSError
 
+@case_api.route("/duplicateCase", methods=['POST'])
+def duplicateCase():
+    try:
+        source_case  = request.json['casename']
+        new_case     = request.json['newCasename']
+        active_case  = session.get('osycase')
+
+        if not active_case:
+            return jsonify({'message': 'No active session.', 'status_code': 'error'}), 403
+        if source_case != active_case:
+            return jsonify({'message': 'Select <b>' + source_case + '</b> first before duplicating it.', 'status_code': 'error'}), 403
+
+        # Sanitize new name
+        import re
+        new_case = new_case.strip()
+        if not new_case:
+            return jsonify({'message': 'New model name cannot be empty.', 'status_code': 'warning'}), 200
+        if re.search(r'[\\/:*?"<>|]', new_case):
+            return jsonify({'message': 'New model name contains invalid characters (<b>\\/:*?&quot;&lt;&gt;|</b>).', 'status_code': 'warning'}), 200
+
+        src  = Path(Config.DATA_STORAGE, source_case)
+        dest = Path(Config.DATA_STORAGE, new_case)
+
+        if os.path.isdir(dest):
+            return jsonify({
+                'message': 'Model <b>' + new_case + '</b> already exists. Please choose a different name.',
+                'status_code': 'warning'
+            }), 200
+
+        # Deep copy excluding res/ solver output directory
+        shutil.copytree(str(src), str(dest), ignore=shutil.ignore_patterns('res'))
+
+        # Recreate empty res/ directory structure
+        os.makedirs(Path(dest, 'res'), exist_ok=True)
+
+        # Reset resData.json so no stale result references exist
+        resDataPath = Path(dest, 'view', 'resData.json')
+        if os.path.isfile(resDataPath):
+            File.writeFile({'osy-cases': []}, resDataPath)
+
+        # Update osy-casename metadata in genData.json
+        genDataPath = Path(dest, 'genData.json')
+        if os.path.isfile(genDataPath):
+            genData = File.readFile(genDataPath)
+            genData['osy-casename'] = new_case
+            File.writeFile(genData, genDataPath)
+
+        return jsonify({
+            'message': 'Model <b>' + source_case + '</b> duplicated as <b>' + new_case + '</b>!',
+            'status_code': 'success',
+            'newCasename': new_case
+        }), 200
+
+    except (IOError, OSError) as e:
+        return jsonify({'message': str(e), 'status_code': 'error'}), 500
+
 @case_api.route("/deleteCase", methods=['POST'])
 def deleteCase():
     try:

--- a/WebAPP/App/Controller/Home.js
+++ b/WebAPP/App/Controller/Home.js
@@ -159,6 +159,8 @@ export default class Home {
             _currentDuplicateSource = $(this).attr('data-ps');
             // Pre-fill the input with a sensible default
             $('#duplicateCaseName').val(_currentDuplicateSource + '_copy');
+            // Programmatically open the modal since stopImmediatePropagation disables data-toggle
+            $('#modalDuplicate').modal('show');
         });
 
         $('#confirmDuplicate').off('click.homeDuplicateConfirm');

--- a/WebAPP/App/Controller/Home.js
+++ b/WebAPP/App/Controller/Home.js
@@ -150,7 +150,45 @@ export default class Home {
             });
         });
 
-        //get descrition
+        // duplicate case
+        let _currentDuplicateSource = null;
+        $(document).off('click', '.duplicateCS');
+        $("#cases").off('click', '.duplicateCS');
+        $("#cases").on('click.homeDuplicate', '.duplicateCS', function(e) {
+            e.stopImmediatePropagation();
+            _currentDuplicateSource = $(this).attr('data-ps');
+            // Pre-fill the input with a sensible default
+            $('#duplicateCaseName').val(_currentDuplicateSource + '_copy');
+        });
+
+        $('#confirmDuplicate').off('click.homeDuplicateConfirm');
+        $('#confirmDuplicate').on('click.homeDuplicateConfirm', function() {
+            if (!_currentDuplicateSource) return;
+            const newName = $('#duplicateCaseName').val().trim();
+            if (!newName) {
+                Message.bigBoxWarning('Duplicate message', 'Please enter a name for the new model.', 3000);
+                return;
+            }
+            Base.duplicateCaseStudy(_currentDuplicateSource, newName)
+            .then(response => {
+                $('#modalDuplicate').modal('hide');
+                Message.clearMessages();
+                if (response.status_code === 'success') {
+                    Message.bigBoxSuccess('Duplicate message', response.message, 3000);
+                    Html.apendModel(response.newCasename);
+                    Html.appendCasePicker(response.newCasename, null);
+                }
+                if (response.status_code === 'warning' || response.status_code === 'error') {
+                    Message.bigBoxWarning('Duplicate message', response.message, 4000);
+                }
+            })
+            .catch(error => {
+                $('#modalDuplicate').modal('hide');
+                Message.danger(error);
+            });
+        });
+
+        //get description
         $("#cases").off('click.homeDescription', '.descriptionPS');
         $("#cases").on('click.homeDescription', '.descriptionPS', function(e){
             //e.stopImmediatePropagation();

--- a/WebAPP/App/View/Home.html
+++ b/WebAPP/App/View/Home.html
@@ -127,3 +127,29 @@
     </div>
   </div>
 </div>
+
+<!--Modal Duplicate model -->
+<div id="modalDuplicate" class="modal fade" role="dialog">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+        <h4 class="modal-title"><i class="fa fa-copy osy"></i> Duplicate model</h4>
+      </div>
+      <div class="modal-body">
+        <p>Enter a name for the duplicate model:</p>
+        <div class="input-group">
+          <span class="input-group-addon"><i class="fa fa-tag"></i></span>
+          <input type="text" id="duplicateCaseName" class="form-control" placeholder="New model name" />
+        </div>
+        <small class="text-muted">The new model will be an independent copy without solver results.</small>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-primary" id="confirmDuplicate">
+          <i class="fa fa-copy"></i> Duplicate
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/WebAPP/App/View/Versions.html
+++ b/WebAPP/App/View/Versions.html
@@ -1,4 +1,10 @@
 
+
+<h3>MUIO ver.5.5.0, <small>20260322</small></h3>
+<ol style="font-style: italic; font-weight: normal;">
+    <li><kbd style="font-weight: bold; background-color:#6FB3E0">Func</kbd>&nbsp;Model Duplicate / Clone feature added. Users can duplicate an existing model from the Home page using the <i class="fa fa-copy"></i> button. The duplicate is a clean copy without solver results.</li>
+</ol>
+
 <h3>MUIO ver.5.4.0, <small>20260131</small></h3>
 <ol style="font-style: italic; font-weight: normal;">
     <li><kbd style="font-weight: bold; background-color:#c74219">Code</kbd>&nbsp;Default salvage value calculation has been changed from straight-line depreciation to sinking fund depreciation.</li>

--- a/WebAPP/Classes/Base.Class.js
+++ b/WebAPP/Classes/Base.Class.js
@@ -162,6 +162,26 @@ export class Base {
         });
     }
 
+    static duplicateCaseStudy(casename, newCasename) {
+        return new Promise((resolve, reject) => {
+            $.ajax({
+                url: this.apiUrl() + "duplicateCase",
+                async: true,
+                type: 'POST',
+                data: JSON.stringify({ "casename": casename, "newCasename": newCasename }),
+                dataType: 'json',
+                contentType: 'application/json; charset=utf-8',
+                success: function (result) {
+                    resolve(result);
+                },
+                error: function (xhr, status, error) {
+                    if (xhr.responseJSON && xhr.responseJSON.message) { error = xhr.responseJSON.message }
+                    reject(error);
+                }
+            });
+        });
+    }
+
     static deleteCaseStudy(casename) {
         return new Promise((resolve, reject) => {
             $.ajax({

--- a/WebAPP/Classes/Html.Class.js
+++ b/WebAPP/Classes/Html.Class.js
@@ -51,6 +51,13 @@ export class Html {
                                 </span>
                             </td>
                             <td style="width:40px; text-align:center">
+                                <span data-toggle="modal" data-target="#modalDuplicate">
+                                    <span class="duplicateCS" data-ps="${value}" data-toggle="tooltip" data-placement="top" title="Duplicate model">
+                                        <span class="glyphicon glyphicon-copy text-info icon-btn"></span>
+                                    </span>
+                                </span>
+                            </td>
+                            <td style="width:40px; text-align:center">
                                 <span data-toggle="modal" data-target="#modalcopy">
                                     <span class="copyCS" data-ps="${value}" id="copy_${value}" data-toggle="tooltip" data-placement="top" title="${selectedCS == value ? 'Copy model' : 'Select model first to copy'}">
                                         <span class="glyphicon glyphicon-duplicate text-info icon-btn"></span>


### PR DESCRIPTION
## Linked issue

- Closes #219

## Existing related work reviewed

- Issues/PRs reviewed: None found after search

## Overlap assessment

- Classification: none
- Overlapping items: None
- Why this is not duplicate/superseded: No existing PR addresses Issue #219. This is the first implementation of the Model Duplicate / Clone feature.

## Why this PR should proceed

- The current workaround (export ZIP → rename → re-upload) is slow and unnecessary. This PR implements the feature as fully described in Issue #219 and satisfies all of its acceptance criteria.

## Summary

- What changed:
  - [CaseRoute.py](cci:7://file:///c:/Users/Muhammed%20Naif/Desktop/Work/GSOC%202026/United%20Nations%20Office%20of%20Information%20Communication%20Technology/MUIOGO/API/Routes/Case/CaseRoute.py:0:0-0:0) — New `/duplicateCase` endpoint: deep copies model directory, skips [res/](cci:1://file:///c:/Users/Muhammed%20Naif/Desktop/Work/GSOC%202026/United%20Nations%20Office%20of%20Information%20Communication%20Technology/MUIOGO/WebAPP/Classes/Html.Class.js:325:4-334:5), resets `resData.json`, updates `osy-casename` in `genData.json`, sanitizes case name.
  - [Base.Class.js](cci:7://file:///c:/Users/Muhammed%20Naif/Desktop/Work/GSOC%202026/United%20Nations%20Office%20of%20Information%20Communication%20Technology/MUIOGO/WebAPP/Classes/Base.Class.js:0:0-0:0) — New [duplicateCaseStudy()](cci:1://file:///c:/Users/Muhammed%20Naif/Desktop/Work/GSOC%202026/United%20Nations%20Office%20of%20Information%20Communication%20Technology/MUIOGO/WebAPP/Classes/Base.Class.js:164:4-182:5) method to call the endpoint.
  - [Html.Class.js](cci:7://file:///c:/Users/Muhammed%20Naif/Desktop/Work/GSOC%202026/United%20Nations%20Office%20of%20Information%20Communication%20Technology/MUIOGO/WebAPP/Classes/Html.Class.js:0:0-0:0) — Duplicate button added to the model card actions.
  - [Home.html](cci:7://file:///c:/Users/Muhammed%20Naif/Desktop/Work/GSOC%202026/United%20Nations%20Office%20of%20Information%20Communication%20Technology/MUIOGO/WebAPP/App/View/Home.html:0:0-0:0) — New `#modalDuplicate` modal with a name input field.
  - [Home.js](cci:7://file:///c:/Users/Muhammed%20Naif/Desktop/Work/GSOC%202026/United%20Nations%20Office%20of%20Information%20Communication%20Technology/MUIOGO/WebAPP/App/Controller/Home.js:0:0-0:0) — Event handler: pre-fills modal, calls API, refreshes model list on success.
  - [Versions.html](cci:7://file:///c:/Users/Muhammed%20Naif/Desktop/Work/GSOC%202026/United%20Nations%20Office%20of%20Information%20Communication%20Technology/MUIOGO/WebAPP/App/View/Versions.html:0:0-0:0) — Changelog updated.
- Why: Addresses all acceptance criteria from Issue #219. Feature is purely additive and does not modify any existing behaviour.

## Validation

- [x] Tests added/updated (or not applicable — no automated tests exist in this repo)
- [x] Validation steps documented
- [x] Evidence attached (screenshots below)

Manual verification steps:
1. Open the app Home page.
2. Click the Duplicate icon on a model card — a modal appears pre-filled with `<modelname>_copy`.
3. Enter a new name and click Confirm.
4. The new model appears immediately in the model list.
5. Select the new model — the Run tab shows no previous [results.](`url`)
6. The original model is untouched.
7. Attempting to duplicate with an already-existing name shows a warning and aborts.
8. Attempting to use invalid characters (e.g. `/`, `\`, `*`) shows a warning and aborts.

*(Screenshots attached below)*

<img width="1919" height="990" alt="image" src="https://github.com/user-attachments/assets/1095d490-5275-47da-a379-232f9a607ce8" />

<img width="1919" height="992" alt="image" src="https://github.com/user-attachments/assets/b1f2ad11-efa7-4ebe-afc3-0f6db97f186e" />

<img width="1919" height="990" alt="image" src="https://github.com/user-attachments/assets/e1c8c507-bf6f-47a6-a1d0-23d57c22484c" />

## Documentation

- [x] [Versions.html](cci:7://file:///c:/Users/Muhammed%20Naif/Desktop/Work/GSOC%202026/United%20Nations%20Office%20of%20Information%20Communication%20Technology/MUIOGO/WebAPP/App/View/Versions.html:0:0-0:0) changelog updated.
- [x] No setup/workflow changes required.

## Scope check

- [x] No unrelated refactors
- [x] Implemented from feature branch `feature/model-duplicate-clone`
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main`

## Exception rationale

- N/A

