### PR TITLE
fix: gracefully handle missing active session on download routes (fixes #415)

### DIFF
--- a/API/Routes/Case/CaseRoute.py
+++ b/API/Routes/Case/CaseRoute.py
@@ -449,6 +449,8 @@ def prepareCSV():
 def downloadCSV():
     try:
         casename = session.get('osycase', None)
+        if casename is None:
+            return jsonify({'message': 'No active session. Please select a model first.', 'status_code': 'error'}), 400
         dataFile = Path(Config.DATA_STORAGE,casename,'export.csv')
         
         dir = Path(Config.DATA_STORAGE,casename)

--- a/API/Routes/DataFile/DataFileRoute.py
+++ b/API/Routes/DataFile/DataFileRoute.py
@@ -210,6 +210,8 @@ def downloadDataFile():
         # return jsonify(response), 200
         #path = "/Examples.pdf"
         case = session.get('osycase', None)
+        if case is None:
+            return jsonify({'message': 'No active session. Please select a model first.', 'status_code': 'error'}), 400
         caserunname = request.args.get('caserunname')
         Config.validate_path(Config.DATA_STORAGE, os.path.join(case or '', 'res', caserunname or ''))
         dataFile = Path(Config.DATA_STORAGE,case, 'res',caserunname, 'data.txt')
@@ -224,6 +226,8 @@ def downloadDataFile():
 def downloadFile():
     try:
         case = session.get('osycase', None)
+        if case is None:
+            return jsonify({'message': 'No active session. Please select a model first.', 'status_code': 'error'}), 400
         file = request.args.get('file')
         Config.validate_path(Config.DATA_STORAGE, os.path.join(case or '', 'res', 'csv', file or ''))
         dataFile = Path(Config.DATA_STORAGE,case,'res','csv',file)
@@ -238,6 +242,8 @@ def downloadFile():
 def downloadCSVFile():
     try:
         case = session.get('osycase', None)
+        if case is None:
+            return jsonify({'message': 'No active session. Please select a model first.', 'status_code': 'error'}), 400
         file = request.args.get('file')
         caserunname = request.args.get('caserunname')
         Config.validate_path(Config.DATA_STORAGE, os.path.join(case or '', 'res', caserunname or '', 'csv', file or ''))
@@ -253,6 +259,8 @@ def downloadCSVFile():
 def downloadResultsFile():
     try:
         case = session.get('osycase', None)
+        if case is None:
+            return jsonify({'message': 'No active session. Please select a model first.', 'status_code': 'error'}), 400
         caserunname = request.args.get('caserunname')
         Config.validate_path(Config.DATA_STORAGE, os.path.join(case or '', 'res', caserunname or ''))
         dataFile = Path(Config.DATA_STORAGE,case, 'res', caserunname,'results.txt')

--- a/API/Routes/DataFile/DataFileRoute.py
+++ b/API/Routes/DataFile/DataFileRoute.py
@@ -213,6 +213,8 @@ def downloadDataFile():
         if case is None:
             return jsonify({'message': 'No active session. Please select a model first.', 'status_code': 'error'}), 400
         caserunname = request.args.get('caserunname')
+        if not caserunname:
+            return jsonify({'message': 'Missing required parameter: caserunname.', 'status_code': 'error'}), 400
         Config.validate_path(Config.DATA_STORAGE, os.path.join(case or '', 'res', caserunname or ''))
         dataFile = Path(Config.DATA_STORAGE,case, 'res',caserunname, 'data.txt')
         return send_file(dataFile.resolve(), as_attachment=True, max_age=0)
@@ -229,6 +231,8 @@ def downloadFile():
         if case is None:
             return jsonify({'message': 'No active session. Please select a model first.', 'status_code': 'error'}), 400
         file = request.args.get('file')
+        if not file:
+            return jsonify({'message': 'Missing required parameter: file.', 'status_code': 'error'}), 400
         Config.validate_path(Config.DATA_STORAGE, os.path.join(case or '', 'res', 'csv', file or ''))
         dataFile = Path(Config.DATA_STORAGE,case,'res','csv',file)
         return send_file(dataFile.resolve(), as_attachment=True, max_age=0)
@@ -246,6 +250,10 @@ def downloadCSVFile():
             return jsonify({'message': 'No active session. Please select a model first.', 'status_code': 'error'}), 400
         file = request.args.get('file')
         caserunname = request.args.get('caserunname')
+        if not file:
+            return jsonify({'message': 'Missing required parameter: file.', 'status_code': 'error'}), 400
+        if not caserunname:
+            return jsonify({'message': 'Missing required parameter: caserunname.', 'status_code': 'error'}), 400
         Config.validate_path(Config.DATA_STORAGE, os.path.join(case or '', 'res', caserunname or '', 'csv', file or ''))
         dataFile = Path(Config.DATA_STORAGE,case,'res',caserunname,'csv',file)
         return send_file(dataFile.resolve(), as_attachment=True, max_age=0)
@@ -262,6 +270,8 @@ def downloadResultsFile():
         if case is None:
             return jsonify({'message': 'No active session. Please select a model first.', 'status_code': 'error'}), 400
         caserunname = request.args.get('caserunname')
+        if not caserunname:
+            return jsonify({'message': 'Missing required parameter: caserunname.', 'status_code': 'error'}), 400
         Config.validate_path(Config.DATA_STORAGE, os.path.join(case or '', 'res', caserunname or ''))
         dataFile = Path(Config.DATA_STORAGE,case, 'res', caserunname,'results.txt')
         return send_file(dataFile.resolve(), as_attachment=True, max_age=0)

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -122,5 +122,61 @@ class AppSmokeTests(unittest.TestCase):
         self.assertEqual(result.stdout.strip(), "")
 
 
+class DownloadRouteGuardTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        sys.path.insert(0, str(API_DIR))
+        os.environ.setdefault("MUIOGO_SECRET_KEY", "smoke-test-secret")
+        cls.app_module = importlib.import_module("app")
+
+    def setUp(self):
+        self.client = self.app_module.app.test_client()
+
+    def test_download_routes_require_active_session(self):
+        endpoints = [
+            ("/downloadDataFile", {"caserunname": "run1"}),
+            ("/downloadFile", {"file": "result.csv"}),
+            ("/downloadCSVFile", {"file": "result.csv", "caserunname": "run1"}),
+            ("/downloadResultsFile", {"caserunname": "run1"}),
+            ("/downloadCSV", {}),
+        ]
+
+        for path, query in endpoints:
+            with self.subTest(path=path):
+                response = self.client.get(path, query_string=query)
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.get_json(),
+                    {
+                        "message": "No active session. Please select a model first.",
+                        "status_code": "error",
+                    },
+                )
+
+    def test_download_routes_require_query_params(self):
+        with self.client.session_transaction() as session_data:
+            session_data["osycase"] = "demo"
+
+        cases = [
+            ("/downloadDataFile", {}, "Missing required parameter: caserunname."),
+            ("/downloadFile", {}, "Missing required parameter: file."),
+            ("/downloadCSVFile", {"caserunname": "run1"}, "Missing required parameter: file."),
+            ("/downloadCSVFile", {"file": "result.csv"}, "Missing required parameter: caserunname."),
+            ("/downloadResultsFile", {}, "Missing required parameter: caserunname."),
+        ]
+
+        for path, query, message in cases:
+            with self.subTest(path=path, query=query):
+                response = self.client.get(path, query_string=query)
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(
+                    response.get_json(),
+                    {
+                        "message": message,
+                        "status_code": "error",
+                    },
+                )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Linked issue

- Closes #415
- Related #400, #411

## Existing related work reviewed

- Issues/PRs reviewed: #407, #400, #411
- If none found, write: None found after search

## Overlap assessment

- Classification: Bug Fix / Edge Case Logic Fix
- Overlapping items: PR #407 touches missing `resData` handling, but entirely misses the missing session vulnerabilities in the [download](cci:1://file:///e:/MUIOGO/MUIOGO/API/Routes/Case/CaseRoute.py:431:0-443:49) endpoints.
- Why this is not duplicate/superseded: No other PR addresses the missing session checks and `TypeError` crashes specifically occurring across the file download routes.

## Why this PR should proceed

- It addresses a critical crash (`500 Internal Server Error`) that occurs when any of the 5 download routes are accessed without a correctly initialized active session, safely catching the error and returning an appropriate `400` response.

## Summary

- What changed: In [API/Routes/DataFile/DataFileRoute.py](cci:7://file:///e:/MUIOGO/MUIOGO/API/Routes/DataFile/DataFileRoute.py:0:0-0:0) (4 routes) and [API/Routes/Case/CaseRoute.py](cci:7://file:///e:/MUIOGO/MUIOGO/API/Routes/Case/CaseRoute.py:0:0-0:0) (1 route), added conditional block `if case is None:` returning a graceful 400 JSON response instead of blindly continuing to the dataset lookup.
- Why: The `pathlib.Path` constructor requires a string and cannot process a returned `None` from `session.get('osycase', None)`. Doing so throws an unhandled `TypeError` in the route's primary thread, crashing the Flask route.

## Validation

- [ ] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

## Documentation

- [ ] Docs updated in this PR (or not applicable)
- [ ] Any setup/workflow changes reflected in repo docs

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

## Exception rationale

- 
