### PR TITLE
test: establish Playwright E2E UI testing foundation (#426)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,42 @@ jobs:
 
       - name: Run tests
         run: pytest --cov=API --cov-report=term-missing --cov-fail-under=5
+
+  ui-test:
+    name: UI E2E (Playwright)
+    runs-on: ubuntu-latest
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Fix requirements encoding
+        run: |
+          python - <<'EOF'
+          import pathlib
+          data = pathlib.Path("requirements.txt").read_bytes()
+          if b"\x00" in data:
+              text = data.decode("utf-16")
+              pathlib.Path("requirements.txt").write_text(text, encoding="utf-8")
+              print("Converted requirements.txt from UTF-16 to UTF-8")
+          else:
+              print("requirements.txt encoding OK")
+          EOF
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Install Playwright
+        run: |
+          pip install "pytest>=7" pytest-playwright requests
+          playwright install chromium
+
+      - name: Run UI Tests
+        run: pytest ui_tests/ -v

--- a/API/app.py
+++ b/API/app.py
@@ -168,6 +168,11 @@ def setSession():
         return jsonify('No selected parameters!'), 404
 
 
+@app.route("/health", methods=['GET'])
+def health_check():
+    return jsonify({"status": "ok"}), 200
+
+
 if __name__ == '__main__':
 # if __name__ == 'app':
     #potrebno radi module js importa u index.html ES6 modules

--- a/README.md
+++ b/README.md
@@ -114,6 +114,23 @@ pip install -r requirements.txt
 pip install -r requirements-build-win.txt
 ```
 
+### Running UI Tests Locally (Playwright E2E)
+
+Because the Playwright dependencies are intentionally kept out of the main `requirements.txt` to keep the production bundle lightweight, you will need to install them manually when developing locally:
+
+```bash
+# 1. Install testing dependencies
+pip install "pytest>=7" pytest-playwright requests
+
+# 2. Install Playwright browser binaries
+playwright install chromium
+
+# 3. Run the UI test suite
+pytest ui_tests/ -v
+```
+
+The E2E test suite automatically spawns an isolated Flask server instance on port `5003` (to avoid conflicting with standard instances) and waits for the application to be fully ready before it executes DOM checks.
+
 ## Project Boundaries
 
 This repository is downstream and separately managed from upstream:

--- a/ui_tests/conftest.py
+++ b/ui_tests/conftest.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import time
+import pytest
+import requests
+import subprocess
+
+@pytest.fixture(scope="session")
+def live_server():
+    """
+    Spins up the Flask backend server on port 5003 for Playwright UI tests.
+    Polls the /health endpoint until it is ready (max 15 seconds) before
+    yielding control to the test runners.
+    """
+    env = os.environ.copy()
+    env["PORT"] = "5003"
+    env["HEROKU_DEPLOY"] = "0"
+
+    print("\nStarting Flask server for E2E tests on port 5003...")
+    
+    # Start the Flask app
+    process = subprocess.Popen(
+        [sys.executable, "API/app.py"],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True
+    )
+
+    base_url = "http://127.0.0.1:5003"
+    api_ready = False
+    
+    # Poll for 15 seconds
+    for _ in range(30):
+        try:
+            res = requests.get(f"{base_url}/health", timeout=1)
+            if res.status_code == 200:
+                api_ready = True
+                break
+        except requests.exceptions.RequestException:
+            pass
+        time.sleep(0.5)
+
+    if not api_ready:
+        process.terminate()
+        outs, errs = process.communicate(timeout=2)
+        raise RuntimeError(f"Flask server at {base_url} did not start within 15 seconds.\nStderr: {errs}")
+
+    yield base_url
+
+    print("\nShutting down Flask server...")
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()

--- a/ui_tests/conftest.py
+++ b/ui_tests/conftest.py
@@ -1,56 +1,110 @@
+"""
+conftest.py — pytest fixture that starts the MUIOGO Flask server for Playwright E2E tests.
+
+Strategy: Run Waitress in a daemon thread *inside* the pytest process.
+
+Why not subprocess?
+  subprocess + Flask dev server (app.run) hangs serving static files on Python 3.12 Windows.
+
+Why Waitress (not Flask dev server)?
+  - Proven to work: it's how the app runs in production.
+  - Threaded properly: 16 threads prevent exhaustion from Playwright's burst of concurrent
+    JS/CSS asset requests when loading index.html.
+
+Why daemon thread (not subprocess)?
+  - Avoids all cross-platform CWD / sys.path / env-var inheritance issues.
+  - The thread is killed automatically when the pytest session ends.
+"""
 import os
 import sys
 import time
+import threading
+
 import pytest
 import requests
-import subprocess
+
+# ---------------------------------------------------------------------------
+# Path constants
+# ---------------------------------------------------------------------------
+_HERE = os.path.dirname(os.path.abspath(__file__))          # ui_tests/
+_PROJECT_ROOT = os.path.dirname(_HERE)                       # MUIOGO/
+_API_DIR = os.path.join(_PROJECT_ROOT, "API")                # MUIOGO/API/
+
+TEST_PORT = 5003
+BASE_URL = f"http://127.0.0.1:{TEST_PORT}"
+
+
+def _run_waitress(app) -> None:
+    """Target function for the daemon thread: serve with Waitress."""
+    from waitress import serve
+    serve(
+        app,
+        host="127.0.0.1",
+        port=TEST_PORT,
+        threads=16,          # handles burst of parallel asset requests from Playwright
+        channel_timeout=10,  # release idle connections quickly between test sessions
+    )
+
 
 @pytest.fixture(scope="session")
 def live_server():
     """
-    Spins up the Flask backend server on port 5003 for Playwright UI tests.
-    Polls the /health endpoint until it is ready (max 15 seconds) before
-    yielding control to the test runners.
+    Start the Flask app in a Waitress daemon thread on port 5003.
+
+    The fixture:
+      1. Configures the environment (HEROKU_DEPLOY=0 → local file sessions, no PostgreSQL).
+      2. Adds API/ to sys.path and changes CWD to project root — mirrors how the app
+         is normally launched, so Config.WEBAPP_PATH resolves to the correct WebAPP/ dir.
+      3. Imports the Flask `app` object and hands it to Waitress running in a daemon thread.
+      4. Polls /health for up to 15 seconds before yielding to the tests.
+      5. Restores CWD on teardown (the daemon thread is killed automatically).
     """
-    env = os.environ.copy()
-    env["PORT"] = "5003"
-    env["HEROKU_DEPLOY"] = "0"
+    # 1. Configure environment BEFORE importing the app so Config reads correct values.
+    os.environ["HEROKU_DEPLOY"] = "0"
+    os.environ["PORT"] = str(TEST_PORT)
 
-    print("\nStarting Flask server for E2E tests on port 5003...")
-    
-    # Start the Flask app
-    process = subprocess.Popen(
-        [sys.executable, "API/app.py"],
-        env=env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True
-    )
+    # 2. Add API/ to sys.path so `from app import app` and its internal imports work.
+    if _API_DIR not in sys.path:
+        sys.path.insert(0, _API_DIR)
 
-    base_url = "http://127.0.0.1:5003"
-    api_ready = False
-    
-    # Poll for 15 seconds
-    for _ in range(30):
-        try:
-            res = requests.get(f"{base_url}/health", timeout=1)
-            if res.status_code == 200:
-                api_ready = True
-                break
-        except requests.exceptions.RequestException:
-            pass
-        time.sleep(0.5)
+    # 3. Change CWD to project root — same as when the app is launched normally.
+    original_cwd = os.getcwd()
+    os.chdir(_PROJECT_ROOT)
 
-    if not api_ready:
-        process.terminate()
-        outs, errs = process.communicate(timeout=2)
-        raise RuntimeError(f"Flask server at {base_url} did not start within 15 seconds.\nStderr: {errs}")
-
-    yield base_url
-
-    print("\nShutting down Flask server...")
-    process.terminate()
     try:
-        process.wait(timeout=5)
-    except subprocess.TimeoutExpired:
-        process.kill()
+        import mimetypes
+        mimetypes.add_type("application/javascript", ".js")
+
+        # Import the Flask application (app-level Config is read here).
+        from app import app  # noqa: E402  (import after path manipulation)
+
+        thread = threading.Thread(
+            target=_run_waitress,
+            args=(app,),
+            daemon=True,          # killed automatically when pytest exits
+            name="muiogo-test-server",
+        )
+        thread.start()
+
+        # 4. Poll /health until the server is ready (max 15 s).
+        ready = False
+        for _ in range(30):
+            try:
+                r = requests.get(f"{BASE_URL}/health", timeout=1)
+                if r.status_code == 200:
+                    ready = True
+                    break
+            except requests.exceptions.RequestException:
+                pass
+            time.sleep(0.5)
+
+        if not ready:
+            raise RuntimeError(
+                f"Flask test server at {BASE_URL} did not start within 15 seconds."
+            )
+
+        yield BASE_URL
+
+    finally:
+        # 5. Restore CWD for safety (daemon thread dies with the process).
+        os.chdir(original_cwd)

--- a/ui_tests/start_test_server.py
+++ b/ui_tests/start_test_server.py
@@ -1,0 +1,39 @@
+"""
+Test-specific Flask server entrypoint for Playwright E2E tests.
+
+Uses Flask's built-in threaded WSGI server (not Waitress) to reliably handle
+the burst of concurrent asset requests that Playwright fires when loading
+index.html — jQuery, Wijmo, SmartAdmin, Plotly etc load in parallel.
+
+Waitress defaults to 4 threads which gets saturated on Windows causing all
+subsequent requests to hang. Flask's threaded=True uses a new thread per
+connection which correctly handles concurrent browser asset loading.
+"""
+import os
+import sys
+import mimetypes
+
+# Resolve paths relative to this file
+_ui_tests_dir = os.path.dirname(os.path.abspath(__file__))
+_project_root = os.path.dirname(_ui_tests_dir)
+_api_dir = os.path.join(_project_root, "API")
+
+# API-internal imports (Config, Routes, etc.) use non-package style
+sys.path.insert(0, _api_dir)
+
+# Ensure CWD is the project root so Flask finds WebAPP/ for templates/static
+os.chdir(_project_root)
+
+from app import app  # noqa: E402  (after path manipulation)
+
+mimetypes.add_type("application/javascript", ".js")
+
+port = int(os.environ.get("PORT", 5003))
+
+app.run(
+    host="127.0.0.1",
+    port=port,
+    threaded=True,       # one thread per connection — handles burst asset loads
+    use_reloader=False,  # never auto-restart inside a test subprocess
+    debug=False,
+)

--- a/ui_tests/test_ui_smoke.py
+++ b/ui_tests/test_ui_smoke.py
@@ -1,55 +1,66 @@
+"""
+test_ui_smoke.py — Playwright smoke tests for the MUIOGO frontend.
+
+Scope: verify that Flask serves the app and core UI elements are present.
+These tests are intentionally minimal and environment-agnostic.
+
+Design rules:
+  - wait_until="commit" on every page.goto() — returns the moment Flask starts
+    sending the response without waiting for CDN resources (MathJax etc.).
+  - Element assertions use generous timeouts because index.html loads ~20
+    synchronous <script> tags before #main and the footer are fully parsed.
+  - No SPA route tests (/#AddCase, /#Home, /#Config) — those require jQuery
+    $.load() to complete and are flaky in headless CI.
+"""
 import re
+
 import requests
 from playwright.sync_api import Page, expect
 
 
+# ---------------------------------------------------------------------------
+# Pure API tests (no browser required)
+# ---------------------------------------------------------------------------
+
 def test_health_endpoint(live_server: str):
-    """Verify the /health API endpoint returns 200 OK (pure API smoke test)."""
-    response = requests.get(f"{live_server}/health", timeout=5)
-    assert response.status_code == 200
-    assert response.json().get("status") == "ok"
-
-
-def test_load_app(page: Page, live_server: str):
-    """
-    Verify that the root page loads with the correct title and static scaffold.
-
-    This checks what Flask actually server-renders via index.html — the page
-    title, the fixed footer text, and the static structural containers.
-    These are guaranteed to be present before any JS executes.
-    """
-    page.goto(live_server)
-
-    # 1. Page title is set statically in index.html
-    expect(page).to_have_title(re.compile(r"MUIO\s*5\.5"))
-
-    # 2. Footer text is hardcoded in index.html — always present
-    expect(page.get_by_text("MUIO ver.5.5", exact=False).first).to_be_visible(timeout=10000)
-
-    # 3. The main content div exists in index.html (no JS needed)
-    expect(page.locator("#main")).to_be_visible(timeout=10000)
-
-
-def test_spa_navbar_hydrates(page: Page, live_server: str):
-    """
-    Verify that jQuery loads the Navbar.html partial into the header.
-
-    The navbar brand text 'MUIO' is injected by:
-      $('header').load('App/View/Navbar.html')
-    We wait up to 15s for it to appear, which covers CI cold-start latency.
-    """
-    page.goto(live_server)
-
-    # The navbar brand text is inside Navbar.html loaded by jQuery
-    expect(page.locator("#header").get_by_text("MUIO", exact=False)).to_be_visible(
-        timeout=15000
-    )
+    """Flask /health must return {"status": "ok"}."""
+    r = requests.get(f"{live_server}/health", timeout=5)
+    assert r.status_code == 200
+    assert r.json().get("status") == "ok"
 
 
 def test_session_api(live_server: str):
-    """Verify the /getSession endpoint returns a valid JSON response."""
-    response = requests.get(f"{live_server}/getSession", timeout=5)
-    assert response.status_code == 200
-    data = response.json()
-    # session key must be present (value can be None for a fresh session)
-    assert "session" in data
+    """Flask /getSession must return a JSON object with a 'session' key."""
+    r = requests.get(f"{live_server}/getSession", timeout=5)
+    assert r.status_code == 200
+    assert "session" in r.json()
+
+
+# ---------------------------------------------------------------------------
+# Browser tests (Playwright)
+# ---------------------------------------------------------------------------
+
+def test_load_app(page: Page, live_server: str):
+    """
+    The root URL must serve index.html with the correct page title.
+
+    wait_until='commit' returns the instant Flask starts sending bytes.
+    to_have_title then polls until the <title> tag is parsed (fast, in <head>).
+    """
+    page.goto(live_server, wait_until="commit")
+    expect(page).to_have_title(re.compile(r"MUIO\s*5\.5"), timeout=15000)
+
+
+def test_static_footer(page: Page, live_server: str):
+    """
+    The footer copyright text must be present in the DOM.
+
+    'MUIO ver.5.5' is hardcoded in index.html (line 143) — no JS needed.
+    It sits after ~20 synchronous <script> tags so we allow 60 s for the
+    browser to finish downloading and executing all blocking scripts.
+    to_be_attached (not to_be_visible) because the footer may be off-screen.
+    """
+    page.goto(live_server, wait_until="commit")
+    expect(
+        page.get_by_text("MUIO ver.5.5", exact=False).first
+    ).to_be_attached(timeout=60000)

--- a/ui_tests/test_ui_smoke.py
+++ b/ui_tests/test_ui_smoke.py
@@ -1,59 +1,58 @@
 import re
+import requests
 from playwright.sync_api import Page, expect
 
+
 def test_load_app(page: Page, live_server: str):
-    """Verify that the index defaults and app container loads correctly."""
+    """Verify the app title and core navigation scaffold renders correctly."""
     page.goto(live_server)
-    
-    # Wait for the frontend to be fully hydrated by checking a known nav element
-    # Explicitly bypassing CSS/ID selectors as requested, using get_by_text / get_by_role
+
+    # Wait for full hydration — check a known branded text in the navbar
     expect(page.get_by_text("MUIO", exact=False).first).to_be_visible(timeout=15000)
     expect(page).to_have_title(re.compile(r"MUIO\s*5\.5"))
 
-def test_case_management(page: Page, live_server: str):
-    """Verify the creation, session activation, and deletion of a mock case."""
-    # Ensure hydration before navigating
+
+def test_add_case_ui_renders(page: Page, live_server: str):
+    """
+    Verify the Add Case form UI mounts correctly.
+
+    Note: Full case creation requires complex jqx widget interaction (year range
+    slider checkboxes) that doesn't translate to headless automation. This smoke
+    test validates the form scaffold renders, which is the critical regression
+    surface for this route.
+    """
     page.goto(f"{live_server}/#AddCase")
-    
-    # Use placeholder instead of #osy-casename ID locator
-    model_name_input = page.get_by_placeholder("Model name")
-    expect(model_name_input).to_be_visible(timeout=10000)
-    
-    # Fill in case data
-    test_case_name = "PlaywrightMockCase"
-    model_name_input.fill(test_case_name)
-    
-    # Click Save new model using role and text
-    page.get_by_role("button", name=re.compile("Save new model", re.IGNORECASE)).click()
-    
-    # Wait to allow AJAX save request to complete before navigating away
-    page.wait_for_timeout(3000)
-    
-    # Go to Home
+
+    # The Model name input field must be visible — proves the AddCase view mounted
+    expect(page.get_by_placeholder("Model name")).to_be_visible(timeout=10000)
+
+    # The page title heading must reflect the route
+    expect(page.get_by_text("Model configuration", exact=False).first).to_be_visible(timeout=10000)
+
+
+def test_home_ui_renders(page: Page, live_server: str):
+    """Verify the Home page MUIO models panel renders without errors."""
     page.goto(f"{live_server}/#Home")
-    
-    # Wait for the case text to be visible in the datatable/cards, confirming creation
-    expect(page.get_by_text(test_case_name).first).to_be_visible(timeout=10000)
-    
-    # Delete the case utilizing the trash icon or delete button role 
-    # (Checking for 'Delete model' title which bypasses class name reliance)
-    trash_icon = page.get_by_title("Delete model").first
-    if trash_icon.count() > 0:
-        trash_icon.click()
-        # Accept confirmation dialogs automatically
-        page.on("dialog", lambda dialog: dialog.accept())
-        confirm_btn = page.get_by_role("button", name=re.compile("Yes", re.IGNORECASE))
-        if confirm_btn.is_visible():
-            confirm_btn.click()
+
+    # The 'MUIO models' heading inside the jarviswidget must be present
+    expect(page.get_by_text("MUIO models", exact=False).first).to_be_visible(timeout=10000)
+
+    # The case search input must be visible — proves the widget scaffold loaded
+    expect(page.get_by_placeholder("Search ...")).to_be_visible(timeout=10000)
+
 
 def test_navigation_diagnostics(page: Page, live_server: str):
-    """Ensure major tabs render properly and verify equations in ModelFile diagnostic UI."""
-    page.goto(f"{live_server}/#ModelFile")
-    
-    # Wait for hydration on ModelFile by checking for expected text content
-    expect(page.get_by_text("Model", exact=False).first).to_be_visible(timeout=10000)
-    
-    # Check Parameters / Config page
+    """Verify the Config/Parameters view mounts with expected headings."""
     page.goto(f"{live_server}/#Config")
-    expect(page.get_by_role("heading", name=re.compile("Parameters", re.IGNORECASE)).first).to_be_visible(timeout=10000)
 
+    # The h2 page title for the Config route contains "Parameters"
+    expect(
+        page.get_by_role("heading", name=re.compile("Parameters", re.IGNORECASE)).first
+    ).to_be_visible(timeout=10000)
+
+
+def test_health_endpoint(live_server: str):
+    """Verify the /health API endpoint returns 200 OK (pure API smoke test)."""
+    response = requests.get(f"{live_server}/health", timeout=5)
+    assert response.status_code == 200
+    assert response.json().get("status") == "ok"

--- a/ui_tests/test_ui_smoke.py
+++ b/ui_tests/test_ui_smoke.py
@@ -26,6 +26,9 @@ def test_case_management(page: Page, live_server: str):
     # Click Save new model using role and text
     page.get_by_role("button", name=re.compile("Save new model", re.IGNORECASE)).click()
     
+    # Wait to allow AJAX save request to complete before navigating away
+    page.wait_for_timeout(3000)
+    
     # Go to Home
     page.goto(f"{live_server}/#Home")
     
@@ -51,6 +54,6 @@ def test_navigation_diagnostics(page: Page, live_server: str):
     expect(page.get_by_text("Model", exact=False).first).to_be_visible(timeout=10000)
     
     # Check Parameters / Config page
-    page.goto(f"{live_server}/#Parameters")
-    expect(page.get_by_text("Parameters", exact=False).first).to_be_visible(timeout=10000)
+    page.goto(f"{live_server}/#Config")
+    expect(page.get_by_role("heading", name=re.compile("Parameters", re.IGNORECASE)).first).to_be_visible(timeout=10000)
 

--- a/ui_tests/test_ui_smoke.py
+++ b/ui_tests/test_ui_smoke.py
@@ -3,56 +3,53 @@ import requests
 from playwright.sync_api import Page, expect
 
 
-def test_load_app(page: Page, live_server: str):
-    """Verify the app title and core navigation scaffold renders correctly."""
-    page.goto(live_server)
-
-    # Wait for full hydration — check a known branded text in the navbar
-    expect(page.get_by_text("MUIO", exact=False).first).to_be_visible(timeout=15000)
-    expect(page).to_have_title(re.compile(r"MUIO\s*5\.5"))
-
-
-def test_add_case_ui_renders(page: Page, live_server: str):
-    """
-    Verify the Add Case form UI mounts correctly.
-
-    Note: Full case creation requires complex jqx widget interaction (year range
-    slider checkboxes) that doesn't translate to headless automation. This smoke
-    test validates the form scaffold renders, which is the critical regression
-    surface for this route.
-    """
-    page.goto(f"{live_server}/#AddCase")
-
-    # The Model name input field must be visible — proves the AddCase view mounted
-    expect(page.get_by_placeholder("Model name")).to_be_visible(timeout=10000)
-
-    # The page title heading must reflect the route
-    expect(page.get_by_text("Model configuration", exact=False).first).to_be_visible(timeout=10000)
-
-
-def test_home_ui_renders(page: Page, live_server: str):
-    """Verify the Home page MUIO models panel renders without errors."""
-    page.goto(f"{live_server}/#Home")
-
-    # The 'MUIO models' heading inside the jarviswidget must be present
-    expect(page.get_by_text("MUIO models", exact=False).first).to_be_visible(timeout=10000)
-
-    # The case search input must be visible — proves the widget scaffold loaded
-    expect(page.get_by_placeholder("Search ...")).to_be_visible(timeout=10000)
-
-
-def test_navigation_diagnostics(page: Page, live_server: str):
-    """Verify the Config/Parameters view mounts with expected headings."""
-    page.goto(f"{live_server}/#Config")
-
-    # The h2 page title for the Config route contains "Parameters"
-    expect(
-        page.get_by_role("heading", name=re.compile("Parameters", re.IGNORECASE)).first
-    ).to_be_visible(timeout=10000)
-
-
 def test_health_endpoint(live_server: str):
     """Verify the /health API endpoint returns 200 OK (pure API smoke test)."""
     response = requests.get(f"{live_server}/health", timeout=5)
     assert response.status_code == 200
     assert response.json().get("status") == "ok"
+
+
+def test_load_app(page: Page, live_server: str):
+    """
+    Verify that the root page loads with the correct title and static scaffold.
+
+    This checks what Flask actually server-renders via index.html — the page
+    title, the fixed footer text, and the static structural containers.
+    These are guaranteed to be present before any JS executes.
+    """
+    page.goto(live_server)
+
+    # 1. Page title is set statically in index.html
+    expect(page).to_have_title(re.compile(r"MUIO\s*5\.5"))
+
+    # 2. Footer text is hardcoded in index.html — always present
+    expect(page.get_by_text("MUIO ver.5.5", exact=False).first).to_be_visible(timeout=10000)
+
+    # 3. The main content div exists in index.html (no JS needed)
+    expect(page.locator("#main")).to_be_visible(timeout=10000)
+
+
+def test_spa_navbar_hydrates(page: Page, live_server: str):
+    """
+    Verify that jQuery loads the Navbar.html partial into the header.
+
+    The navbar brand text 'MUIO' is injected by:
+      $('header').load('App/View/Navbar.html')
+    We wait up to 15s for it to appear, which covers CI cold-start latency.
+    """
+    page.goto(live_server)
+
+    # The navbar brand text is inside Navbar.html loaded by jQuery
+    expect(page.locator("#header").get_by_text("MUIO", exact=False)).to_be_visible(
+        timeout=15000
+    )
+
+
+def test_session_api(live_server: str):
+    """Verify the /getSession endpoint returns a valid JSON response."""
+    response = requests.get(f"{live_server}/getSession", timeout=5)
+    assert response.status_code == 200
+    data = response.json()
+    # session key must be present (value can be None for a fresh session)
+    assert "session" in data

--- a/ui_tests/test_ui_smoke.py
+++ b/ui_tests/test_ui_smoke.py
@@ -1,0 +1,56 @@
+import re
+from playwright.sync_api import Page, expect
+
+def test_load_app(page: Page, live_server: str):
+    """Verify that the index defaults and app container loads correctly."""
+    page.goto(live_server)
+    
+    # Wait for the frontend to be fully hydrated by checking a known nav element
+    # Explicitly bypassing CSS/ID selectors as requested, using get_by_text / get_by_role
+    expect(page.get_by_text("MUIO", exact=False).first).to_be_visible(timeout=15000)
+    expect(page).to_have_title(re.compile(r"MUIO\s*5\.5"))
+
+def test_case_management(page: Page, live_server: str):
+    """Verify the creation, session activation, and deletion of a mock case."""
+    # Ensure hydration before navigating
+    page.goto(f"{live_server}/#AddCase")
+    
+    # Use placeholder instead of #osy-casename ID locator
+    model_name_input = page.get_by_placeholder("Model name")
+    expect(model_name_input).to_be_visible(timeout=10000)
+    
+    # Fill in case data
+    test_case_name = "PlaywrightMockCase"
+    model_name_input.fill(test_case_name)
+    
+    # Click Save new model using role and text
+    page.get_by_role("button", name=re.compile("Save new model", re.IGNORECASE)).click()
+    
+    # Go to Home
+    page.goto(f"{live_server}/#Home")
+    
+    # Wait for the case text to be visible in the datatable/cards, confirming creation
+    expect(page.get_by_text(test_case_name).first).to_be_visible(timeout=10000)
+    
+    # Delete the case utilizing the trash icon or delete button role 
+    # (Checking for 'Delete model' title which bypasses class name reliance)
+    trash_icon = page.get_by_title("Delete model").first
+    if trash_icon.count() > 0:
+        trash_icon.click()
+        # Accept confirmation dialogs automatically
+        page.on("dialog", lambda dialog: dialog.accept())
+        confirm_btn = page.get_by_role("button", name=re.compile("Yes", re.IGNORECASE))
+        if confirm_btn.is_visible():
+            confirm_btn.click()
+
+def test_navigation_diagnostics(page: Page, live_server: str):
+    """Ensure major tabs render properly and verify equations in ModelFile diagnostic UI."""
+    page.goto(f"{live_server}/#ModelFile")
+    
+    # Wait for hydration on ModelFile by checking for expected text content
+    expect(page.get_by_text("Model", exact=False).first).to_be_visible(timeout=10000)
+    
+    # Check Parameters / Config page
+    page.goto(f"{live_server}/#Parameters")
+    expect(page.get_by_text("Parameters", exact=False).first).to_be_visible(timeout=10000)
+


### PR DESCRIPTION
## Resolves #426

## What This PR Does
I have built a stable, cross-platform Playwright E2E testing foundation for the MUIOGO frontend.
It introduces:
- A dedicated **ui-test job** in CI  
- A **live_server pytest fixture** that starts Flask reliably before browser tests  
- A focused **smoke test suite** that validates what Flask guarantees  

This approach deliberately avoids:
- Dependence on JS execution timing  
- jQuery AJAX completion  
- External CDN availability  

---

## The Problems Encountered (and what I have learned)

The integration was not that straightforward, I had to identify three distinct failure classes and resolve them:

### Problem 1: Subprocess Flask dev server hangs on Python 3.12 (Windows)

**Initial Approach:**
- Spawned `API/app.py` as a subprocess using Flask dev server (`app.run()`)

**Observed Behavior:**
- `/health` responded instantly  
- `page.goto("/")` timed out at 30 seconds  

**Root Cause:**
- Flask (Werkzeug) dev server is **single-threaded**
- Python 3.12 Windows uses **ProactorEventLoop**
- Playwright triggers ~20 parallel requests for `<script>` tags
- Server handled `/health` but got stuck queueing asset requests

**Fix:**
- Replaced subprocess with **in-process Waitress daemon thread**
- Waitress uses **thread-based I/O (no asyncio)**
- Configuration:
  - `threads=16`
  - `channel_timeout=10`

---

### Problem 2: Waitress thread exhaustion between test sessions

**Observed Behavior:**
- First test passed  
- Second test always timed out  

**Root Cause:**
- Playwright left connections in **TIME_WAIT**
- Waitress (default 4 threads) got blocked
- No threads available for next request  

**Fix:**
- Increased threads:
  - `threads=16`
- Reduced idle connection time:
  - `channel_timeout=10` (from 120)

### Problem 3: CDN resources blocking DOMContentLoaded

**Observed Behavior:**
- Switching to `wait_until="domcontentloaded"` still caused timeouts  

**Root Cause:**
- DOMContentLoaded waits for:
  - All synchronous `<script>` downloads + execution  
- `index.html` contains 20+ scripts  
- External CDN (MathJax) delays loading  

**Fix:**
- Use:
  ```python
  wait_until="commit"
  ```
Then validate elements using:
- `to_have_title`
- `to_be_attached`

Use independent timeouts (15s–60s) for stability.

## Problem 4:  SPA routes are unreliable in headless CI

### Affected Routes
- `/#AddCase`
- `/#Home`
- `/#Config`

### Root Cause
- Routes rely on jQuery `$.load()` (AJAX)
- Require:
  - Session state  
  - Pre-seeded data  
- Not reliable in a headless CI environment  

### Fix
Scope tests only to **Flask-guaranteed outputs**:
- `/health` API  
- `/getSession` API  
- Page `<title>`  
- Static footer text  

---

## Evidence: Stable Test Runs (Python 3.12, Windows)
<img width="1091" height="801" alt="image" src="https://github.com/user-attachments/assets/f296701e-6c37-4317-877f-3621e453c39b" />
<img width="1049" height="692" alt="image" src="https://github.com/user-attachments/assets/a2d87662-712c-4157-ab07-5964e55dff0d" />

---

## Tests Included

- `test_health_endpoint` → `/health` returns `{ "status": "ok" }`  
- `test_session_api` → `/getSession` returns session data  
- `test_load_app[chromium]` → page title matches **MUIO 5.5**  
- `test_static_footer[chromium]` → footer contains **MUIO ver.5.5**  

---

## Files Changed

| File | Change |
|------|--------|
| `API/app.py` | Added `/health` endpoint |
| `ui_tests/conftest.py` | `live_server` fixture using Waitress |
| `ui_tests/test_ui_smoke.py` | 4 stable smoke tests |
| `.github/workflows/ci.yml` | Added `ui-test` job |
| `README.md` | Added local testing instructions |

---

## Dependency Hygiene

### pytest-playwright and Chromium
- Installed dynamically in CI  

### Production Environment
- Remains unaffected  
  