### PR TITLE
fix: correct guard order in OsemosysClass.RYE() to prevent phantom Em…

### DIFF
--- a/API/Classes/Case/OsemosysClass.py
+++ b/API/Classes/Case/OsemosysClass.py
@@ -613,9 +613,9 @@ class Osemosys():
                 RYE[param][sc] = {}
                 for o in array:
                     for year, val in o.items():
-                        if year not in RYE[param][sc]:
-                            RYE[param][sc][year] = {}
                         if (year != 'EmisId'):
+                            if year not in RYE[param][sc]:
+                                RYE[param][sc][year] = {}
                             RYE[param][sc][year][o['EmisId']] = val
         return RYE
 


### PR DESCRIPTION
- Closes #455
- Related #424

## Existing related work reviewed

- Issues/PRs reviewed: #424 (fix: correct guard order in OsemosysClass.RYE() to prevent phantom 'EmisId' key)
- #424 fixed the same pattern in a different method; this PR addresses the remaining instance in `RYE()`

## Overlap assessment

- Classification: No overlap
- Overlapping items: None
- Why this is not duplicate/superseded: #424 fixed `RYC()` guard order; this PR fixes the same bug pattern in the `RYE()` method which was missed

## Why this PR should proceed

- The `RYE()` parser is the **only** remaining method in `OsemosysClass` with the inverted guard order. All sibling methods (`RYC`, `RYT`, `RYTs`, `RYTTs`, `RYCTs`, etc.) already use the correct pattern. This is a data-corruption bug that creates a phantom `'EmisId'` key in the parsed emission data, which causes `KeyError` crashes in `gen_RYE()` during solver data file generation.

## Summary

- **What changed:** Swapped the two guard conditions in `OsemosysClass.RYE()` (line 608) so the `year != 'EmisId'` exclusion check runs *before* the dict-entry creation, matching the canonical pattern used by every other parser method in the class.
- **Why:** The original order (`if year not in RYE` before `if year != 'EmisId'`) creates a phantom empty dict entry `RYE[param][sc]['EmisId'] = {}` which (1) pollutes the data structure, (2) causes `KeyError` crashes when `gen_RYE()` iterates year keys, and (3) can produce corrupted solver `.dat` files.

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Validation steps documented
- [x] Evidence attached (logs/screenshots/output as relevant)

### Reproduction steps:
1. Run `python scripts/reproduce_rye_bug.py` from the `MUIOGO/` root
2. Observe the `[BUGGY]` section showing phantom `'EmisId'` key and `KeyError` crashes
3. Observe the `[FIXED]` section showing clean year-only keys

### Before (buggy):
```python
# Guard order WRONG — creates dict entry before exclusion check
if year not in RYE[param][sc]:
    RYE[param][sc][year] = {}
if (year != 'EmisId'):
    RYE[param][sc][year][o['EmisId']] = val
```

### After (fixed):
# Guard order CORRECT — matches RYC, RYT, etc.
if (year != 'EmisId'):
    if year not in RYE[param][sc]:
        RYE[param][sc][year] = {}
    RYE[param][sc][year][o['EmisId']] = val
