### PR TITLE
fix(#328): close file handle in readDataFile using context manager

### DIFF
--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -1073,9 +1073,8 @@ class DataFile(Osemosys):
             #f = open(self.dataFile, mode="r")
             dataFilePath = Path(Config.DATA_STORAGE, self.case, 'res',caserunname,'data.txt')
             if os.path.exists(dataFilePath):
-                f = open(dataFilePath, mode="r", encoding='utf-8-sig')
-                data =  f.read()
-                f.close
+                with open(dataFilePath, mode="r", encoding='utf-8-sig') as f:
+                    data = f.read()
             else:
                 data = None
 

--- a/test_issue_328.py
+++ b/test_issue_328.py
@@ -1,0 +1,52 @@
+"""
+Test for Issue #328: File handle not closed in readDataFile.
+Verifies that the `with open()` pattern is used instead of bare `f.close` (no parens).
+"""
+import sys
+import inspect
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'API'))
+
+from API.Classes.Case.DataFileClass import DataFile
+
+
+def run_tests():
+    passed = 0
+    failed = 0
+
+    # Test 1: Check that readDataFile uses 'with open' (context manager)
+    source = inspect.getsource(DataFile.readDataFile)
+
+    if 'with open(' in source:
+        print("PASS: readDataFile uses 'with open()' context manager")
+        passed += 1
+    else:
+        print("FAIL: readDataFile does not use 'with open()' context manager")
+        failed += 1
+
+    # Test 2: Check that bare 'f.close' (without parens) is NOT present
+    # Split lines and check for 'f.close' that isn't 'f.close()'
+    lines = source.split('\n')
+    has_bare_close = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith('#'):
+            continue
+        if 'f.close' in stripped and 'f.close()' not in stripped:
+            has_bare_close = True
+            break
+
+    if not has_bare_close:
+        print("PASS: no bare 'f.close' (without parentheses) found")
+        passed += 1
+    else:
+        print("FAIL: bare 'f.close' still present — file handle leak!")
+        failed += 1
+
+    print(f"\nResults: {passed} passed, {failed} failed")
+    sys.exit(0 if failed == 0 else 1)
+
+
+if __name__ == "__main__":
+    run_tests()


### PR DESCRIPTION
readDataFile used f.close without parentheses, meaning the file descriptor was never actually closed. Replaced with a `with open()` context manager that guarantees automatic closure.

## Linked issue

- Closes #328

## Existing related work reviewed

- Issues/PRs reviewed: None found after search

## Overlap assessment

- Classification: none
- Overlapping items: none
- Why this is not duplicate/superseded: no existing PR addresses the unclosed file handle in readDataFile

## Why this PR should proceed

Issue #328 documents a confirmed bug where `f.close` (without parentheses) is a no-op, causing file descriptor leaks under repeated calls. This PR applies the standard Python fix using a `with` context manager.

## Summary

- What changed: Replaced bare `f.close` with `with open() as f:` context manager in `readDataFile` (`API/Classes/Case/DataFileClass.py`)
- Why: `f.close` without `()` is a no-op — the file is never closed, leaking OS file handles under repeated calls

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

## Documentation

- [x] Docs updated in this PR (or not applicable)
- [x] Any setup/workflow changes reflected in repo docs

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

## Exception rationale

