### PR TITLE
Fix: calculate relative arcname for backupCase ZIP generation (fixes #403)

### DIFF
--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -215,8 +215,12 @@ def backupCase():
                     if filename != 'lp.lp':
                         #create complete filepath of file in directory
                         filePath = os.path.join(folderName, filename)
+                        
+                        # Calculate relative path so archive stores 'CaseName/...' instead of absolute system paths
+                        arcname = os.path.relpath(filePath, str(casePath.parent))
+                        
                         # Add file to zip
-                        zipObj.write(filePath)      
+                        zipObj.write(filePath, arcname=arcname)      
 
             #osemosys 2.1 backup only input files
             # for filename in os.listdir(str(casePath)):


### PR DESCRIPTION
## Linked issue

- Closes #403

## Existing related work reviewed

- Issues/PRs reviewed: Searched issues covering `/backupCase`. Found only #229 (which addresses a timeout race-condition), but it does not resolve the `arcname` directory layout bug.
- If none found, write: None found after search

## Overlap assessment

- Classification: Bug Fix
- Overlapping items: None
- Why this is not duplicate/superseded: Corrects the internal ZIP extraction pathing behavior independently of any other backup endpoint concerns.

## Why this PR should proceed

- It solves an immediate user pain-point that guarantees Case Backups are generated with portable, correctly formatted directories instead of leaking the absolute directory chains of the host server filesystem.

## Summary

- What changed: Added `arcname` calculation utilizing `os.path.relpath` inside `UploadRoute.py`'s `backupCase()` logic algorithm.
- Why: To mandate that the `.zip` archive stores only the targeted case's relative structure (e.g. `CaseName/genData.json`) instead of defaulting to absolute backend host paths (e.g. `e/MUIOGO/DataStorage/.../genData.json`).

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

*Validation notes*: Backup was visually validated on local UI. Unzipping the resulting archive directly outputs the clean `caseData` payload folder rather than the host's directory structure (Refer to the screenshot uploaded in Issue #403).

## Documentation

- [x] Docs updated in this PR (or not applicable)
- [x] Any setup/workflow changes reflected in repo docs

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)