### PR TITLE
[Bug] Misspelled "syncronized" in S3 sync response messages

### DIFF
--- a/API/Routes/Case/CaseRoute.py
+++ b/API/Routes/Case/CaseRoute.py
@@ -24,7 +24,7 @@ def initSyncS3():
         #downoload param file from S3 bucket
         syncS3.downloadSync('Parameters.json', Config.DATA_STORAGE, Config.S3_BUCKET)
         response = {
-            "message": "Cases syncronized with S3 bucket!",
+            "message": "Cases synchronized with S3 bucket!",
             "status_code": "success"
         }
         return jsonify(response), 200

--- a/API/Routes/Case/SyncS3Route.py
+++ b/API/Routes/Case/SyncS3Route.py
@@ -37,7 +37,7 @@ def uploadSync():
         s3.uploadSync(localDir, case, Config.S3_BUCKET, '*')
 
         response = {
-            "message": 'Case <b>'+ case + '</b> syncronized!',
+            "message": 'Case <b>'+ case + '</b> synchronized!',
             "status_code": "success"
         }
         return jsonify(response), 200


### PR DESCRIPTION
## Linked issue

- Closes #440 
- Related: none

## Existing related work reviewed

- Issues/PRs reviewed: #425 (UI polish tracking — covers frontend typos, not backend response strings), PR #374 (DataFile.js/AddCase.js typos — different files entirely), #221 (dead code removal — covers the commented-out instance at CaseRoute.py:528).

## Overlap assessment

- Classification: New, non-overlapping fix
- Overlapping items: None
- Why this is not duplicate/superseded: No existing issue or PR addresses the backend "syncronized" typo. The commented-out instance at CaseRoute.py:528 is dead code and intentionally left for #221.

## Why this PR should proceed

- 2-line fix in 2 files. User-facing text correction. Zero behavior change. Neither file is upstream-overlap surface per `docs/UPSTREAM_SYNC.md`.

## Summary

- What changed: Corrected "syncronized" → "synchronized" in S3 sync success messages in CaseRoute.py and SyncS3Route.py.
- Why: Misspelled word displayed to users after S3 sync operations.

## Validation

- [x] Tests added/updated (or not applicable) — N/A: text-only change.
- [x] Validation steps documented
- [x] Evidence attached

`python -m py_compile` passes on both files. `git diff --check` clean. Branched off latest `upstream/main` (5f8f89af).

## Documentation

- [x] Docs updated in this PR (or not applicable) — N/A
- [x] Any setup/workflow changes reflected in repo docs — N/A

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch (`fix/typo-syncronized-response-messages`)
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main`

## Exception rationale

N/A
