### PR TITLE
Fix logically impossible condition in updateTEViewData when TechId an…

### DIFF
--- a/API/Classes/Case/OsemosysClass.py
+++ b/API/Classes/Case/OsemosysClass.py
@@ -947,10 +947,11 @@ class Osemosys():
             jsonData = File.readFile(jsonPath)
 
             for obj in jsonData[ParamId][ScId]:
-                for k,v in obj.items():
-                    if ((k == TechId if TechId is not None else True) and 
-                        (k == EmisId if EmisId is not None else True)):
-                        obj[k] = value
+                if TechId is not None and TechId in obj:
+                    if EmisId is not None and EmisId in obj[TechId]:
+                        obj[TechId][EmisId] = value
+                    elif EmisId is None:
+                        obj[TechId] = value
             File.writeFile( jsonData, jsonPath)
         except(IOError):
             raise IOError


### PR DESCRIPTION
…d EmisId are both provided

## Linked issue

* Closes #413 
* Related #413 

## Existing related work reviewed

* Issues/PRs reviewed: None found after search

## Overlap assessment

* Classification: Bug fix
* Overlapping items: None identified
* Why this is not duplicate/superseded: No existing issue or PR addresses the logically impossible condition in `updateTEViewData()`.

## Why this PR should proceed

* Fixes a logic error that prevents updates when both `TechId` and `EmisId` are provided.
* Ensures the update operation correctly modifies the JSON structure.
* Prevents silent failure where values were never written.

## Summary

* What changed:

  * Replaced a logically impossible condition where a single key `k` was compared against both `TechId` and `EmisId`.
  * Updated the logic to correctly treat `TechId` and `EmisId` as nested keys in the JSON structure.

* Why:

  * A single dictionary key cannot equal two different values simultaneously.
  * The previous condition always evaluated to `False` when both parameters were provided, preventing the update from executing.

## Validation

- [ ] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

## Documentation

- [x] Docs updated in this PR (or not applicable)
- [ ] Any setup/workflow changes reflected in repo docs

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

## Exception rationale

- Only for narrow docs/typo PRs that do not use a linked issue.
- Leave blank otherwise.
