### PR TITLE
fix: adopt v5.5 result metadata and register missing result groups (#392)

### DIFF
--- a/WebAPP/Classes/Const.Class.js
+++ b/WebAPP/Classes/Const.Class.js
@@ -96,8 +96,11 @@ export const GROUPNAMES = {
 }
 
 export const RESULTGROUPNAMES = {
+    "R"     :"Region",
     "RT"    :"Region, technology",
     "RYT"    :"Region, year, technology",
+    "RYC"    :"Region, year, commodity",
+    "RYCn"   :"Region, year, constraint",
     "RYE"    :"Region, year, emission",
     "RYS"    :"Region, year, storage",
     "RYTM"  :"Region, year, technology, mode of operation",
@@ -158,25 +161,31 @@ export const PARAMCOLORS = {
     "RYCTs": "greenLight"
 }
 
-export const RESULTPARAMORDER = [ 
-    "RT"    ,     
-    "RYT"    ,     
-    "RYE"    , 
+export const RESULTPARAMORDER = [
+    "R"     ,
+    "RT"    ,
+    "RYT"    ,
+    "RYC"    ,
+    "RYCn"   ,
+    "RYE"    ,
     "RYS"    ,
-    "RYTM"  ,   
-    "RYTC" , 
-    "RYTE"  ,     
-    "RYTTs"   , 
-    "RYCTs"  ,  
-    "RYTEM"  ,  
-    "RYTCTs" , 
-    "RYTMTs" ,    
-    "RYTCMTs"  
+    "RYTM"  ,
+    "RYTC" ,
+    "RYTE"  ,
+    "RYTTs"   ,
+    "RYCTs"  ,
+    "RYTEM"  ,
+    "RYTCTs" ,
+    "RYTMTs" ,
+    "RYTCMTs"
 ];
 
 export const RESULTPARAMCOLORS = {
+    "R": "orange",
     "RT": "blue",
     "RYT": "blueLight",
+    "RYC": "grey",
+    "RYCn": "pink",
     "RYE": "yellow",
     "RYS": "red",
     "RYTM": "pink",

--- a/WebAPP/DataStorage/Variables.json
+++ b/WebAPP/DataStorage/Variables.json
@@ -7,7 +7,7 @@
             "unitRule": {
                 "cat": [
                     {
-                        "var": ""
+                        "var": "number"
                     }
                 ]
             }
@@ -117,7 +117,11 @@
             "value": "Number Of New Technology Units",
             "name": "NumberOfNewTechnologyUnits",
             "unitRule": {
-                "cat": []
+                "cat": [
+                    {
+                        "var": "number"
+                    }
+                ]
             }
         },
         {
@@ -154,21 +158,10 @@
             "unitRule": {
                 "cat": [
                     {
-                        "var": "CapUnitId"
-                    }
-                ]
-            }
-        }
-    ],
-    "RYC": [
-        {
-            "id": "EB_d",
-            "value": "Shadow price - Annual Commodity Balance",
-            "name": "EBb4_EnergyBalanceEachYear4_ICR",
-            "unitRule": {
-                "cat": [
+                        "var": "milion"
+                    },
                     {
-                        "var": "CapUnitId"
+                        "var": "Currency"
                     }
                 ]
             }
@@ -182,33 +175,16 @@
             "unitRule": {
                 "cat": [
                     {
+                        "var": "milion"
+                    },
+                    {
+                        "var": "Currency"
+                    },
+                    {
+                        "var": "divide"
+                    },
+                    {
                         "var": "EmiUnit"
-                    }
-                ]
-            }
-        }
-    ],
-    "RYCn": [
-        {
-            "id": "UDCI_d",
-            "value": "Shadow price - UDC Inequality",
-            "name": "UDC1_UserDefinedConstraintInequality",
-            "unitRule": {
-                "cat": [
-                    {
-                        "var": ""
-                    }
-                ]
-            }
-        },
-        {
-            "id": "UDCE_d",
-            "value": "Shadow price - UDC Equality",
-            "name": "UDC2_UserDefinedConstraintEquality",
-            "unitRule": {
-                "cat": [
-                    {
-                        "var": ""
                     }
                 ]
             }
@@ -251,7 +227,6 @@
                 ]
             }
         },
-
         {
             "id": "SVS",
             "value": "Salvage Value Storage",
@@ -278,6 +253,55 @@
                     },
                     {
                         "var": "Currency"
+                    }
+                ]
+            }
+        }
+    ],
+    "RYC": [
+        {
+            "id": "EB_d",
+            "value": "Shadow price - Energy Balance",
+            "name": "EBb4_EnergyBalanceEachYear4_ICR",
+            "unitRule": {
+                "cat": [
+                    {
+                        "var": "milion"
+                    },
+                    {
+                        "var": "Currency"
+                    },
+                    {
+                        "var": "divide"
+                    },
+                    {
+                        "var": "EmiUnit"
+                    }
+                ]
+            }
+        }
+    ],
+    "RYCn": [
+        {
+            "id": "UDCI_d",
+            "value": "Shadow price - UDC Inequality",
+            "name": "UDC1_UserDefinedConstraintInequality",
+            "unitRule": {
+                "cat": [
+                    {
+                        "var": "number"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "UDCE_d",
+            "value": "Shadow price - UDC Equality",
+            "name": "UDC2_UserDefinedConstraintEquality",
+            "unitRule": {
+                "cat": [
+                    {
+                        "var": "number"
                     }
                 ]
             }
@@ -386,6 +410,12 @@
                 "cat": [
                     {
                         "var": "ActUnitId"
+                    },
+                    {
+                        "var": "divide"
+                    },
+                    {
+                        "var": "years"
                     }
                 ]
             }
@@ -412,6 +442,12 @@
                 "cat": [
                     {
                         "var": "CommUnit"
+                    },
+                    {
+                        "var": "divide"
+                    },
+                    {
+                        "var": "years"
                     }
                 ]
             }
@@ -424,6 +460,12 @@
                 "cat": [
                     {
                         "var": "CommUnit"
+                    },
+                    {
+                        "var": "divide"
+                    },
+                    {
+                        "var": "years"
                     }
                 ]
             }


### PR DESCRIPTION
# Align result metadata with upstream MUIO v5.5

Align result metadata with upstream MUIO v5.5 as the authoritative source.

---

## Variables.json fixes

- **OV, NONTU, UDCI_d, UDCE_d**
  - Filled empty `unitRule` values with correct definitions

- **TEP**
  - Changed `CapUnitId` → `milion Currency`
  - Reason: cost variable, not capacity

- **AEL_d**
  - Changed `EmiUnit` → `milion Currency / EmiUnit`
  - Reason: shadow price requires composite unit

- **EB_d**
  - Changed `CapUnitId` → `milion Currency / EmiUnit`
  - Renamed to **"Energy Balance"**

- **ROA**
  - Added `/years` divisor to represent rate

- **ROPBT, ROUBT**
  - Added `/years` divisor to represent rate units

---

## Const.Class.js updates

Added missing result groups so they are accessible in Pivot UI:

- Added to:
  - `RESULTGROUPNAMES`
  - `RESULTPARAMORDER`
  - `RESULTPARAMCOLORS`

- New groups:
  - `R` → Objective Value
  - `RYC` → Commodity shadow prices
  - `RYCn` → Constraint shadow prices

---

## Linked issue

- Closes #392  
- Related: #388, #390, #391  

---

## Existing related work reviewed

- Reviewed PRs/issues:
  - #396 (guardrails - different scope)
  - #397 (backend runtime - no metadata overlap)
  - #402 (smoke harness - different scope)

- None modify:
  - `Variables.json` unit rules  
  - `Const.Class.js` result group registration  

---

## Overlap assessment

- **Classification:** No overlap  
- **Overlapping items:** None  

**Reason:**  
No existing PR addresses:
- Incorrect unit rules in `Variables.json`
- Missing `R`, `RYC`, `RYCn` registrations

---

## Why this PR should proceed

- Shadow prices (`AEL_d`, `EB_d`, `UDCI_d`, `UDCE_d`)
  - Currently display incorrect or blank units

- `TEP`
  - Displays capacity units instead of currency

- Rate variables (`ROA`, `ROPBT`, `ROUBT`)
  - Missing `/years`, leading to incorrect interpretation

- Result groups (`R`, `RYC`, `RYCn`)
  - Not visible in Pivot UI despite valid data

---

## Summary

- **What changed:**
  - Fixed 10 incorrect/empty unit rules in `Variables.json`
  - Added 3 missing result groups in `Const.Class.js`

- **Why:**
  - MUIOGO must align with upstream **MUIO v5.5 metadata**
  - Ensures correct interpretation of:
    - Shadow prices
    - Cost variables
    - Rate variables

---

## Validation

- [ ] Tests added/updated (not applicable)
- [x] Validation steps documented
- [ ] Evidence attached

### Validation steps

1. Load the app → open **Pivot results page**
2. Verify:
   - `TEP` and `NONTU` show correct units under `RYT`
3. Navigate to:
   - `RYC`, `RYE`, `RYCn` groups via selector
4. Confirm:
   - Objective Value (`R`) shows unit = `number`
5. Verify:
   - `ROA`, `ROPBT`, `ROUBT` include `/years` in units

---

## Documentation

- [x] Docs updated (not applicable - metadata change only)
- [x] No setup/workflow changes required

---

## Scope check

- [x] No unrelated refactors  
- [x] Feature branch used  
- [x] No dependency on upstream `OSeMOSYS/MUIO`  
- [x] Base: `EAPD-DRB/MUIOGO:main`  

---

## Exception rationale

