### PR TITLE
[AUTO] Daily update: fix Home copy S3 pre-sync target

### DIFF
--- a/API/Routes/Case/CaseRoute.py
+++ b/API/Routes/Case/CaseRoute.py
@@ -86,7 +86,8 @@ def copy():
         if(os.path.isdir(dest)):
             response = {
                 "message": 'Model <b>'+ case + '_copy</b> already exists, please rename existing model first!',
-                "status_code": "warning"
+                "status_code": "warning",
+                "casename": case_copy
             }
         else:
             shutil.copytree(str(src), str(dest) )
@@ -96,7 +97,8 @@ def copy():
             File.writeFile(genData, casePath)
             response = {
                 "message": 'Model <b>'+ case + '</b> copied!',
-                "status_code": "success"
+                "status_code": "success",
+                "casename": case_copy
             }
         return jsonify(response), 200
     except(IOError):

--- a/API/Routes/Case/SyncS3Route.py
+++ b/API/Routes/Case/SyncS3Route.py
@@ -14,8 +14,10 @@ def deleteResultsPreSync():
         
         resPath = Path(Config.DATA_STORAGE, case, 'res')
         dataPath = Path(Config.DATA_STORAGE, case, 'data.txt')
-        shutil.rmtree(resPath)
-        os.remove(dataPath)
+        if resPath.exists():
+            shutil.rmtree(resPath)
+        if dataPath.exists():
+            os.remove(dataPath)
 
         response = {
             "message": 'Case <b>'+ case + '</b> deleted!',

--- a/WebAPP/App/Controller/Home.js
+++ b/WebAPP/App/Controller/Home.js
@@ -120,7 +120,6 @@ export default class Home {
         $("#cases").on('click.homeCopy', '.copyCS', function(e){
             e.stopImmediatePropagation();
             var casename = $(this).attr('data-ps');
-            var copiedCaseName = casename + '_copy';
             if (casename !== model.casename) {
                 Message.bigBoxWarning('Copy message',
                     'Select <b>' + casename + '</b> first to copy it.', 4000);
@@ -129,6 +128,7 @@ export default class Home {
             Base.copyCaseStudy(casename)
             .then(response => {
                 Message.clearMessages();
+                var copiedCaseName = response.casename || (casename + '_copy');
                 if(response.status_code=="success"){
                     Message.bigBoxSuccess('Copy message', response.message, 3000);
                     //REFRESH

--- a/WebAPP/App/Controller/Home.js
+++ b/WebAPP/App/Controller/Home.js
@@ -120,6 +120,7 @@ export default class Home {
         $("#cases").on('click.homeCopy', '.copyCS', function(e){
             e.stopImmediatePropagation();
             var casename = $(this).attr('data-ps');
+            var copiedCaseName = casename + '_copy';
             if (casename !== model.casename) {
                 Message.bigBoxWarning('Copy message',
                     'Select <b>' + casename + '</b> first to copy it.', 4000);
@@ -131,12 +132,12 @@ export default class Home {
                 if(response.status_code=="success"){
                     Message.bigBoxSuccess('Copy message', response.message, 3000);
                     //REFRESH
-                    Html.apendModel(casename+'_copy');
-                    Html.appendCasePicker(casename+'_copy', null)
+                    Html.apendModel(copiedCaseName);
+                    Html.appendCasePicker(copiedCaseName, null)
                     if (Base.AWS_SYNC == 1){
-                        SyncS3.deleteResultsPreSync(casename)
+                        SyncS3.deleteResultsPreSync(copiedCaseName)
                         .then(response =>{
-                            SyncS3.uploadSync(casename+'_copy');
+                            SyncS3.uploadSync(copiedCaseName);
                         });  
                     }
                 }


### PR DESCRIPTION
- clear pre-sync artifacts for the copied case instead of the source case on Home page copy
- tolerate missing res/data artifacts during pre-sync cleanup so first-time syncs do not fail
- preserve existing Home copy/delete selection safeguards and handler cleanup behavior

## Linked issue

- Closes #
- Related #

## Existing related work reviewed

- Issues/PRs reviewed:
- If none found, write: None found after search

## Overlap assessment

- Classification:
- Overlapping items:
- Why this is not duplicate/superseded:

## Why this PR should proceed

- 

## Summary

- What changed:
- Why:

## Validation

- [ ] Tests added/updated (or not applicable)
- [ ] Validation steps documented
- [ ] Evidence attached (logs/screenshots/output as relevant)

## Documentation

- [ ] Docs updated in this PR (or not applicable)
- [ ] Any setup/workflow changes reflected in repo docs

## Scope check

- [ ] No unrelated refactors
- [ ] Implemented from a feature branch
- [ ] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [ ] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

## Exception rationale

- Only for narrow docs/typo PRs that do not use a linked issue.
- Leave blank otherwise.
