### PR TITLE
Fix/449 dead code exception handlers

### DIFF
--- a/API/Routes/Case/CaseRoute.py
+++ b/API/Routes/Case/CaseRoute.py
@@ -103,8 +103,6 @@ def copy():
                 "status_code": "success"
             }
         return jsonify(response), 200
-    except(IOError):
-        raise IOError
     except OSError:
         return jsonify({'message': 'A filesystem error occurred.', 'status_code': 'error'}), 500
 

--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -399,8 +399,6 @@ def uploadCaseUnchunked_old():
         }
 
         return jsonify(response), 200
-    except(IOError):
-        raise IOError
     except OSError:
         return jsonify({'message': 'A filesystem error occurred.', 'status_code': 'error'}), 500
 
@@ -649,7 +647,5 @@ def uploadXls():
         }
 
         return jsonify(response), 200
-    except(IOError):
-        raise IOError
     except OSError:
         return jsonify({'message': 'A filesystem error occurred.', 'status_code': 'error'}), 500


### PR DESCRIPTION
## Linked issue

- Closes #449
- Related #89, #90

## Existing related work reviewed

- Issues/PRs reviewed:
  - [#89](https://github.com/EAPD-DRB/MUIOGO/issues/89) - Original stack-trace leak report (closed)
  - [#90](https://github.com/EAPD-DRB/MUIOGO/pull/90) - Added `except OSError` JSON handlers that are now unreachable (merged)
  - Commits [d38c2dd](https://github.com/EAPD-DRB/MUIOGO/commit/d38c2dd) and [b541ecb](https://github.com/EAPD-DRB/MUIOGO/commit/b541ecb) - "preserve existing IOError behavior" (root cause of the dead code)

## Overlap assessment

- Classification: Follow-up fix to #90
- Overlapping items: PR #90 added the `except OSError` JSON handlers this PR makes reachable
- Why this is not duplicate/superseded: PR #90 is merged but its JSON error handlers are unreachable dead code due to the `except(IOError): raise IOError` blocks left above them. This PR completes #90's stated goal.

## Why this PR should proceed

- PR #90 intended to return structured JSON 500 responses for filesystem errors, but the `except(IOError): raise IOError` pattern left above the new handlers makes them unreachable. Clients currently receive raw HTML 500 stack traces, leaking internal details. This is a minimal 6-line deletion that fixes the bug without changing any other behavior.

## Summary

- What changed: Removed `except(IOError): raise IOError` blocks from 3 route endpoints:
  - `API/Routes/Case/CaseRoute.py` - `/copyCase` (lines 106–107)
  - `API/Routes/Upload/UploadRoute.py` - `uploadCaseUnchunked_old` (lines 402–403)
  - `API/Routes/Upload/UploadRoute.py` - `uploadXls` (lines 652–653)
- Why: In Python 3.3+, `IOError` is an alias for `OSError`. The pattern `except(IOError): raise IOError` catches any filesystem error (since `IOError == OSError`), then re-raises it. A raised exception inside an `except` clause propagates out - it does **not** fall through to the next `except`. This made the `except OSError: return jsonify(...)` handlers added by PR #90 completely unreachable.

## Validation

- [x] Tests added/updated (or not applicable) - No new tests needed; this is a 6-line deletion removing dead code. Existing behavior is unchanged except filesystem errors now return JSON instead of stack traces.
- [x] Validation steps documented
  - Static check: `grep -n "except(IOError):" API/Routes/Case/CaseRoute.py API/Routes/Upload/UploadRoute.py` - confirms no `raise IOError` patterns remain
  - Runtime check: Make the data storage directory read-only, then `POST /copyCase` with a valid session → should return `{"message": "A filesystem error occurred.", "status_code": "error"}` with HTTP 500 instead of a raw stack trace
- [ ] Evidence attached (logs/screenshots/output as relevant)

## Documentation

- [x] Docs updated in this PR (or not applicable) - No documentation changes needed; this is a bug fix removing dead code.
- [x] Any setup/workflow changes reflected in repo docs - N/A

## Scope check

- [x] No unrelated refactors
- [x] Implemented from a feature branch (`fix/449-dead-code-exception-handlers`)
- [x] Change is deliverable without upstream `OSeMOSYS/MUIO` dependency
- [x] Base repo/branch is `EAPD-DRB/MUIOGO:main` (not upstream)

## Exception rationale

