### PR TITLE
fix: use submitted_file instead of undefined filename in uploadXls error response

### DIFF
--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -641,7 +641,7 @@ def uploadXls():
                     "message": "Template " + submitted_file +" is not valid .xlsx file!",
                     "status_code": "warning",
                     "casename": case,
-                    "template": filename
+                    "template": submitted_file
                 })
 
         response = {


### PR DESCRIPTION
## Summary

Fixes a `NameError` crash in `uploadXls()` when an uploaded file has an invalid extension.

**Root cause:** The `filename` variable is only defined inside the `if` branch (via `secure_filename()`), but the `else` branch (invalid extension) also references `filename` on line 644. If the first uploaded file has an invalid extension, `filename` is never assigned, causing the server to crash.

## Changes

- `API/Routes/Upload/UploadRoute.py` line 644: `filename` → `submitted_file`

## Test plan

- [ ] Upload an `.xlsx` file — verify success response includes correct template name
- [ ] Upload a non-xlsx file (e.g., `.txt`) — verify error response returns without crash
- [ ] Upload multiple files with mix of valid and invalid extensions — verify all responses are correct

Fixes #360

@SeaCelo 