### PR TITLE
Fix #372: Remove redundant manual CORS headers in app.py

### DIFF
--- a/API/app.py
+++ b/API/app.py
@@ -66,20 +66,6 @@ app.register_blueprint(syncs3_api)
 
 CORS(app)
 
-#potrebno kad je front end na drugom serveru 127.0.0.1
-@app.after_request
-def add_headers(response):
-    if Config.HEROKU_DEPLOY == 0: 
-        #localhost
-        response.headers.add('Access-Control-Allow-Origin', 'http://127.0.0.1')
-    else:
-        #HEROKU
-        response.headers.add('Access-Control-Allow-Origin', 'https://osemosys.herokuapp.com/')
-    response.headers.add('Access-Control-Allow-Credentials', 'true')
-    response.headers.add('Access-Control-Allow-Headers', 'Content-Type, Authorization')
-    #response.headers['Content-Type'] = 'application/javascript'
-    return response
-
 # @app.errorhandler(CustomException)
 # def handle_invalid_usage(error):
 #     response = jsonify(error.to_dict())


### PR DESCRIPTION
## Linked issue

- Closes #372
- Related #

## Existing related work reviewed

- Issues/PRs reviewed:
- If none found, write: None found after search

## Overlap assessment

- Classification: none
- Overlapping items: N/A
- Why this is not duplicate/superseded: N/A

## Why this PR should proceed

- Resolves a network security conflict caused by legacy technical debt.

## Summary

- What changed: Removed the legacy `@app.after_request` block in `API/app.py` that manually injected CORS headers.
- Why: The application already utilizes the `Flask-CORS` middleware (`CORS(app)`). The manual hook was injecting duplicate `Access-Control-Allow-Origin` headers (violating W3C specs) and hardcoding an invalid portless localhost origin along with dead Heroku routes. Removing it allows `Flask-CORS` to handle cross-origin requests securely and dynamically.

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

*Validation steps:* Verified that `API/app.py` compiles and the local Flask server runs successfully without the removed block, allowing `Flask-CORS` to handle headers normally.

## Documentation

- [x] Docs updated in this PR (or not applicable)
- [x] Any setup/workflow changes reflected in repo docs

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

## Exception rationale

-