### PR TITLE
fix: replace hardcoded HEROKU URL with env-configurable API_BASE_URL

### DIFF
--- a/API/Classes/Base/Config.py
+++ b/API/Classes/Base/Config.py
@@ -78,7 +78,8 @@ if not os.access(DATA_STORAGE, os.W_OK):
 # EXTRACT_FOLDER = Path(OSEMOSYS_ROOT, "")
 # SOLVERs_FOLDER = Path(OSEMOSYS_ROOT, 'WebAPP', 'SOLVERs')
 
-HEROKU_DEPLOY = 0
+HEROKU_DEPLOY = int(os.environ.get("HEROKU_DEPLOY", 0))
+API_BASE_URL = os.environ.get("API_BASE_URL", "")
 AWS_SYNC = 0
 
 PINNED_COLUMNS = ('Sc', 'Tech', 'Comm', 'Emis','Stg', 'Ts', 'MoO', 'UnitId', 'Se','Dt', 'Dtb', 'paramName','TechName', 'CommName', 'EmisName', 'ConName', 'MoId')

--- a/API/app.py
+++ b/API/app.py
@@ -83,18 +83,12 @@ app.register_blueprint(syncs3_api)
 
 CORS(app)
 
-#potrebno kad je front end na drugom serveru 127.0.0.1
 @app.after_request
 def add_headers(response):
-    if Config.HEROKU_DEPLOY == 0: 
-        #localhost
-        response.headers.add('Access-Control-Allow-Origin', 'http://127.0.0.1')
-    else:
-        #HEROKU
-        response.headers.add('Access-Control-Allow-Origin', 'https://osemosys.herokuapp.com/')
+    allowed_origin = Config.API_BASE_URL if Config.API_BASE_URL else 'http://127.0.0.1'
+    response.headers.add('Access-Control-Allow-Origin', allowed_origin)
     response.headers.add('Access-Control-Allow-Credentials', 'true')
     response.headers.add('Access-Control-Allow-Headers', 'Content-Type, Authorization')
-    #response.headers['Content-Type'] = 'application/javascript'
     return response
 
 # @app.errorhandler(CustomException)
@@ -114,7 +108,7 @@ def home():
     #         syncS3.downloadSync(case, Config.DATA_STORAGE, Config.S3_BUCKET)
     #     #downoload param file from S3 bucket
     #     syncS3.downloadSync('Parameters.json', Config.DATA_STORAGE, Config.S3_BUCKET)
-    return render_template('index.html')
+    return render_template('index.html', api_base_url=Config.API_BASE_URL)
 
 
 @app.route("/getSession", methods=['GET'])

--- a/WebAPP/Classes/Base.Class.js
+++ b/WebAPP/Classes/Base.Class.js
@@ -3,16 +3,13 @@ import { Html } from "./Html.Class.js";
 import { SyncS3 } from "./SyncS3.Class.js";
 
 export class Base {
-    static HEROKU = 0;
     static AWS_SYNC = 0;
     //init sync flag to pull from S3 only one time when visit home page
     static INIT_SYNC = 1;
 
     static apiUrl() {
-        if (this.HEROKU == 1) {
-            return "https://osemosys.herokuapp.com/";
-        }
-        return `${window.location.origin}/`;
+        const base = window.API_BASE_URL || window.location.origin;
+        return `${base}/`;
     }
 
     static initSyncS3() {

--- a/WebAPP/index.html
+++ b/WebAPP/index.html
@@ -83,6 +83,9 @@
 		<!-- iOS web-app metas : hides Safari UI Components and Changes Status Bar Appearance -->
 		<meta name="apple-mobile-web-app-capable" content="yes">
 		<meta name="apple-mobile-web-app-status-bar-style" content="black">
+
+		<!-- API base URL injected by Flask; falls back to window.location.origin in Base.Class.js -->
+		<script>window.API_BASE_URL = "{{ api_base_url }}";</script>
 	</head>
 
 	<body class=" minified smart-style-4  fixed-header ">


### PR DESCRIPTION
## Linked issue

- Related # 386

## Existing related work reviewed

- Issues/PRs reviewed: https://github.com/EAPD-DRB/MUIOGO/issues/386
- If none found, write: None found after search

## Overlap assessment

- Classification: No duplicate found
- Overlapping items: #386 discusses deployment configuration concerns; no existing PR addresses the hardcoded URL directly
- Why this is not duplicate/superseded: #386 identifies the problem; this PR is the implementation fix

## Why this PR should proceed

- The hardcoded `https://osemosys.herokuapp.com/` URL in source code prevents deployment to any server other than that specific Heroku app without manual edits. This fix removes that blocker with no breaking changes for local development

## Summary

- What changed:
  - Removed static `HEROKU = 0` flag and hardcoded `https://osemosys.herokuapp.com/ URL from WebAPP/Classes/Base.Class.js`
  - `apiUrl()` now resolves to `window.API_BASE_URL || window.location.origin` — no source code edit needed to change deployment target
  - `API/Classes/Base/Config.py`: added `API_BASE_URL = os.environ.get("API_BASE_URL", "")` and made `HEROKU_DEPLOY` env-driven via `os.environ.get("HEROKU_DEPLOY", 0)`
  - `API/app.py`: CORS Access-Control-Allow-Origin header now uses `Config.API_BASE_URL` if set, falls back to `http://127.0.0.1`; render_template passes `api_base_url` to `index.html`
  - `WebAPP/index.html`: injects `window.API_BASE_URL` from Flask before any scripts load
- Why:
  - The previous `HEROKU = 1` code path hardcoded a specific Heroku app URL, requiring contributors to edit source code to deploy anywhere else
  - This blocks Docker, AWS, GCP, Azure, and any multi-user deployment without manual source changes
  - With this fix, setting `API_BASE_URL=https://your-server.org` in the environment is sufficient — local development requires no config at all (falls back to `window.location.origin`)

## Validation

- [X] Tests added/updated (or not applicable)
- [X] Validation steps documented
- [X] Evidence attached (logs/screenshots/output as relevant)
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/38d23595-dd6e-4f4c-b1c7-69791ca45400" />

Validation steps:
1. Run locally without setting `API_BASE_URL` — confirm app loads and API calls resolve to window.location.origin
2. Set `API_BASE_URL=https://your-server.org` in `.env` and restart — confirm all API calls target that URL
3. Confirm `window.API_BASE_URL` is injected in page source via browser dev tools → View Page Source

## Documentation

- [X] Docs updated in this PR (or not applicable)
- [X] Any setup/workflow changes reflected in repo docs

## Scope check

- [X] No unrelated refactors
- [X] Implemented from a feature branch
- [X] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [X] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

## Exception rationale

- Only for narrow docs/typo PRs that do not use a linked issue.
- Leave blank otherwise.
