### PR TITLE
Fix Results tab crash on pre-v5.6 cases

### DIFF
--- a/WebAPP/AppResults/Model/Pivot.Model.js
+++ b/WebAPP/AppResults/Model/Pivot.Model.js
@@ -7,7 +7,8 @@ export class Model {
         let group = 'RYT';
         let param = 'ANC';
 
-        let CUSTOM_INDICATORS = DataModelResult.mergeAllIndicatorsGrouped(INDICATORS, genData['osy-indicators']);
+        // MUIOGO: `|| []` guards pre-v5.6 cases that have no osy-indicators
+        let CUSTOM_INDICATORS = DataModelResult.mergeAllIndicatorsGrouped(INDICATORS, genData['osy-indicators'] || []);
 
          console.log('VARIABLES original ', VARIABLES)
          console.log('CUSTOM_INDICATORS ', CUSTOM_INDICATORS)

--- a/WebAPP/Classes/DataModelResult.Class.js
+++ b/WebAPP/Classes/DataModelResult.Class.js
@@ -387,7 +387,8 @@ export class DataModelResult{
 
 
     static mergeAllIndicatorsGrouped(indicatorTypesJson, customIndicators) {
-        console.log('customIndicators ', customIndicators)
+        // MUIOGO: guard pre-v5.6 cases whose genData has no osy-indicators array
+        const customList = Array.isArray(customIndicators) ? customIndicators : [];
         // 1) Sakupi sve tipove indikatora + group info
         const typeById = {};
 
@@ -405,7 +406,7 @@ export class DataModelResult{
         const result = {};
 
         // 3) obrada custom indikatora
-        for (const item of customIndicators) {
+        for (const item of customList) {
             if (!item || typeof item !== "object") continue;
 
             const indicatorName = item["Indicator"];


### PR DESCRIPTION
Closes #474.

Opening the Results (Pivot) view on a pre-v5.6 case threw `TypeError: customIndicators is not iterable` and blocked the page. It hit the bundled CLEWs Demo and any case saved before v5.6, since those have no `osy-indicators` field in their genData.

The v5.6 indicator work added a guard for this in the AddCase view but missed the Pivot path. This adds it in two places: the shared `mergeAllIndicatorsGrouped` now treats a missing/non-array input as empty, and the Pivot caller passes `[]` when the field is absent, matching the AddCase pattern.

## How to test

**macOS / Linux** — fresh clone, full copy/paste:

```bash
cd ~/Desktop
gh repo clone EAPD-DRB/MUIOGO MUIOGO-pr475
cd MUIOGO-pr475
gh pr checkout 475
./scripts/setup.sh        # creates the venv, installs deps + demo data
./scripts/start.sh        # launches the API and opens the browser
```

**Windows (PowerShell)** — fresh clone, full copy/paste:

```powershell
cd $HOME\Desktop
gh repo clone EAPD-DRB/MUIOGO MUIOGO-pr475
cd MUIOGO-pr475
gh pr checkout 475
scripts\setup.bat
scripts\start.bat
```

Already have a clone? Just `cd` into it and run `gh pr checkout 475`, then `./scripts/setup.sh --check` (Windows: `scripts\setup.bat --check`) and the start script.

Then in the app:

1. Open the bundled **CLEWs Demo** (a pre-v5.6 case, so it has no `osy-indicators`).
2. Run a solve, or just load the demo data.
3. Click **Results** in the left menu.

Before this fix you'd get a yellow `TypeError: customIndicators is not iterable` banner and a blank Results view. After, the pivot grid loads with no warning.

Also confirm nothing regressed for indicators: open a case that *has* an indicator configured, view Results, and check the indicator still shows up.

When you're done, the throwaway clone can be removed: `rm -rf ~/Desktop/MUIOGO-pr475` (Windows: `Remove-Item -Recurse -Force $HOME\Desktop\MUIOGO-pr475`).

## Tested

- Reproduced the exact error on the demo, confirmed it's gone after the fix
- Ran the real function with no indicators, an empty list, and a real indicator — only the last produces grouped output, as expected
- node --check on both files
- CI green (ruff, validate, pytest)


cc: @autibet @utsinboots 