### PR TITLE
Fix parameters definitions panel content clipping on AddCase page

### DIFF
--- a/WebAPP/References/smartadmin/css/osy.css
+++ b/WebAPP/References/smartadmin/css/osy.css
@@ -658,8 +658,8 @@ li {
 
 .dropdown-menu-extra-wide{
     min-width: 0!important;
-    width: min(1520px, calc(100vw - 120px))!important;
-    max-width: calc(100vw - 120px)!important;
+    width: calc(100vw - 120px)!important;
+    max-width: 1520px!important;
     z-index: 9000!important;
     padding: 20px!important;
     overflow-x: auto;

--- a/WebAPP/References/smartadmin/css/osy.css
+++ b/WebAPP/References/smartadmin/css/osy.css
@@ -657,9 +657,12 @@ li {
 }
 
 .dropdown-menu-extra-wide{
-    min-width: 1520px!important;
+    min-width: 0!important;
+    width: min(1520px, calc(100vw - 120px))!important;
+    max-width: calc(100vw - 120px)!important;
     z-index: 9000!important;
     padding: 20px!important;
+    overflow-x: auto;
     /* padding-top: 15px!important; */
 }
 


### PR DESCRIPTION
## Summary
Fixes content clipping in the Parameters definitions panel on the 
Model configuration page.

## Linked issue
Closes #366

## Change made
Modified `.dropdown-menu-extra-wide` class in `osy.css`:
- Changed `min-width: 1520px` to `min-width: 0` to prevent the panel 
  from overflowing the viewport
- Added `width: min(1520px, calc(100vw - 120px))` so the panel respects 
  the viewport width
- Added `max-width: calc(100vw - 120px)` to cap the panel within screen bounds
- Added `overflow-x: auto` to enable horizontal scrolling when content 
  exceeds the panel width

## Related work reviewed
None found.

## Overlap classification
None

## Why this PR should proceed
Minimal fix for a confirmed UI bug. No architectural changes.