### PR TITLE
governance(#255): enforce required related-work field and disable bla…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,7 +43,7 @@ body:
       label: Related work checked
       description: List anything relevant you checked before opening this issue. Use issue/PR numbers like #123, or write `None found after search`.
     validations:
-      required: false
+      required: true
   - type: dropdown
     id: proposed_track
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Project support guide
     url: https://github.com/EAPD-DRB/MUIOGO/blob/main/SUPPORT.md

--- a/.github/ISSUE_TEMPLATE/feature_task.yml
+++ b/.github/ISSUE_TEMPLATE/feature_task.yml
@@ -40,7 +40,7 @@ body:
       label: Related work checked
       description: List anything relevant you checked before opening this issue. Use issue/PR numbers like #123, or write `None found after search`.
     validations:
-      required: false
+      required: true
   - type: dropdown
     id: proposed_track
     attributes:

--- a/.github/ISSUE_TEMPLATE/question_blocker.yml
+++ b/.github/ISSUE_TEMPLATE/question_blocker.yml
@@ -39,7 +39,7 @@ body:
       label: Related work checked
       description: List anything relevant you checked before opening this issue. Use issue/PR numbers like #123, or write `None found after search`.
     validations:
-      required: false
+      required: true
   - type: dropdown
     id: proposed_track
     attributes:


### PR DESCRIPTION
## Linked issue
Related #255
Related #299

## Existing related work reviewed
Issues/PRs reviewed: #255 (governance proposal), #299 (initial rollout)

## Overlap assessment
- Classification: complementary follow-up
- Overlapping items: #299 created the issue templates with the `related_work` field as optional
- Why this is not duplicate/superseded: #299 added the field but did not enforce it. #255 explicitly requires contributors to document related work. This PR tightens enforcement — 4 one-line YAML edits with no functional overlap.

## Why this PR should proceed
#255 states: "Issue form requires links to related existing issues/PRs." Currently the field exists but is optional, and blank issues bypass templates entirely. These two gaps allow contributors to skip the research-first requirement.

Note: `proposed_track` is intentionally left optional per CONTRIBUTING.md — track labels are assigned by maintainers.

## Summary
- What changed:
  - `related_work` validation set to `required: true` in `bug_report.yml`, `feature_task.yml`, `question_blocker.yml`
  - `blank_issues_enabled` set to `false` in `config.yml` — all issues must now use structured templates
- Why: enforces the research-first intake policy defined in #255. Blank issues allowed contributors to bypass required fields entirely.

```diff
# In all 3 issue templates
-      required: false
+      required: true

# In config.yml
-blank_issues_enabled: true
+blank_issues_enabled: false
