### PR TITLE
fix: sanitize dzuuid to prevent path traversal in /uploadCase (#254)

### DIFF
--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -1,3 +1,4 @@
+import re
 import shutil
 from flask import Blueprint, request, jsonify, send_file, after_this_request
 from zipfile import ZipFile
@@ -538,6 +539,12 @@ def handle_full_zip(file, filepath=None):
 
     return jsonify({"response": msg}), 200
 
+def sanitize_uuid(value: str) -> str:
+    """Allow only safe UUID-like characters to prevent path traversal."""
+    if not value or not re.fullmatch(r'[a-zA-Z0-9_\-]{1,64}', value):
+        raise ValueError(f"Invalid dzuuid: {value!r}")
+    return value
+
 @upload_api.route('/uploadCase', methods=['POST'])
 def uploadCase():
     try:
@@ -545,6 +552,8 @@ def uploadCase():
         # 1) Primanje Dropzone chunk meta
         # -------------------------------
         dz_uuid = request.form.get("dzuuid")
+        if dz_uuid is not None:
+            dz_uuid = sanitize_uuid(dz_uuid)
         dz_chunk_index = request.form.get("dzchunkindex")
         dz_total_chunks = request.form.get("dztotalchunkcount")
         file = request.files.get("file")
@@ -602,8 +611,8 @@ def uploadCase():
         #return handle_full_zip(open(final_zip, "rb"), final_zip)
         return handle_full_zip(None, final_zip) 
 
-    except PermissionError:
-        return jsonify({"error": "Invalid path"}), 400
+    except (PermissionError, ValueError) as e:
+        return jsonify({"error": "Invalid request parameter"}), 400
     except Exception as e:
         return jsonify({"error": str(e)}), 500
     


### PR DESCRIPTION
## Linked issue
- Closes #254
- Related #256

## Existing related work reviewed
- Issues/PRs reviewed: #256 (Fix path traversal vulnerability by validating dzuuid), #321 (Zip Slip vulnerability)
- If none found, write: None found after search

## Overlap assessment
- Classification: Complementary
- Overlapping items: #256 also addresses dzuuid sanitization in /uploadCase
- Why this is not duplicate/superseded: #256 appears to have been closed/merged but the 
  sanitize_uuid() helper function and the ValueError catch in the except block were not 
  present in the current main branch code, leaving the path traversal vector still open. 
  This PR completes the fix with explicit input validation before any path construction occurs.

## Why this PR should proceed
- The vulnerability (CWE-22) is still reproducible on the current main branch — a crafted 
  dzuuid value like `../../../../etc` passes through to Path("_chunks", dz_uuid) and 
  subsequently to shutil.rmtree() without rejection
- The fix is minimal, non-breaking, and backward-compatible — all valid Dropzone-generated 
  UUIDs (e.g. `a1b2c3d4-e5f6-...`) match the allowed pattern `[a-zA-Z0-9_\-]{1,64}`
- Returns a clean HTTP 400 for invalid input rather than leaking internal error details

## Summary
- What changed: Added `sanitize_uuid()` helper in `API/Routes/Upload/UploadRoute.py` that 
  validates dzuuid against a strict `[a-zA-Z0-9_\-]{1,64}` regex before it is used to 
  construct any filesystem path. Moved the sanitization call to run immediately after 
  retrieving dzuuid from the request form, before `Path("_chunks", dz_uuid)` is constructed. 
  Updated the except block to catch `ValueError` alongside `PermissionError` and return HTTP 
  400 with a safe generic error message.