### PR TITLE
feat: port DataFile diagnostics UI and ModelFile page from MUIO v5.5

### DIFF
--- a/WebAPP/App/Controller/DataFile.js
+++ b/WebAPP/App/Controller/DataFile.js
@@ -19,11 +19,13 @@ export default class DataFile {
                 promise.push(genData);
                 const resData = Osemosys.getResultData(casename, 'resData.json');
                 promise.push(resData);
+                const modelFile = Osemosys.readModelFile();
+                promise.push(modelFile);
                 return Promise.all(promise);
             })
             .then(data => {
-                let [casename, genData, resData] = data;
-                let model = new Model(casename, genData, resData, "DataFile");
+                let [casename, genData, resData, modelFile] = data;
+                let model = new Model(casename, genData, resData, modelFile, "DataFile");
                 if (casename) {
                     this.initPage(model);
                 } else {
@@ -43,6 +45,7 @@ export default class DataFile {
         //Navbar.initPage(model.casename, model.pageId);
         Html.title(model.casename, model.title, "");
         Html.renderCases(model.cases);
+        Html.renderModelFile(model.modelFile);
         //potrebno je napraviti render svih scenarija (mozda je dodan novi scenario u medjuvremenu), on mora biti dodan u listu scenarija po case run samo sto nece biti aktivan
         // Html.renderScOrder(model.scBycs[model.cs]);
         //console.log('model.scenarios ',model.scenarios)
@@ -69,11 +72,13 @@ export default class DataFile {
                 promise.push(genData);
                 const resData = Osemosys.getResultData(casename, 'resData.json');
                 promise.push(resData);
+                const modelFile = Osemosys.readModelFile();
+                promise.push(modelFile);
                 return Promise.all(promise);
             })
             .then(data => {
-                let [casename, genData, resData] = data;
-                let model = new Model(casename, genData, resData, "DataFile");
+                let [casename, genData, resData, modelFile] = data;
+                let model = new Model(casename, genData, resData, modelFile, "DataFile");
                 $(".DataFile").hide();
                 $("#osy-DataFile").empty();
                 $("#osy-runOutput").empty();
@@ -95,7 +100,6 @@ export default class DataFile {
     }
 
     static initEvents(model) {
-
         $("#casePicker").off('click');
         $("#casePicker").on('click', '.selectCS', function (e) {
             e.preventDefault();
@@ -104,6 +108,22 @@ export default class DataFile {
             Html.updateCasePicker(casename);
             DataFile.refreshPage(casename);
             Message.smallBoxInfo("Case selection", casename + " is selected!", 3000);
+        });
+
+        $("#osy-logFile").off('click');
+        $("#osy-logFile").on('click', function (event) {
+            Message.loaderStart('Generating log file!')
+            Osemosys.readLogFile()
+            .then(response => {
+                Message.loaderEnd();
+                console.log('resposne ', response)
+                $("#osy-logFiletxt").html('<pre class="log-output">'+response+'</pre>');
+                $("#osy-LogFileModal").modal("show");
+            })
+            .catch(error => {
+                Message.loaderEnd();
+                Message.bigBoxDanger('Error message', error, null);
+            })
         });
 
         $("#osy-btnScOrder").off('click');
@@ -143,10 +163,39 @@ export default class DataFile {
 
         });
 
+        function setAllCheckboxes(state) {
+            $('#osy-scOrder input[type="checkbox"]:not(:disabled)')
+                .prop('checked', state)
+                .trigger('change');
+        }
+
+        $("#toggle-all").off('click');
+        $('#toggle-all').on('click', function (e) {
+
+            e.preventDefault();
+            e.stopPropagation();
+
+            const $btn = $(this);
+            const $boxes = $('#osy-scOrder input[type="checkbox"]:not(:disabled)');
+            const anyUnchecked = $boxes.is(':not(:checked)');
+
+            setAllCheckboxes(anyUnchecked);
+
+            const $icon = $btn.find('i.fa');
+            if (anyUnchecked) {
+                $icon.removeClass('fa-square-o').addClass('fa-check-square-o');
+                $btn.find('span').text('Uncheck all');
+            } else {
+                $icon.removeClass('fa-check-square-o').addClass('fa-square-o');
+                $btn.find('span').text('Check all');
+            }
+
+        });
+
         $("#btnSaveOrder").off('click');
         $("#btnSaveOrder").on('click', function (event) {
             Message.clearMessages();
-            Message.bigBoxSuccess('Sceanario order', 'You have updated scenarios order data!', 3000);
+            Message.bigBoxWarning('Scenario Order Updated', 'You have updated the order of scenarios. To apply your changes, please click Update Case.', 4000);
             $('#osy-order').modal('toggle');
 
             //nema potrebe da spasavmo scenario order jer se on ada nalazi u resData

--- a/WebAPP/App/Controller/ModelFile.js
+++ b/WebAPP/App/Controller/ModelFile.js
@@ -1,0 +1,148 @@
+import { Osemosys } from "../../Classes/Osemosys.Class.js";
+
+export default class ModelFile {
+
+  static onLoad() {
+    Osemosys.readModelFile()
+      .then(txt => {
+        if (!txt) {
+          document.getElementById("equations").innerHTML =
+            "<div class='alert alert-danger'>Unable to load model file.</div>";
+          return;
+        }
+        const eqs = ModelFile.extractEquations(txt);
+        ModelFile.renderEquations(eqs);
+      });
+  }
+
+  // -----------------------------------------
+  // Extract: objective + constraints
+  // -----------------------------------------
+  static extractEquations(txt) {
+    const src = txt.replace(/\r/g, "");
+    const eqs = [];
+
+    // Objective
+    const objRe = /(minimize|maximize)\s+([A-Za-z_]\w*)\s*:\s*([\s\S]*?)\s*;/i;
+    const mObj = src.match(objRe);
+    if (mObj) {
+      eqs.push({
+        section: "Objective",
+        name: mObj[2],
+        latex: ModelFile.gmplToLatex(mObj[3].trim())
+      });
+    }
+
+    // Constraints
+    const consRe = /s\.t\.\s*([A-Za-z_]\w*)\s*(\{[^}]*\})?\s*:\s*([\s\S]*?)(?=;)/gi;
+    let m;
+    while ((m = consRe.exec(src)) !== null) {
+      eqs.push({
+        section: ModelFile.detectSection(m[1]),
+        name: m[1],
+        latex: ModelFile.gmplToLatex(m[3].trim())
+      });
+    }
+
+    return eqs;
+  }
+
+  // -----------------------------------------
+  // Section assignment
+  // -----------------------------------------
+  static detectSection(name) {
+    const n = name.toUpperCase();
+
+    if (n.startsWith("EB")) return "Energy Balance";
+        if (n.startsWith("E")) return "Emissions";
+    if (n.startsWith("A") || n.startsWith("TAC") || n.startsWith("AAC")) return "Activity";
+    if (n.startsWith("NC") || n.startsWith("TC") || n.startsWith("C")) return "Capacity";
+    if (n.startsWith("S")) return "Storage";
+    if (n.startsWith("UDC")) return "User-defined Constraints";
+    return "Other";
+  }
+
+  // -----------------------------------------
+  // GMPL --> LaTeX
+  // -----------------------------------------
+    static gmplToLatex(expr) {
+        let s = expr;
+
+        s = s.replace(/&&/g, " \\land ");
+        s = s.replace(/<=/g, "\\le ")
+            .replace(/>=/g, "\\ge ")
+            .replace(/\*/g, "\\cdot ");
+
+        // sum{}
+        s = s.replace(/sum\s*\{([^}]*)\}/gi, (_, inside) => {
+        const cleaned = inside
+            .split(',')
+            .map(p => p.trim().replace(/\s+in\s+/i," \\in "))
+            .join(', ');
+        return `\\sum_{${cleaned}}`;
+        });
+
+        // X[a,b]
+        s = s.replace(/([A-Za-z_]\w*)\s*\[([^\]]+)\]/g, "\\mathrm{$1}_{ $2 }");
+
+        // ukloni nove linije
+        s = s.replace(/\n+/g, " ");
+
+        return s;
+    }
+
+  // -----------------------------------------
+  // FINAL RENDER + NUMERACIJA + LINIJE
+  // -----------------------------------------
+    static renderEquations(eqs) {
+    const out = document.getElementById("equations");
+
+    let html = "";
+    let lastSection = "";
+    let counter = 1;
+
+    eqs.forEach((eq, i) => {
+        const isNewSection = eq.section !== lastSection;
+
+        // Deblja linija izmedju sekcija (ali ne prije prve)
+        if (isNewSection && i !== 0) {
+        html += `<hr class="section-sep">`;
+        }
+
+        // Naslov sekcije ako je nova
+        if (isNewSection) {
+        html += `
+            <h4 class="mt-2 mb-3" style="border-bottom:1px solid #ddd; padding-bottom:4px;">
+            ${eq.section}
+            </h4>
+        `;
+        lastSection = eq.section;
+        }
+
+        // Jednadzba + rucna numeracija + tanka linija nakon svake
+        html += `
+            <div class="mb-3" style="text-align:left;">
+                <div class="text-secondary small mb-1">${eq.name}</div>
+
+                <div class="math-wrapper">
+                    $$
+
+                    \\begin{align}
+                        ${eq.latex}
+                    \\end{align}
+                    \\tag{${counter}}
+
+                    $$
+                </div>
+
+                <hr class="eq-sep">
+            </div>
+            `;
+
+            counter++;
+        });
+
+        out.innerHTML = html;
+        MathJax.typesetPromise();
+    }
+}

--- a/WebAPP/App/Model/DataFile.Model.js
+++ b/WebAPP/App/Model/DataFile.Model.js
@@ -1,6 +1,6 @@
 
 export class Model {
-    constructor (casename, genData, resData, pageId) {
+    constructor (casename, genData, resData, modelFile, pageId) {
       if(casename){
 
         let cases = resData['osy-cases'];
@@ -54,6 +54,7 @@ export class Model {
         
         this.casename = casename;
         this.cs = cs;
+        this.modelFile = modelFile;
         this.scBycs = scBycs;
         this.title = "Run model";
         this.scenarios = scenarios;

--- a/WebAPP/App/Model/ModelFile.Model.js
+++ b/WebAPP/App/Model/ModelFile.Model.js
@@ -1,0 +1,17 @@
+export class Model {
+    constructor (casename, modelFile, pageId) {
+      if(casename){
+
+        this.casename = casename || null;
+        this.title = "Model file";
+        this.modelFile = modelFile || "";
+        this.pageId = pageId;
+
+      }else{
+        this.casename = null;
+        this.title = "Model file";
+        this.scenarios = null;
+        this.pageId = pageId;
+      }
+    }
+}

--- a/WebAPP/App/View/DataFile.html
+++ b/WebAPP/App/View/DataFile.html
@@ -38,7 +38,7 @@
 
                                     </div>
                                     <br />
-                                    <!-- 
+                                    <!--
                                     <hr><br /> -->
                                     <div class="row no-gutter">
                                         <section class="col col-8">
@@ -161,13 +161,6 @@
             </article>
 
             <article class="col-sm-9 col-md-9 col-lg-9">
-                <!-- <div class="jarviswidget" id="wid-id-1" data-widget-colorbutton="false" data-widget-editbutton="false"
-                    data-widget-custombutton="false" data-widget-deletebutton="false">
-                    <header>
-                        <span class="widget-icon"> <i class="fa fa-edit"></i> </span>
-                        <h2> Case runs </h2>
-                    </header>
-                    <div> -->
                 <div id="tabs">
                     <ul class="nav nav-tabs in">
                         <li class="active">
@@ -175,6 +168,7 @@
                                 <span class="hidden-mobile hidden-tablet"> Cases </span>
                             </a>
                         </li>
+
                         <li>
                             <a data-toggle="tab" href="#tabDataFile" class="DataFile" style="display: none;"> <i
                                     class="fa fa-lg fa-file-text"></i>
@@ -207,6 +201,17 @@
                         </li>
 
                         <li class="pull-right">
+
+                            <button id="osy-logFile"
+                                    class="btn btn-white btn-default btn-bold">
+                                <i class="fa fa-clipboard fa-lg text-info"></i> LOG FILE
+                            </button>
+
+                            <button data-toggle="modal" data-target="#osy-ModelFileModal"
+                                    class="btn btn-white btn-default btn-bold">
+                                <i class="fa fa-cogs fa-lg text-danger"></i> MODEL FILE
+                            </button>
+
                             <button id="osy-batchRun" class="btn btn-white btn-default btn-bold"
                                 style="display: none;">
                                 <i class="fa fa-play-circle fa-lg osy-second-color"></i> BATCH RUN
@@ -333,23 +338,20 @@
     </section>
 </div>
 
-
 <!-- Modal -->
 <div class="modal fade" id="osy-order" tabindex="-1" role="dialog">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <!-- <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
-					&times;
-				</button> -->
-
-                <button type="button" class="btn btn-white btn-default pull-right" data-dismiss="modal">
-                    <i class="fa fa-times fa-lg" aria-hidden="true"></i> Cancel
-                </button>
 
                 <button type="button" class="btn btn-white btn-default pull-right" id='btnSaveOrder'>
-                    <i class="fa fa-save fa-lg"></i> Save
+                    <i class="fa fa-check fa-lg"></i> Confirm
                 </button>
+
+                <button type="button" id="toggle-all" class="btn btn-white btn-default pull-right">
+                    <i class="fa fa-check-square-o fa-lg osy-second-color" aria-hidden="true"></i>
+                </button>
+
                 <h4 class="modal-title">
                     <i class="fa fa-sort osy-second-color" aria-hidden="true"></i> Scenario order
                 </h4>
@@ -388,6 +390,56 @@
                     <div class="row">
                         <div class="col-md-12 col-lg-12">
                             <div id='valOutput'></div>
+                        </div>
+                    </div>
+                </fieldset>
+                <footer></footer>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="osy-ModelFileModal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-dialog-wide">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
+                    &times;
+                </button>
+                <h4 class="modal-title">
+                    <i class="fa  fa-info-circle fa-lg osy-second-color" aria-hidden="true"></i> MUIO Model File
+                </h4>
+            </div>
+            <div class="modal-body" style="padding-top: 0px;">
+                <fieldset style="padding-top: 15px;">
+                    <div class="row">
+                        <div class="col-md-12 col-lg-12">
+                            <div id='osy-ModelFile'></div>
+                        </div>
+                    </div>
+                </fieldset>
+                <footer></footer>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="osy-LogFileModal" tabindex="-1" role="dialog">
+    <div class="modal-dialog modal-dialog-wide">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
+                    &times;
+                </button>
+                <h4 class="modal-title">
+                    <i class="fa  fa-info-circle fa-lg text-info" aria-hidden="true"></i> MUIO Log File
+                </h4>
+            </div>
+            <div class="modal-body" style="padding-top: 0px;">
+                <fieldset style="padding-top: 15px;">
+                    <div class="row">
+                        <div class="col-md-12 col-lg-12">
+                            <div id='osy-logFiletxt'></div>
                         </div>
                     </div>
                 </fieldset>

--- a/WebAPP/App/View/ModelFile.html
+++ b/WebAPP/App/View/ModelFile.html
@@ -1,0 +1,39 @@
+<div class="row">
+    <div class="col-xs-12 col-sm-7 col-md-7 col-lg-4">
+        <h2 class="page-title txt-color-blueDark" id="osy-title"><i class="fa-fw fa fa-home"></i> Model File <span>>
+                create & edit</span></h2>
+    </div>
+    <div class="col-xs-12 col-sm-5 col-md-5 col-lg-8">
+        <ul id="sparks" class="">
+            <li class="sparks-info">
+                <h5> Selected Model: <span class="txt-color-blue" id="osy-case"></span></h5>
+            </li>
+        </ul>
+    </div>
+</div>
+
+
+<div class="container-fluid mt-4">
+
+    <h3>Model Equations</h3>
+    <div id="equations"></div>
+
+</div>
+
+
+<style>
+.section-sep {
+  border: 0;
+  border-top: 2px solid #999;
+  margin: 16px 0;
+}
+.eq-sep {
+  border: 0;
+  border-top: 1px dashed #ddd;
+  margin-top: 8px;
+}
+.math-wrapper {
+  overflow-x: auto;
+   overflow-y: hidden;
+}
+</style>

--- a/WebAPP/Classes/Html.Class.js
+++ b/WebAPP/Classes/Html.Class.js
@@ -209,6 +209,12 @@ export class Html {
 
     }
 
+    static renderModelFile(ModelFile){
+        $("#osy-ModelFile").empty();
+        $("#osy-ModelFile").html('');
+        $("#osy-ModelFile").html('<pre class="log-output">'+ModelFile+'</pre>');
+    }
+
     static appendCasePicker(value, selectedCS, pageId) {
         let res = `
         <li id=p_${value.replace(/[^A-Z0-9]/ig, "")}>

--- a/WebAPP/Classes/Osemosys.Class.js
+++ b/WebAPP/Classes/Osemosys.Class.js
@@ -288,6 +288,46 @@ export class Osemosys {
         });
     }
 
+    static readModelFile() {
+        return fetch(Base.apiUrl() + "readModelFile", {
+            method: "GET",
+            cache: "no-store"
+        })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error("Could not load model file");
+            }
+            return response.text();
+        })
+        .then(text => {
+            return text;
+        })
+        .catch(error => {
+            console.error("readModelFile error:", error);
+            return null;
+        });
+    }
+
+    static readLogFile() {
+        return fetch(Base.apiUrl() + "readLogFile", {
+            method: "GET",
+            cache: "no-store"
+        })
+        .then(response => {
+            if (!response.ok) {
+                throw new Error("Could not load log file");
+            }
+            return response.text();
+        })
+        .then(text => {
+            return text;
+        })
+        .catch(error => {
+            console.error("readLogFile error:", error);
+            return null;
+        });
+    }
+
     static readDataFile(casename, caserunname) {
         return new Promise((resolve, reject) => {
             $.ajax({

--- a/WebAPP/Routes/Routes.Class.js
+++ b/WebAPP/Routes/Routes.Class.js
@@ -110,6 +110,16 @@ export class Routes {
                 });
             });
         });
+        crossroads.addRoute('/ModelFile', function() {
+            $('#content').html('<h1 class="ajax-loading-animation"><i class="fa fa-cog fa-spin"></i> Loading...</h1>');
+            import('../App/Controller/ModelFile.js')
+            .then(ModelFile => {
+                $( ".osy-content" ).load( 'App/View/ModelFile.html', function() {
+                    localStorage.setItem("osy-pageId", "ModelFile");
+                    ModelFile.default.onLoad();
+                });
+            });
+        });
         crossroads.addRoute('/Versions', function() {
             $('#content').html('<h1 class="ajax-loading-animation"><i class="fa fa-cog fa-spin"></i> Loading...</h1>');
             $( ".osy-content" ).load( 'App/View/Versions.html');

--- a/WebAPP/index.html
+++ b/WebAPP/index.html
@@ -37,7 +37,20 @@
 		<script src="References/plotly/plotly-2.27.0.min.js"></script>
 		<!-- <script src='https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.17/d3.min.js'></script> -->
 
-
+		<!-- MathJax 3 -->
+		<script>
+			window.MathJax = {
+				tex: {
+					packages: {'[+]': ['ams']},
+					inlineMath: [['\\(','\\)']],
+					displayMath: [['$$','$$']],
+					processEscapes: true,
+					processEnvironments: true,
+					linebreaks: { automatic: true }
+				}
+			};
+		</script>
+		<script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js" defer></script>
 
 		<!-- SmartAdmin Styles : Caution! DO NOT change the order -->
 		<link rel="stylesheet" type="text/css" media="screen" href="References/smartadmin/css/smartadmin-production-plugins.min.css">


### PR DESCRIPTION
## Linked issue

- Closes #391
- Related #388, #390

## Existing related work reviewed

- Issues/PRs reviewed: #390 (PR #397 — backend endpoints), #388 (parent tracking issue)
- Upstream MUIO v5.5 source files reviewed via `muio-upstream/master`

## Overlap assessment

- Classification: Sequential dependency — this is the frontend counterpart to #390 (backend)
- Overlapping items: #390 added `/readModelFile` and `/readLogFile` backend endpoints; this PR adds the frontend that consumes them
- Why this is not duplicate/superseded: #390 is backend-only. This PR ports the frontend UI that uses those endpoints, plus the standalone ModelFile page and MathJax integration which are entirely new

## Why this PR should proceed

- #391 is the next sequential child of #388 (Absorb MUIO v5.5). The backend prerequisite (#390) is complete. This delivers the diagnostics UI that upstream v5.5 provides, following upstream by default with no MUIOGO-specific patches needed on the frontend side.

## Summary

- What changed:
  - Added `readModelFile()` and `readLogFile()` frontend fetch helpers to `Osemosys.Class.js`
  - Updated DataFile page with LOG FILE button, MODEL FILE button (with modals), and scenario toggle-all control
  - Updated `DataFile.Model.js` constructor to accept and store `modelFile`
  - Added `Html.renderModelFile()` helper
  - Created standalone ModelFile page (`Controller/ModelFile.js`, `Model/ModelFile.Model.js`, `View/ModelFile.html`) that parses GMPL model, converts to LaTeX, and renders equations with MathJax
  - Added MathJax 3 CDN with AMS package to `index.html`
  - Added `/ModelFile` route to `Routes.Class.js`
- Why: Port upstream MUIO v5.5 diagnostics UI into MUIOGO as specified in #391 and parent #388

## Validation

- [x] Tests added/updated (or not applicable) — no existing test suite for frontend; manual validation performed
- [x] Validation steps documented
  - Started app locally with `python app.py` on Python 3.12
  - Verified `/readModelFile` endpoint returns 200
  - Verified `/readLogFile` endpoint returns 404 gracefully (no log file yet — expected)
  - Navigated to `#/ModelFile` — standalone page renders model equations with MathJax (Objective, Activity, Capacity sections visible with LaTeX formatting)
- [x] Evidence attached — ModelFile page screenshot confirmed during development

## Documentation

- [x] Docs updated in this PR (or not applicable) — no doc changes needed; features are self-discoverable UI elements

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

## Exception rationale

