### PR TITLE
Validate model version during model load

### DIFF
--- a/API/Classes/Base/ModelVersionClass.py
+++ b/API/Classes/Base/ModelVersionClass.py
@@ -1,0 +1,79 @@
+import logging
+
+from Classes.Base.CustomExceptionClass import CustomException
+
+CURRENT_MODEL_VERSION = "5.0"
+
+
+class ModelVersionError(CustomException):
+    def __init__(self, message, case=None, detected_version=None, expected_version=None):
+        payload = {
+            "status_code": "version_mismatch",
+            "case": case,
+            "detected_version": detected_version,
+            "expected_version": expected_version or CURRENT_MODEL_VERSION,
+        }
+        CustomException.__init__(self, message, status_code=409, payload=payload)
+
+
+def get_model_version(genData):
+    if not isinstance(genData, dict):
+        return None
+
+    version = genData.get("modelVersion")
+    if version is None:
+        version = genData.get("osy-version")
+
+    if version is None:
+        return None
+
+    version = str(version).strip()
+    return version or None
+
+
+def stamp_model_version(genData, version=CURRENT_MODEL_VERSION):
+    if genData is None:
+        return genData
+
+    version = str(version).strip() or CURRENT_MODEL_VERSION
+    genData["modelVersion"] = version
+    genData["osy-version"] = version
+    return genData
+
+
+def validate_model_version(genData, case=None):
+    detected_version = get_model_version(genData)
+
+    if detected_version == CURRENT_MODEL_VERSION:
+        return detected_version
+
+    if case:
+        case_label = f"Model <b>{case}</b>"
+    else:
+        case_label = "Selected model"
+
+    if detected_version is None:
+        message = (
+            f"{case_label} is missing schema version metadata. "
+            f"Open the model configuration page and click <b>Update model</b> "
+            f"before generating data or running the solver."
+        )
+    else:
+        message = (
+            f"{case_label} uses schema version <b>{detected_version}</b>, but the current backend "
+            f"expects <b>{CURRENT_MODEL_VERSION}</b>. Open the model configuration page and click "
+            f"<b>Update model</b> before generating data or running the solver."
+        )
+
+    logging.warning(
+        "Model version mismatch for case '%s': detected=%s expected=%s",
+        case,
+        detected_version,
+        CURRENT_MODEL_VERSION,
+    )
+    raise ModelVersionError(
+        message,
+        case=case,
+        detected_version=detected_version,
+        expected_version=CURRENT_MODEL_VERSION,
+    )

--- a/API/Classes/Case/ImportTemplate.py
+++ b/API/Classes/Case/ImportTemplate.py
@@ -5,6 +5,7 @@ import string, random, json, os.path, time
 from Classes.Base import Config
 from Classes.Case.CaseClass import Case
 from Classes.Base.FileClass import File
+from Classes.Base.ModelVersionClass import stamp_model_version
 
 class ImportTemplate():
     def __init__(self,template):
@@ -814,6 +815,7 @@ class ImportTemplate():
             genData["osy-scenarios"] = self.defaultScenario(True)
             genData["osy-constraints"] = []
             genData["osy-years"] = yearsArray
+            stamp_model_version(genData, version)
 
             casename = genData['osy-casename']
 

--- a/API/Classes/Case/OsemosysClass.py
+++ b/API/Classes/Case/OsemosysClass.py
@@ -4,6 +4,7 @@ import platform
 import shutil
 from Classes.Base import Config
 from Classes.Base.FileClass import File
+from Classes.Base.ModelVersionClass import validate_model_version
 
 class Osemosys():
     def __init__(self, case):
@@ -11,6 +12,7 @@ class Osemosys():
         self.PARAMETERS = File.readParamFile(Path(Config.DATA_STORAGE, 'Parameters.json'))
         self.VARIABLES = File.readParamFile(Path(Config.DATA_STORAGE, 'Variables.json'))
         self.genData =  File.readFile(Path(Config.DATA_STORAGE,case,'genData.json'))
+        validate_model_version(self.genData, case)
         self.resData = File.readFile( Path(Config.DATA_STORAGE, case,'view', 'resData.json'))
         
         #Case.__init__(self, case)

--- a/API/Routes/Case/CaseRoute.py
+++ b/API/Routes/Case/CaseRoute.py
@@ -5,6 +5,7 @@ import shutil
 import pandas as pd
 from Classes.Base import Config
 from Classes.Base.FileClass import File
+from Classes.Base.ModelVersionClass import stamp_model_version
 from Classes.Case.CaseClass import Case
 from Classes.Case.UpdateCaseClass import UpdateCase
 from Classes.Case.ImportTemplate import ImportTemplate
@@ -248,6 +249,7 @@ def updateData():
 def saveCase():
     try:
         genData = request.json['data']
+        stamp_model_version(genData)
         casename = genData['osy-casename']
         case = session.get('osycase', None)
 

--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -9,6 +9,7 @@ from threading import Thread
 
 from Classes.Base import Config
 from Classes.Base.FileClass import File
+from Classes.Base.ModelVersionClass import stamp_model_version
 
 upload_api = Blueprint('UploadRoute', __name__)
 
@@ -137,6 +138,12 @@ def updateStorageSet(casename):
     genData["osy-stg"] = []
 
     File.writeFile( genData, genDataPath)
+
+def stampCurrentModelVersion(casename):
+    genDataPath = Path(Config.DATA_STORAGE, casename, 'genData.json')
+    genData = File.readParamFile(genDataPath)
+    stamp_model_version(genData)
+    File.writeFile(genData, genDataPath)
 
 def updateViewDefintions(casename):
     viewDataPath = Path(Config.DATA_STORAGE,casename,'view','viewDefinitions.json')
@@ -371,6 +378,7 @@ def uploadCaseUnchunked_old():
                                 elif name == '5.0': 
                                     zf.extractall(os.path.join(Config.EXTRACT_FOLDER))
                                     updateViewDefintions(casename)
+                                    stampCurrentModelVersion(casename)
                                     msg.append({
                                         "message": "Model " + casename +" have been uploaded!",
                                         "status_code": "success",
@@ -511,6 +519,7 @@ def handle_full_zip(file, filepath=None):
                     elif name == '5.0':
                         zf.extractall(os.path.join(Config.EXTRACT_FOLDER))
                         updateViewDefintions(casename)
+                        stampCurrentModelVersion(casename)
                         msg.append({
                             "message": "Model " + casename +" have been uploaded!",
                             "status_code": "success",

--- a/API/app.py
+++ b/API/app.py
@@ -27,6 +27,7 @@ from datetime import timedelta
 
 #import json
 from Classes.Base import Config
+from Classes.Base.CustomExceptionClass import CustomException
 # from API.Classes.Base.SyncS3 import SyncS3
 from Routes.Upload.UploadRoute import upload_api
 from Routes.Case.CaseRoute import case_api
@@ -97,11 +98,11 @@ def add_headers(response):
     #response.headers['Content-Type'] = 'application/javascript'
     return response
 
-# @app.errorhandler(CustomException)
-# def handle_invalid_usage(error):
-#     response = jsonify(error.to_dict())
-#     response.status_code = error.status_code
-#     return response
+@app.errorhandler(CustomException)
+def handle_invalid_usage(error):
+    response = jsonify(error.to_dict())
+    response.status_code = error.status_code
+    return response
 
 #entry point to frontend
 @app.route("/", methods=['GET'])

--- a/WebAPP/App/Controller/AddCase.js
+++ b/WebAPP/App/Controller/AddCase.js
@@ -229,6 +229,7 @@ export default class AddCase {
             });
 
             let POSTDATA = {
+                "modelVersion": "5.0",
                 "osy-version": "5.0",
                 "osy-casename": casename,
                 "osy-desc": desc,
@@ -1140,7 +1141,6 @@ export default class AddCase {
         });
     }
 }
-
 
 
 

--- a/WebAPP/App/Controller/Home.js
+++ b/WebAPP/App/Controller/Home.js
@@ -85,12 +85,11 @@ export default class Home {
             //Sidebar.Load(casename, model.genData, model.PARAMETERS);
             Osemosys.getData(casename, 'genData.json')
             .then(genData => {
-                //console.log('genData ', genData["osy-version"])
+                let modelVersion = parseFloat(genData.modelVersion || genData["osy-version"] || 0);
                 Home.refreshPage(casename);
                 Message.smallBoxInfo("Case selection", casename + " is selected!", 3000);
-                if(parseFloat(genData["osy-version"]) < 4.5){
-                    //console.log('manje od 4.5')
-                    Message.bigBoxWarning("Warning", "You have selected a model created in a earlier version of this UI. In order to update to the current version click <b>Update model</b> on the configuration page.", 10000);
+                if(modelVersion < 5.0){
+                    Message.bigBoxWarning("Warning", "You have selected a model created with an older schema version. Open <b>Model configuration</b> and click <b>Update model</b> before generating data or running the solver.", 10000);
                 }
             })
         });

--- a/WebAPP/App/Controller/LegacyImport.js
+++ b/WebAPP/App/Controller/LegacyImport.js
@@ -117,6 +117,7 @@ export default class LegacyImport {
             }
 
             let POSTDATA = {
+                "modelVersion": "5.0",
                 "osy-version": "5.0",
                 "osy-casename": casename,
                 "osy-desc": desc,

--- a/WebAPP/Classes/Base.Class.js
+++ b/WebAPP/Classes/Base.Class.js
@@ -2,6 +2,13 @@ import { Message } from "./Message.Class.js";
 import { Html } from "./Html.Class.js";
 import { SyncS3 } from "./SyncS3.Class.js";
 
+function getApiError(xhr, error) {
+    if (xhr && xhr.responseJSON && xhr.responseJSON.message) {
+        return xhr.responseJSON.message;
+    }
+    return error;
+}
+
 export class Base {
     static HEROKU = 0;
     static AWS_SYNC = 0;
@@ -29,8 +36,7 @@ export class Base {
                     resolve(result);
                 },
                 error: function (xhr, status, error) {
-                    if (error == 'UNKNOWN') { error = xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -50,8 +56,7 @@ export class Base {
                     resolve(result);
                 },
                 error: function (xhr, status, error) {
-                    if (error == 'UNKNOWN') { error = xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -73,8 +78,7 @@ export class Base {
                     resolve(result);
                 },
                 error: function (xhr, status, error) {
-                    if (error == 'UNKNOWN') { error = xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -93,9 +97,7 @@ export class Base {
                     resolve(result);
                 },
                 error: function (xhr, status, error) {
-                    if (error == 'UNKNOWN') { error = xhr.responseJSON.message }
-
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -114,8 +116,7 @@ export class Base {
                     resolve(result);
                 },
                 error: function (xhr, status, error) {
-                    if (error == 'UNKNOWN') { error = xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -134,8 +135,7 @@ export class Base {
                     resolve(result);
                 },
                 error: function (xhr, status, error) {
-                    if (error == 'UNKNOWN') { error = xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -154,9 +154,7 @@ export class Base {
                     resolve(result);
                 },
                 error: function (xhr, status, error) {
-                    //custom exception
-                    if (xhr.responseJSON && xhr.responseJSON.message) { error = xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -175,9 +173,7 @@ export class Base {
                     resolve(result);
                 },
                 error: function (xhr, status, error) {
-                    //custom exception
-                    if (xhr.responseJSON && xhr.responseJSON.message) { error = xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -196,9 +192,7 @@ export class Base {
                     resolve(result);
                 },
                 error: function (xhr, status, error) {
-                    //custom exception
-                    if (error == 'UNKNOWN') { error = xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -219,9 +213,7 @@ export class Base {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    //custom exception
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });

--- a/WebAPP/Classes/Osemosys.Class.js
+++ b/WebAPP/Classes/Osemosys.Class.js
@@ -1,5 +1,12 @@
 import { Base } from "./Base.Class.js";
 
+function getApiError(xhr, error) {
+    if (xhr && xhr.responseJSON && xhr.responseJSON.message) {
+        return xhr.responseJSON.message;
+    }
+    return error;
+}
+
 export class Osemosys {
     
     static getParamFile(dataJson='Parameters.json') {
@@ -16,8 +23,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -37,8 +43,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -57,8 +62,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -80,8 +84,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -100,8 +103,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -120,8 +122,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -143,8 +144,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -166,8 +166,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -186,8 +185,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -209,8 +207,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -233,8 +230,7 @@ export class Osemosys {
                 },
                 error: function(xhr, status, error) {
                     console.log("xhr, status, error ", xhr, status, error )
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -257,8 +253,7 @@ export class Osemosys {
                 },
                 error: function(xhr, status, error) {
                     console.log("xhr, status, error ", xhr, status, error )
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -281,8 +276,7 @@ export class Osemosys {
                 },
                 error: function(xhr, status, error) {
                     console.log("xhr, status, error ", xhr, status, error )
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -304,8 +298,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -327,8 +320,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -347,8 +339,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -466,8 +457,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -486,8 +476,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -521,8 +510,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -542,8 +530,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -563,8 +550,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });
@@ -583,8 +569,7 @@ export class Osemosys {
                     resolve(result);
                 },
                 error: function(xhr, status, error) {
-                    if(error == 'UNKNOWN'){ error =  xhr.responseJSON.message }
-                    reject(error);
+                    reject(getApiError(xhr, error));
                 }
             });
         });


### PR DESCRIPTION
## Linked issue

- Closes #172
- Related #173

## Existing related work reviewed

- Issues/PRs reviewed: #172, #173
- If none found, write: None found after search

## Overlap assessment

- Classification: Related follow-up, not duplicate
- Overlapping items:
  - #172 enforces schema version validation during model load
  - #173 is a broader schema migration framework for legacy models
- Why this is not duplicate/superseded:
  - This PR adds fail-fast validation and version stamping for current models
  - It does not implement automatic migration of legacy schemas
  - Legacy update/migration work can still build on top of this contract later

## Why this PR should proceed

- It establishes a centralized schema-version contract in the backend instead of relying on scattered checks
- It prevents legacy or malformed cases from reaching run/view workflows and failing later in less clear ways
- It preserves the existing “select old model, then update it from configuration” workflow instead of blocking case selection entirely
- It improves user feedback by surfacing the backend version-mismatch message in the frontend

## Summary

- What changed:
  - Added a centralized model version helper in `API/Classes/Base/ModelVersionClass.py`
  - Added structured `version_mismatch` errors for missing or incompatible schema versions
  - Enabled the existing `CustomException` JSON error handler in `API/app.py`
  - Validated schema version when loading model data in `OsemosysClass`
  - Stamped `modelVersion` alongside `osy-version` when saving new/current models and importing templates
  - Backfilled `modelVersion` for uploaded `5.0` archives without changing the legacy upload/update flow
  - Updated frontend error handling to consistently surface backend messages
  - Added a Home-page warning for older schema versions using `modelVersion || osy-version`
- Why:
  - To enforce model-version compatibility at the point where run/view workflows actually depend on the schema
  - To give users a clear upgrade path instead of allowing incompatible models to fail deeper in the workflow

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

Validation performed:
- `python3 -m py_compile` on all changed Python files
- Helper smoke tests for:
  - current version acceptance
  - legacy version rejection
  - missing version metadata rejection
- Flask test client smoke test confirming `viewData` returns `409` with `version_mismatch`
- Playwright smoke tests confirming:
  - current-schema case selection does not show legacy warning
  - legacy-schema case selection shows the warning
  - ViewData displays the backend version-mismatch message
- Upload smoke test confirming a `5.0` archive missing `modelVersion` is backfilled on restore

## Documentation

- [x] Docs updated in this PR (or not applicable)
- [x] Any setup/workflow changes reflected in repo docs

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

## Exception rationale

