### PR TITLE
[v5.5] Fix result metadata and shadow-price rendering (align with upstream Variables.json)

### DIFF
--- a/WebAPP/AppResults/Controller/Pivot.js
+++ b/WebAPP/AppResults/Controller/Pivot.js
@@ -443,6 +443,10 @@ export default class Pivot {
                 app.engine.fields.getField('Emi').isContentHtml = true;
                 app.engine.fields.getField('Emi Desc').isContentHtml = true;
             }
+            else if (group == "RYCn") { 
+                app.engine.fields.getField('Con').isContentHtml = true;
+                app.engine.fields.getField('Con Desc').isContentHtml = true;
+            }
             else{
                 app.engine.fields.getField('Tech').isContentHtml = true;
                 app.engine.fields.getField('Tech Desc').isContentHtml = true;
@@ -571,6 +575,10 @@ export default class Pivot {
                     app.engine.rowFields.push('Case');
                     app.engine.valueFields.push('Value');
                 }
+                else if (model.group == 'RY') {
+                    app.engine.rowFields.push('Case', 'Year');
+                    app.engine.valueFields.push('Value');
+                }
                 else if(model.group == 'RYE' ){
                     app.engine.columnFields.push('Emi');
                     app.engine.rowFields.push('Case','Year');
@@ -640,11 +648,11 @@ export default class Pivot {
                 }
                 console.log('view ok')
                 app.engine.fields.getField('Unit').isContentHtml = true;
-                if(model.group != "RYS" && model.group != "RYCTs" && model.group != "RYC" && model.group != "RYE" && model.group != "RYCn"&& model.group != "R"){
+                if (model.group != "RYS" && model.group != "RYCTs" && model.group != "RYC" && model.group != "RYE" && model.group != "RYCn" && model.group != "R" && model.group != "RY"){
                     app.engine.fields.getField('Tech').isContentHtml = true;
                     app.engine.fields.getField('Tech Desc').isContentHtml = true;
                 }
-                if(model.group == "RYTC" || model.group == "RYCTs" || model.group == "RYTCMTs" || model.group == "RYC"){
+                if (model.group == "RYTC" || model.group == "RYCTs" || model.group == "RYTCMTs" || model.group == "RYC"){
                     app.engine.fields.getField('Comm').isContentHtml = true;
                     app.engine.fields.getField('Comm Desc').isContentHtml = true;
                 }
@@ -664,6 +672,7 @@ export default class Pivot {
                 Message.loaderEnd();
             }
             else{
+                app.engine.itemsSource = [];
                 Message.dangerOsy("Results do not contain values for variable <b>"+model.VARNAMES[model.group][model.param] + "</b> please check input data and rerun the model.")
                 Message.loaderEnd();
             }
@@ -679,21 +688,25 @@ export default class Pivot {
         if(model.VIEW == 'null'){
             app.engine.viewDefinition = model.DEFAULTVIEW;
             app.pivotChart.header = '';
-            if(model.group != "RYS" && model.group != "RYCTs"){
+            if (model.group != "RYS" && model.group != "RYCTs" && model.group != "RYC" && model.group != "RYE" && model.group != "RYCn" && model.group != "R") {
                 app.engine.fields.getField('Tech').isContentHtml = true;
                 app.engine.fields.getField('Tech Desc').isContentHtml = true;
             }
-            if(model.group == "RYTC" || model.group == "RYCTs" || model.group == "RYTCMTs"){
+            if (model.group == "RYTC" || model.group == "RYCTs" || model.group == "RYTCMTs" || model.group == "RYC"){
                 app.engine.fields.getField('Comm').isContentHtml = true;
                 app.engine.fields.getField('Comm Desc').isContentHtml = true;
             }
-            if(model.group == "RYTE" || model.group == "RYTEM"){
+            if(model.group == "RYTE" || model.group == "RYTEM" || model.group == "RYE"){
                 app.engine.fields.getField('Emi').isContentHtml = true;
                 app.engine.fields.getField('Emi Desc').isContentHtml = true;
             }
             if(model.group == "RYS"){
                 app.engine.fields.getField('Stg').isContentHtml = true;
                 app.engine.fields.getField('Stg Desc').isContentHtml = true;
+            }
+            if(model.group == "RYCn"){
+                app.engine.fields.getField('Con').isContentHtml = true;
+                app.engine.fields.getField('Con Desc').isContentHtml = true;
             }
             Html.title(model.casename, model.VARNAMES[model.group][model.param], model.group+' Default view');
         }
@@ -721,15 +734,15 @@ export default class Pivot {
                             // app.engine.fields.getField('Unit').isContentHtml = true;
                             // app.engine.fields.getField('Tech').isContentHtml = true;
                             // app.engine.fields.getField('Tech Desc').isContentHtml = true;
-                            if(model.group != "RYS" && model.group != "RYCTs"){
+                            if (model.group != "RYS" && model.group != "RYCTs" && model.group != "RYC" && model.group != "RYE" && model.group != "RYCn" && model.group != "R"){
                                 app.engine.fields.getField('Tech').isContentHtml = true;
                                 app.engine.fields.getField('Tech Desc').isContentHtml = true;
                             }
-                            if(model.group == "RYTC" || model.group == "RYCTs" || model.group == "RYTCMTs"){
+                            if (model.group == "RYTC" || model.group == "RYCTs" || model.group == "RYTCMTs" || model.group == "RYC"){
                                 app.engine.fields.getField('Comm').isContentHtml = true;
                                 app.engine.fields.getField('Comm Desc').isContentHtml = true;
                             }
-                            if(model.group == "RYTE" || model.group == "RYTEM"){
+                            if (model.group == "RYTE" || model.group == "RYTEM" || model.group == "RYE"){
                                 app.engine.fields.getField('Emi').isContentHtml = true;
                                 app.engine.fields.getField('Emi Desc').isContentHtml = true;
                             }
@@ -737,7 +750,10 @@ export default class Pivot {
                                 app.engine.fields.getField('Stg').isContentHtml = true;
                                 app.engine.fields.getField('Stg Desc').isContentHtml = true;
                             }
-
+                            if (model.group == "RYCn") {
+                                app.engine.fields.getField('Con').isContentHtml = true;
+                                app.engine.fields.getField('Con Desc').isContentHtml = true;
+                            }
                         } 
                     }
                     else{

--- a/WebAPP/Classes/Const.Class.js
+++ b/WebAPP/Classes/Const.Class.js
@@ -63,11 +63,13 @@ export const PARAM_TECH_GROUPS = ['RT', 'RYT', 'RYTM', 'RYTC', 'RYTCn', 'RYTCM',
 export const PARAM_COMM_GROUPS = ['RYC', 'RYTC', 'RYTCM','RYCTs']
 export const PARAM_EMIS_GROUPS = ['RE', 'RYE', 'RYTE', 'RYTEM']
 export const PARAM_STORAGE_GROUPS = ['RS', 'RYS', 'RTSM', 'RYTEM']
+export const PARAM_CON_GROUPS = ['RYCn']
 
 export const VAR_TECH_GROUPS = ['RT', 'RYT', 'RYTM', 'RYTC', 'RYTE', 'RYTEM', 'RYTMTs', 'RYTCMTs']
-export const VAR_COMM_GROUPS = ['RYTC','RYCTs','RYTCMTs']
-export const VAR_EMIS_GROUPS = ['RYTE', 'RYTEM']
+export const VAR_COMM_GROUPS = ['RYTC', 'RYCTs', 'RYTCMTs', 'RYC']
+export const VAR_EMIS_GROUPS = ['RYTE', 'RYTEM', 'RYE']
 export const VAR_STORAGE_GROUPS = ['RYS']
+export const VAR_CON_GROUPS = ['RYCn']
 
 export const GROUPNAMES = {
     "R": "Region",
@@ -96,10 +98,14 @@ export const GROUPNAMES = {
 }
 
 export const RESULTGROUPNAMES = {
+    "R": "Region",
+    "RY"    :"Region, year",
     "RT"    :"Region, technology",
     "RYT"    :"Region, year, technology",
     "RYE"    :"Region, year, emission",
     "RYS"    :"Region, year, storage",
+    "RYC"   : "Region, year, commodity",
+    "RYCn"  : "Region, year, constraint",
     "RYTM"  :"Region, year, technology, mode of operation",
     "RYTC"  :"Region, year, technology, commodity",
     "RYTE"      :"Region, year, technology, emission",
@@ -141,7 +147,6 @@ export const PARAMCOLORS = {
     "RE": "yellow",
     "RYCn": "pink",
     "RYTs": "red",
-    "RYDtb": "blue",
     "RYDtb": "red",
     "RYT": "greenLight",
     "RYTCn": "pink",
@@ -161,8 +166,10 @@ export const PARAMCOLORS = {
 export const RESULTPARAMORDER = [ 
     "RT"    ,     
     "RYT"    ,     
-    "RYE"    , 
-    "RYS"    ,
+    "RYC",
+    "RYE",
+    "RYS",
+    "RYCn",
     "RYTM"  ,   
     "RYTC" , 
     "RYTE"  ,     
@@ -187,7 +194,9 @@ export const RESULTPARAMCOLORS = {
     "RYTEM": "grey",
     "RYTCTs": "pink",
     "RYTMTs": "teal",
-    "RYTCMTs": "blue"
+    "RYTCMTs": "blue",
+    "RYC": "grey",
+    "RYCn": "pink",
 }
 
 export const UNITS = 

--- a/WebAPP/Classes/DataModelResult.Class.js
+++ b/WebAPP/Classes/DataModelResult.Class.js
@@ -1,6 +1,6 @@
 
 import { DataModel} from "./DataModel.Class.js"
-import { UNITDEFINITION, VAR_TECH_GROUPS, VAR_COMM_GROUPS, VAR_EMIS_GROUPS, VAR_STORAGE_GROUPS } from "./Const.Class.js";
+import { VAR_TECH_GROUPS, VAR_COMM_GROUPS, VAR_EMIS_GROUPS, VAR_STORAGE_GROUPS, VAR_CON_GROUPS } from "./Const.Class.js";
 
 export class DataModelResult{
 
@@ -145,6 +145,7 @@ export class DataModelResult{
                         unitData[group][obj.id][tObj.Tech]['CapUnitId'] = techUnits[tObj.TechId]['CapUnitId'];
                         unitData[group][obj.id][tObj.Tech]['ActUnitId'] = techUnits[tObj.TechId]['ActUnitId'];
                         unitData[group][obj.id][tObj.Tech]['Currency'] = genData['osy-currency'];
+                        unitData[group][obj.id][tObj.Tech]['number'] = 'number';
                     });
                 }
                 //comm parameters
@@ -191,6 +192,21 @@ export class DataModelResult{
                         unitData[group][obj.id][eObj.Stg]['Currency'] = genData['osy-currency'];
                     });
                 }
+                // con parameters
+                if (VAR_CON_GROUPS.includes(group)) {
+                    $.each(genData['osy-constraints'], function (id, cObj) {
+                        unitData[group][obj.id][cObj.Con] = {};
+                        unitData[group][obj.id][cObj.Con]['years'] = 'years';
+                        unitData[group][obj.id][cObj.Con]['percent'] = '%';
+                        unitData[group][obj.id][cObj.Con]['divide'] = '/';
+                        unitData[group][obj.id][cObj.Con]['multiply'] = '*';
+                        unitData[group][obj.id][cObj.Con]['hundert'] = '100';
+                        unitData[group][obj.id][cObj.Con]['thousand'] = '10<sup>3</sup>';
+                        unitData[group][obj.id][cObj.Con]['milion'] = '10<sup>6</sup>';
+                        unitData[group][obj.id][cObj.Con]['Currency'] = genData['osy-currency'];
+                        unitData[group][obj.id][cObj.Con]['number'] = 'number';
+                    });
+                }
                 unitData[group][obj.id]['years'] = 'years';
                 unitData[group][obj.id]['number'] = 'number';
                 unitData[group][obj.id]['percent'] = '%';
@@ -199,8 +215,6 @@ export class DataModelResult{
                 unitData[group][obj.id]['hundert'] = '100';
                 unitData[group][obj.id]['thousand'] = '10<sup>3</sup>';
                 unitData[group][obj.id]['milion'] = '10<sup>6</sup>';
-                unitData[group][obj.id]['hundert'] = '100';
-                unitData[group][obj.id]['thousand'] = '10<sup>3</sup>';
             });
         });
         return unitData;       
@@ -228,6 +242,7 @@ export class DataModelResult{
         let dataC = {};
         let dataE = {};
         let dataS = {};
+        let dataCon = {};
 
         $.each(DATA[param], function (cs, array) {    
             //console.log('DATA ', DATA[param]) 
@@ -275,7 +290,7 @@ export class DataModelResult{
                         // chunk['Unit'] = jsonLogic.apply(rule, data);
                         
 
-                        if(obj.Comm){
+                        if (obj.Comm && !obj.Tech) {
                             
                             //uslov dodan vk 18072924 ako smo izbrisali commodity a postoji u resulttima
                             if(obj.Comm in commData){
@@ -298,8 +313,10 @@ export class DataModelResult{
                             if(obj.Con in conData){
                                 chunk['Con'] = obj.Con;
                                 chunk['ConDesc'] = conData[obj.Con]["Desc"];
-                                chunk['Unit'] = 'n/a';
-                               
+
+                                dataCon = unitData[group][param][obj.Con];
+                                let rule = paramById[group][param]['unitRule'];
+                                chunk['Unit'] = jsonLogic.apply(rule, { ...dataCon });
                             }
                             else{
                                 chunk['Con'] = '<i class="fa fa-exclamation-triangle danger" aria-hidden="true"></i> ' +obj.Con;
@@ -338,7 +355,7 @@ export class DataModelResult{
                                 chunk['Unit'] = '<i class="fa fa-exclamation-triangle danger" aria-hidden="true"></i> n/a';
                             }
                         }
-                        if(obj.Tech){
+                        if (obj.Tech && !obj.Comm) {
                             //console.log('techData ', obj.Tech, '------',  techData[obj.Tech])   //DEMINDLFO 
                             //vk 18972024 ovaj uslov dodat - ako korisnik izbrise tech on ce ostati u view json filovima i doci ce do greske, ovaj tech se mora ignorisati u pivotdata
                             if(obj.Tech in techData){
@@ -380,6 +397,54 @@ export class DataModelResult{
                                 pivotData.push(chunk);
                             }
     
+                        }
+                        if (obj.Tech && obj.Comm) {
+                            if (obj.Tech in techData && obj.Comm in commData) {
+                                let rule = paramById[group][param]['unitRule'];
+                                dataT = unitData[group][param][obj.Tech];
+                                dataC = unitData[group][param][obj.Comm];
+
+                                // console.log('dataT ', dataT, 'dataC ', dataC, 'rule ', rule, 'group ', group, 'param ', param)
+                                if (techData[obj.Tech].TG.length != 0) {
+                                    $.each(techData[obj.Tech].TG, function (id, tg) {
+                                        let tmp = {};
+                                        tmp = JSON.parse(JSON.stringify(chunk));
+                                        tmp['Tech'] = obj.Tech;
+                                        tmp['TechGroup'] = techGroupNames[tg];
+                                        tmp['TechDesc'] = techData[obj.Tech]["Desc"];
+                                        tmp['TechGroupDesc'] = techGroupData[tg]["Desc"];
+
+                                        console.log('jsonLogic.apply(rule, {...dataT, ...dataC}) ', jsonLogic.apply(rule, { ...dataT, ...dataC }));
+                                        tmp['Unit'] = jsonLogic.apply(rule, { ...dataT, ...dataC });
+
+                                        tmp['Comm'] = obj.Comm;
+                                        tmp['CommDesc'] = commData[obj.Comm]["Desc"];
+                                        pivotData.push(tmp);
+                                    })
+                                }
+                                else {
+                                    chunk['Tech'] = obj.Tech;
+                                    chunk['TechGroup'] = 'No group';
+                                    chunk['TechDesc'] = techData[obj.Tech]["Desc"];
+                                    chunk['TechGroupDesc'] = 'No group';
+                                    chunk['Unit'] = jsonLogic.apply(rule, { ...dataT, ...dataC });
+                                    //pivotData.push(chunk);
+                                    chunk['Comm'] = obj.Comm;
+                                    chunk['CommDesc'] = commData[obj.Comm]["Desc"];
+                                    pivotData.push(chunk);
+                                }
+                            }
+                            else {
+                                chunk['Tech'] = '<i class="fa fa-exclamation-triangle danger" aria-hidden="true"></i> ' + obj.Tech;
+                                chunk['TechGroup'] = 'No group';
+                                chunk['TechDesc'] = '<i class="fa fa-exclamation-triangle danger" aria-hidden="true"></i> ' + obj.Tech + " deleted from model";
+                                chunk['TechGroupDesc'] = 'No group';
+                                chunk['Unit'] = '<i class="fa fa-exclamation-triangle danger" aria-hidden="true"></i> n/a';
+
+                                chunk['Comm'] = '<i class="fa fa-exclamation-triangle danger" aria-hidden="true"></i> ' + obj.Comm;
+                                chunk['CommDesc'] = '<i class="fa fa-exclamation-triangle danger" aria-hidden="true"></i> ' + obj.Comm + " deleted from model";
+                                pivotData.push(chunk);
+                            }
                         }
                         if(!obj.Tech){
                             pivotData.push(chunk);

--- a/WebAPP/DataStorage/Variables.json
+++ b/WebAPP/DataStorage/Variables.json
@@ -7,7 +7,7 @@
             "unitRule": {
                 "cat": [
                     {
-                        "var": ""
+                        "var": "number"
                     }
                 ]
             }
@@ -117,7 +117,11 @@
             "value": "Number Of New Technology Units",
             "name": "NumberOfNewTechnologyUnits",
             "unitRule": {
-                "cat": []
+                "cat": [
+                    {
+                        "var": "number"
+                    }
+                ]
             }
         },
         {
@@ -154,21 +158,10 @@
             "unitRule": {
                 "cat": [
                     {
-                        "var": "CapUnitId"
-                    }
-                ]
-            }
-        }
-    ],
-    "RYC": [
-        {
-            "id": "EB_d",
-            "value": "Shadow price - Annual Commodity Balance",
-            "name": "EBb4_EnergyBalanceEachYear4_ICR",
-            "unitRule": {
-                "cat": [
+                        "var": "milion"
+                    },
                     {
-                        "var": "CapUnitId"
+                        "var": "Currency"
                     }
                 ]
             }
@@ -182,33 +175,16 @@
             "unitRule": {
                 "cat": [
                     {
+                        "var": "milion"
+                    },
+                    {
+                        "var": "Currency"
+                    },
+                    {
+                        "var": "divide"
+                    },
+                    {
                         "var": "EmiUnit"
-                    }
-                ]
-            }
-        }
-    ],
-    "RYCn": [
-        {
-            "id": "UDCI_d",
-            "value": "Shadow price - UDC Inequality",
-            "name": "UDC1_UserDefinedConstraintInequality",
-            "unitRule": {
-                "cat": [
-                    {
-                        "var": ""
-                    }
-                ]
-            }
-        },
-        {
-            "id": "UDCE_d",
-            "value": "Shadow price - UDC Equality",
-            "name": "UDC2_UserDefinedConstraintEquality",
-            "unitRule": {
-                "cat": [
-                    {
-                        "var": ""
                     }
                 ]
             }
@@ -251,7 +227,6 @@
                 ]
             }
         },
-
         {
             "id": "SVS",
             "value": "Salvage Value Storage",
@@ -278,6 +253,55 @@
                     },
                     {
                         "var": "Currency"
+                    }
+                ]
+            }
+        }
+    ],
+    "RYC": [
+        {
+            "id": "EB_d",
+            "value": "Shadow price - Energy Balance",
+            "name": "EBb4_EnergyBalanceEachYear4_ICR",
+            "unitRule": {
+                "cat": [
+                    {
+                        "var": "milion"
+                    },
+                    {
+                        "var": "Currency"
+                    },
+                    {
+                        "var": "divide"
+                    },
+                    {
+                        "var": "EmiUnit"
+                    }
+                ]
+            }
+        }
+    ],
+    "RYCn": [
+        {
+            "id": "UDCI_d",
+            "value": "Shadow price - UDC Inequality",
+            "name": "UDC1_UserDefinedConstraintInequality",
+            "unitRule": {
+                "cat": [
+                    {
+                        "var": "number"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "UDCE_d",
+            "value": "Shadow price - UDC Equality",
+            "name": "UDC2_UserDefinedConstraintEquality",
+            "unitRule": {
+                "cat": [
+                    {
+                        "var": "number"
                     }
                 ]
             }
@@ -386,6 +410,12 @@
                 "cat": [
                     {
                         "var": "ActUnitId"
+                    },
+                    {
+                        "var": "divide"
+                    },
+                    {
+                        "var": "years"
                     }
                 ]
             }
@@ -412,6 +442,12 @@
                 "cat": [
                     {
                         "var": "CommUnit"
+                    },
+                    {
+                        "var": "divide"
+                    },
+                    {
+                        "var": "years"
                     }
                 ]
             }
@@ -424,6 +460,12 @@
                 "cat": [
                     {
                         "var": "CommUnit"
+                    },
+                    {
+                        "var": "divide"
+                    },
+                    {
+                        "var": "years"
                     }
                 ]
             }


### PR DESCRIPTION
## Linked issue

- Closes #392 
- Related #388 

## Existing related work reviewed

- Issues/PRs reviewed: #388, #390, #391, #397, #398, #405 

## Overlap assessment

- Classification: complementary and extending
- Overlapping items: #388 (parent tracker), #397 (backend sync), #405 (result metadata alignment)
- Why this is not duplicate/superseded:  
  - #405 aligns `Variables.json` and registers result groups at the metadata level  
  - This PR completes that alignment in the frontend rendering layer, ensuring:
    - `unitRule` is applied in Pivot for result groups that define units via metadata (while keeping upstream `Objective Value` behavior as `n/a`)
    - Correct dimension handling for `RYC`, `RYE`, `RYCn`
    - Consistent behavior in `updateParam` and `updateView`
    - Proper empty-state handling (no stale pivot data)  
  - Without these changes, metadata updates alone do not fully reflect in the UI

## Why this PR should proceed

- #392 has no existing end-to-end frontend implementation
- Frontend was not aligned with upstream v5.5 metadata
- Without this, result rendering and units remain inconsistent

## Summary

- What changed: 
  - Adopted and applied upstream `Variables.json` as source of truth across Pivot rendering
  - Fixed unit rendering using `unitRule` instead of hardcoded `n/a`
  - Added support for `RYCn` (constraint group)
  - Fixed Pivot handling and field rendering for `RYC`, `RYE`, and `RYCn` groups
  - Synced `updateView` logic with `updateParam`
  - Cleared pivot data when no results exist (prevents stale UI)
- Why:
  - Previous implementation assumed Tech-based groups
  - New v5.5 groups use different dimensions (Comm, Emi, Con)
  - Pivot needed to respect upstream grouping and unit rules

## Validation

- [x] Tests added/updated (not applicable; UI layer, no existing test coverage)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

Manual validation:
- `Shadow price - Energy Balance` (`RYC`)
  - commodity-based pivoting works
  - units render from metadata
- `Shadow price - Emissions Limit` (`RYE`)
  - emission-based pivoting works
  - units render from metadata
- `Shadow price - UDC Inequality` (`RYCn`)
  - constraint-based pivoting works
  - units render correctly
- `Shadow price - UDC Equality` (`RYCn`)
  - empty-state clears stale pivot/grid/chart content
- `Number Of New Technology Units`
  - `number`-based unit handling works

- Rechecked representative existing result paths:
  - `New Capacity`
  - `New Storage Capacity`
  - `Input To New Capacity`
  - `Rate Of Activity`

### RYC – Shadow price - Energy Balance

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0dd09a28-98fe-45b0-be1f-46a5fdce6a73" />

### RYCn – Shadow price - UDC Inequality

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8e95c379-a052-455e-be13-d8b465dc7fa0" />

### RYCn – Shadow price - UDC Equality (empty state)

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9fef5020-3ad1-4a38-800c-325d7a9af6ae" />

### RYT – Number Of New Technology Units

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8156c058-f29a-4a6e-a65c-73f41ccece6b" />

## Documentation

- [x] Docs updated in this PR (not applicable)
- [x] Any setup/workflow changes reflected in repo docs

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

## Exception rationale