### PR TITLE
fix: use casename instead of case for resData and viewDefinitions paths in handle_full_zip

### DIFF
--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -462,8 +462,8 @@ def handle_full_zip(file, filepath=None):
                                 viewDef[list['id']] = []
                         resPath = Path(Config.DATA_STORAGE,casename,'res')
                         viewPath = Path(Config.DATA_STORAGE,casename,'view')
-                        resDataPath = Path(Config.DATA_STORAGE,case,'view','resData.json')
-                        viewDataPath = Path(Config.DATA_STORAGE,case,'view','viewDefinitions.json')
+                        resDataPath = Path(Config.DATA_STORAGE,casename,'view','resData.json')
+                        viewDataPath = Path(Config.DATA_STORAGE,casename,'view','viewDefinitions.json')
                         if os.path.exists(resPath):
                             shutil.rmtree(resPath)
                         if os.path.exists(viewPath):


### PR DESCRIPTION
## Summary

Fixes incorrect variable usage in `handle_full_zip()` where `case` (ZIP filename) was used instead of `casename` (internal folder name) when constructing paths for `resData.json` and `viewDefinitions.json`.

**Root cause:** `case` is derived from `os.path.splitext(submitted_file)[0]` (the ZIP filename), while `casename` is derived from `zippedfilepath.parent.name` (the folder inside the ZIP). When these differ — which happens during chunked uploads where the ZIP is named with a UUID — the files are written to a non-existent or wrong directory.

**Lines 463–464** already use `casename` correctly for `resPath` and `viewPath`. Lines 465–466 were inconsistent.

## Changes

- `API/Routes/Upload/UploadRoute.py` line 465: `case` → `casename`
- `API/Routes/Upload/UploadRoute.py` line 466: `case` → `casename`

## Test plan

- [ ] Upload a model ZIP where the filename differs from the internal folder name
- [ ] Verify `resData.json` and `viewDefinitions.json` are created in the correct model directory
- [ ] Verify chunked uploads still work correctly

Fixes #359

@SeaCelo 