### PR TITLE
fix: handle restore warning responses in upload UI

### DIFF
--- a/WebAPP/Classes/Base.Class.js
+++ b/WebAPP/Classes/Base.Class.js
@@ -233,6 +233,26 @@ export class Base {
     static uploadFunction = function () {
         Dropzone.autoDiscover = false;
 
+        const handleCaseRestoreSuccess = function (result, showWarning = false) {
+            let casename = result.casename;
+            if (casename) {
+                Html.apendModel(casename);
+            }
+
+            Message.bigBoxSuccess("Upload response", result.message, null);
+            if (showWarning && result.message_warning) {
+                Message.warningOsy(result.message_warning);
+            }
+
+            $('#modalrestore').modal('toggle');
+            if (Base.AWS_SYNC == 1 && casename) {
+                SyncS3.deleteResultsPreSync(casename)
+                    .then(response => {
+                        SyncS3.uploadSync(casename);
+                    });
+            }
+        };
+
         var MyDropzone = new Dropzone("#myDropzone", {
             //url: "http://127.0.0.1:5000/upload",
             url: Base.apiUrl() + "uploadCase",
@@ -270,22 +290,24 @@ export class Base {
             // },
             success: function (file, response) {
                 console.log('response ', response   )
-           
-                if (response.response[0]['status_code'] == 'success') {
-                    let casename = response.response[0]['casename'];
-                         console.log('casename ', casename   )
-                    Html.apendModel(casename);
-                    Message.bigBoxSuccess("Upload response", response.response[0]['message'], null);
-                    //value.previewElement.innerHTML = "";
-                    $('#modalrestore').modal('toggle');
-                    if (Base.AWS_SYNC == 1) {
-                        SyncS3.deleteResultsPreSync(casename)
-                            .then(response => {
-                                SyncS3.uploadSync(casename);
-                            });
-                    }
-                } else if (response.response[0]['status_code'] == 'warning') {
+                const result = response.response && response.response[0];
 
+                if (!result) {
+                    Message.bigBoxDanger("Upload response", "Upload completed but returned an unexpected response.", null);
+                    return;
+                }
+
+                if (result['status_code'] == 'success') {
+                    console.log('casename ', result['casename'])
+                    handleCaseRestoreSuccess(result);
+                } else if (result['status_code'] == 'warning') {
+                    if (result.message_warning) {
+                        handleCaseRestoreSuccess(result, true);
+                    } else {
+                        Message.bigBoxWarning("Upload response", result['message'], null);
+                    }
+                } else if (result['status_code'] == 'error') {
+                    Message.bigBoxDanger("Upload response", result['message'], null);
                 }
                 // $.each(file, function (key, value) {
                 //     if (response.response[key]['status_code'] == 'success') {


### PR DESCRIPTION
## Linked issue

- Closes #420
- Related #293, #322, #341, #404, #419

## Existing related work reviewed

- Issues/PRs reviewed:
  - #293 Move demo data archive to GitHub release asset, download on demand
  - #322 Replace `zf.extractall` with `safe_extractall`
  - #341 fix(backupCase): replace download thread race with `after_this_request`
  - #404 Fix: calculate relative arcname for backupCase ZIP generation
  - #419 fix(api): implement robust zip extraction and path sanitization
- None of the above appears to address the frontend restore-warning handling gap in the upload success callback.

## Overlap assessment

- Classification: Adjacent but non-overlapping
- Overlapping items:
  - #293, #322, #341, #404, and #419 are all archive / restore / ZIP-related at the backend or archive-processing layer
- Why this is not duplicate/superseded:
  - This PR fixes a frontend behavior bug in `WebAPP/Classes/Base.Class.js`
  - The backend already returns a valid legacy-restore warning response
  - The bug is that the browser success handler ignores that warning path entirely
  - As a result, a legacy restore can succeed on disk while the UI does not append the restored model, does not close the modal, and does not surface the upgrade warning
  - That is a separate issue from ZIP extraction safety, backup archive contents, or backend restore mechanics

## Why this PR should proceed

- It fixes a real user-visible bug where successful legacy restores appear to fail in the UI
- The change is narrow, low-risk, and isolated to the upload success handler
- It improves correctness without changing backend contracts or adding broad refactors
- It restores expected behavior for legacy model uploads while preserving warning-only handling for non-restoring cases such as "already exists"

## Summary

- What changed:
  - Added a small shared success helper for case-restore responses in `WebAPP/Classes/Base.Class.js`
  - Updated the upload success callback to handle three cases explicitly:
    - `success`
    - `warning` with `message_warning` for successful legacy restores
    - `warning` without restore side effects, such as "already exists"
  - Added a defensive guard for malformed / unexpected upload responses
- Why:
  - The backend intentionally returns `status_code: "warning"` for older model restores
  - The previous frontend code had an empty `warning` branch, so restore completion was not reflected in the UI
  - Users could therefore restore a legacy model successfully but see no appended model, no modal close, and no migration guidance

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented

Validation details:
- Ran a targeted Node-based harness against the actual upload success callback logic
- Verified expected behavior for:
  - `success`: model appended, success message shown, modal closed
  - legacy restore `warning`: model appended, success message shown, upgrade warning shown, modal closed
  - non-restoring `warning`: warning shown only, no UI mutation
  - `error`: danger message shown

Example validation output:
```text
success: [["append","Demo"],["success","Upload response","ok",null],["modal","toggle"]]
warning_restore: [["append","Legacy"],["success","Upload response","uploaded",null],["warningOsy","needs update"],["modal","toggle"]]
warning_exists: [["warning","Upload response","already exists",null]]
error: [["danger","Upload response","bad zip",null]]
