### PR TITLE
fix: guard remaining DataFileRoute endpoints against null 

### DIFF
--- a/API/Routes/DataFile/DataFileRoute.py
+++ b/API/Routes/DataFile/DataFileRoute.py
@@ -15,13 +15,15 @@ def generateDataFile():
         casename = request.json['casename']
         caserunname = request.json['caserunname']
 
-        if casename != None:
-            txtFile = DataFile(casename)
-            txtFile.generateDatafile(caserunname)
-            response = {
-                "message": "You have created data file!",
-                "status_code": "success"
-            }      
+        if not casename:
+            return jsonify({'message': 'No model selected.', 'status_code': 'error'}), 400
+
+        txtFile = DataFile(casename)
+        txtFile.generateDatafile(caserunname)
+        response = {
+            "message": "You have created data file!",
+            "status_code": "success"
+        }
         return jsonify(response), 200
     except(IOError):
         return jsonify('No existing cases!'), 404
@@ -36,10 +38,11 @@ def createCaseRun():
         caserunname = request.json['caserunname']
         data = request.json['data']
 
-        if casename != None:
-            caserun = DataFile(casename)
-            response = caserun.createCaseRun(caserunname, data)
-     
+        if not casename:
+            return jsonify({'message': 'No model selected.', 'status_code': 'error'}), 400
+
+        caserun = DataFile(casename)
+        response = caserun.createCaseRun(caserunname, data)
         return jsonify(response), 200
     except(IOError):
         return jsonify('No existing cases!'), 404
@@ -55,10 +58,11 @@ def updateCaseRun():
         oldcaserunname = request.json['oldcaserunname']
         data = request.json['data']
 
-        if casename != None:
-            caserun = DataFile(casename)
-            response = caserun.updateCaseRun(caserunname, oldcaserunname, data)
-     
+        if not casename:
+            return jsonify({'message': 'No model selected.', 'status_code': 'error'}), 400
+
+        caserun = DataFile(casename)
+        response = caserun.updateCaseRun(caserunname, oldcaserunname, data)
         return jsonify(response), 200
     except(IOError):
         return jsonify('No existing cases!'), 404
@@ -103,10 +107,11 @@ def deleteScenarioCaseRuns():
         scenarioId = request.json['scenarioId']
         casename = request.json['casename']
 
-        if casename != None:
-            caserun = DataFile(casename)
-            response = caserun.deleteScenarioCaseRuns(scenarioId)
-     
+        if not casename:
+            return jsonify({'message': 'No model selected.', 'status_code': 'error'}), 400
+
+        caserun = DataFile(casename)
+        response = caserun.deleteScenarioCaseRuns(scenarioId)
         return jsonify(response), 200
     except(IOError):
         return jsonify('No existing cases!'), 404
@@ -118,10 +123,11 @@ def saveView():
         param = request.json['param']
         data = request.json['data']
 
-        if casename != None:
-            caserun = DataFile(casename)
-            response = caserun.saveView(data, param)
-     
+        if not casename:
+            return jsonify({'message': 'No model selected.', 'status_code': 'error'}), 400
+
+        caserun = DataFile(casename)
+        response = caserun.saveView(data, param)
         return jsonify(response), 200
     except(IOError):
         return jsonify('No existing cases!'), 404
@@ -133,10 +139,11 @@ def updateViews():
         param = request.json['param']
         data = request.json['data']
 
-        if casename != None:
-            caserun = DataFile(casename)
-            response = caserun.updateViews(data, param)
-     
+        if not casename:
+            return jsonify({'message': 'No model selected.', 'status_code': 'error'}), 400
+
+        caserun = DataFile(casename)
+        response = caserun.updateViews(data, param)
         return jsonify(response), 200
     except(IOError):
         return jsonify('No existing cases!'), 404
@@ -312,15 +319,17 @@ def batchRun():
         modelname = request.json['modelname']
         cases = request.json['cases']
 
-        if modelname != None:
-            txtFile = DataFile(modelname)
-            for caserun in cases:
-                logger.info("Generating data file for model %s caserun %s", modelname, caserun)
-                txtFile.generateDatafile(caserun)
+        if not modelname:
+            return jsonify({'message': 'No model selected.', 'status_code': 'error'}), 400
 
-            response = txtFile.batchRun( 'CBC', cases) 
-        end = time.time()  
-        response['time'] = end-start 
+        txtFile = DataFile(modelname)
+        for caserun in cases:
+            logger.info("Generating data file for model %s caserun %s", modelname, caserun)
+            txtFile.generateDatafile(caserun)
+
+        response = txtFile.batchRun( 'CBC', cases)
+        end = time.time()
+        response['time'] = end-start
         return jsonify(response), 200
     except(IOError):
         return jsonify('Error!'), 404
@@ -330,11 +339,12 @@ def cleanUp():
     try:
         modelname = request.json['modelname']
 
-        if modelname != None:
-            model = DataFile(modelname)
-            logger.info("Cleaning up results for model %s", modelname)
-            response = model.cleanUp()
+        if not modelname:
+            return jsonify({'message': 'No model selected.', 'status_code': 'error'}), 400
 
+        model = DataFile(modelname)
+        logger.info("Cleaning up results for model %s", modelname)
+        response = model.cleanUp()
         return jsonify(response), 200
     except(IOError):
         return jsonify('Error!'), 404


### PR DESCRIPTION
## Linked issue

- Closes #438 
- Related #252, #288

## Existing related work reviewed

- Issues/PRs reviewed: #252 (original bug report), PR #253 (partial fix for readDataFile/validateInputs), #288 (batchRun crash, same root cause), PR #422 (added the guard pattern to deleteCaseRun).

## Overlap assessment

- Classification: Follow-up fix for incomplete prior work
- Overlapping items: PR #253 (fixed 2 of 10 affected routes)
- Why this is not duplicate/superseded: PR #253 fixed readDataFile and validateInputs but left 8 other routes with the same crash pattern. This PR completes that coverage.

## Why this PR should proceed

- Completes an acknowledged-but-incomplete fix (PR #253 / issue #252). Uses the exact guard pattern already present in deleteCaseRun (written by the maintainer in PR #422). 1 file, purely additive null checks, zero behavior change for valid requests.

## Summary

- What changed: Added early `return 400` guards to 8 DataFileRoute endpoints (generateDataFile, createCaseRun, updateCaseRun, deleteScenarioCaseRuns, saveView, updateViews, batchRun, cleanUp).
- Why: These routes crash with `UnboundLocalError` when `casename`/`modelname` is `null`, producing a raw 500 with a full stack trace instead of a clean 400 JSON response.

## Validation

- [x] Tests added/updated (or not applicable) - N/A: guard pattern is identical to existing deleteCaseRun guard. Existing smoke tests cannot run without Python 3.10-3.12.
- [x] Validation steps documented
- [x] Evidence attached

`python -m py_compile API/Routes/DataFile/DataFileRoute.py` passes. `git diff --check` clean. Branched off latest `upstream/main` (5f8f89af).

## Documentation

- [x] Docs updated in this PR (or not applicable) - N/A
- [x] Any setup/workflow changes reflected in repo docs - N/A

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch (`fix/unbound-local-datafile-routes`)
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main`

## Exception rationale

N/A
