### PR TITLE
fix: update hardcoded osy-version from 5.0 to 5.5 in AddCase.js

### DIFF
--- a/WebAPP/App/Controller/AddCase.js
+++ b/WebAPP/App/Controller/AddCase.js
@@ -229,7 +229,7 @@ export default class AddCase {
             });
 
             let POSTDATA = {
-                "osy-version": "5.0",
+                "osy-version": "5.5",
                 "osy-casename": casename,
                 "osy-desc": desc,
                 "osy-date": date,


### PR DESCRIPTION
Closes #453 

## Summary
- What changed: `"osy-version": "5.0"` → `"osy-version": "5.5"` on line 232 of AddCase.js
- Why: The version was not updated after the v5.5 sync. Every new model gets stamped "5.0" while the app displays "ver.5.5"

## Impact
1. **Version mismatch**: UI header says v5.5, saved genData.json says 5.0
2. **Export/import**: UploadRoute.py reads osy-version to decide migration paths — wrong stamp = wrong handling
3. **Future compat**: Any v5.5-specific logic keyed on osy-version won't fire for these models

## Proof
<img width="646" height="387" alt="image" src="https://github.com/user-attachments/assets/6262bcf1-35d9-4d84-a546-956c561bb1d2" />

And UI header shows "MUIO ver.5.5"



## Existing related work reviewed
- Reviewed all 24 open PRs — none touch the osy-version assignment in AddCase.js

## Scope check
- [x] No unrelated refactors
- [x] Implemented from a feature branch
- [x] Change is deliverable without upstream 'OSeMOSYS/MuIO' dependency
- [x] Base repo/branch is 'EAPD-DRB/MUIOGO:main' (not upstream)
