### PR TITLE
fix: add missing request field validation to all ViewDataRoute endpoints

### DIFF
--- a/API/Routes/Case/ViewDataRoute.py
+++ b/API/Routes/Case/ViewDataRoute.py
@@ -1,11 +1,15 @@
 from flask import Blueprint, jsonify, request
 from Classes.Case.OsemosysClass import Osemosys
+from utils import validate_json_fields
 
 viewdata_api = Blueprint('ViewDataRoute', __name__)
 
 @viewdata_api.route("/viewData", methods=['POST'])
 def viewData():
     try:
+        err, code = validate_json_fields('casename')
+        if err:
+            return err, code
         casename = request.json['casename']
         if casename != None:
             osy = Osemosys(casename)
@@ -23,6 +27,9 @@ def viewData():
 @viewdata_api.route("/viewTEData", methods=['POST'])
 def viewTEData():
     try:
+        err, code = validate_json_fields('casename')
+        if err:
+            return err, code
         casename = request.json['casename']
         if casename != None:
             osy = Osemosys(casename)
@@ -39,7 +46,9 @@ def viewTEData():
 @viewdata_api.route("/updateViewData", methods=['POST'])
 def updateViewData():
     try:
-        #casename, updateType, groupId, paramId, TechId, CommId, EmisId, Timeslice
+        err, code = validate_json_fields('casename', 'year', 'ScId', 'groupId', 'paramId', 'TechId', 'CommId', 'EmisId', 'Timeslice', 'value')
+        if err:
+            return err, code
         casename = request.json['casename']
         #updateType = request.json['updateType']
         year = request.json['year']
@@ -72,7 +81,9 @@ def updateViewData():
 @viewdata_api.route("/updateTEViewData", methods=['POST'])
 def updateTEViewData():
     try:
-        #casename, updateType, groupId, paramId, TechId, CommId, EmisId, Timeslice
+        err, code = validate_json_fields('casename', 'scId', 'groupId', 'paramId', 'techId', 'emisId', 'value')
+        if err:
+            return err, code
         casename = request.json['casename']
         scId = request.json['scId']
         groupId = request.json['groupId']


### PR DESCRIPTION
## Linked issue

- Closes #447 
- Related #77, #185

## Existing related work reviewed

- Issues/PRs reviewed: #77 (original bug report), PR #79 (added validation to 10 routes, missed ViewDataRoute), #185 (follow-up tracking, closed prematurely), #347 / PR #350 (ViewDataRoute session auth different bug class).

## Overlap assessment

- Classification: Follow-up fix for incomplete prior work
- Overlapping items: PR #79 (fixed 10 of 14 route files)
- Why this is not duplicate/superseded: PR #79 and issue #185 missed ViewDataRoute.py entirely. Issue #347 / PR #350 address session auth on this file, not input validation different bug class, different fix, no code overlap.

## Why this PR should proceed

- Completes acknowledged-but-incomplete validation coverage. Uses the existing `validate_json_fields` utility identically to every other route file. 1 file, 13 lines added, zero behavior change for valid requests. `updateViewData` and `updateTEViewData` are core data editing routes every cell edit in the parameter grid hits them.

## Summary

- What changed: Added `validate_json_fields()` calls to all 4 ViewDataRoute.py endpoints (viewData, viewTEData, updateViewData, updateTEViewData).
- Why: Missing field in any request body crashes with `KeyError` → raw 500 stack trace. Every other route file already validates; ViewDataRoute was skipped.

## Validation

- [x] Tests added/updated (or not applicable) - N/A: uses existing `validate_json_fields` utility which is already tested.
- [x] Validation steps documented
- [x] Evidence attached

`python -m py_compile API/Routes/Case/ViewDataRoute.py` passes. `git diff --check` clean. Branched off latest `upstream/main` (5f8f89af).

## Documentation

- [x] Docs updated in this PR (or not applicable) - N/A
- [x] Any setup/workflow changes reflected in repo docs - N/A

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch (`fix/viewdataroute-missing-input-validation`)
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main`

## Exception rationale

N/A
