### PR TITLE
fix: compress case backups + demo-data archive (DEFLATE)

### DIFF
--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -1,6 +1,6 @@
 import shutil
 from flask import Blueprint, request, jsonify, send_file, after_this_request
-from zipfile import ZipFile
+from zipfile import ZipFile, ZIP_DEFLATED
 from pathlib import Path, PurePosixPath
 from werkzeug.utils import secure_filename
 import os, time, json, glob
@@ -281,7 +281,13 @@ def backupCase():
         zippedFile = Path(Config.validate_path(Config.DATA_STORAGE, f"{case}.zip"))
 
         '''File system data storage'''
-        with ZipFile(zippedFile, 'w') as zipObj:
+        # DEFLATE rather than the ZipFile default of ZIP_STORED. Case backups are
+        # JSON/CSV/text (model inputs, solver results, pivot views) which compress
+        # ~15-30x; storing them uncompressed made the demo archive 48 MB and a real
+        # country case ~944 MB. Every standard reader (Python zipfile, unzip, OS
+        # archivers) handles DEFLATE, and the read/extract paths are unchanged, so
+        # existing STORED backups still restore.
+        with ZipFile(zippedFile, 'w', compression=ZIP_DEFLATED) as zipObj:
             # Iterate over all the files in directory
             for folderName, subfolders, filenames in os.walk(str(casePath)):
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For setup options, use the "--help" flag:
 
 The demo dataset (`CLEWs.Demo.zip`) is hosted as a [GitHub release asset](https://github.com/EAPD-DRB/MUIOGO/releases/tag/demo-data) and downloaded automatically during setup when not already cached locally.
 
-- SHA-256: `facf4bda703f67b3c8b8697fea19d7d49be72bc2029fc05a68c61fd12ba7edde`
+- SHA-256: `db92d380b0448f767c4ba56eea5c79b14bcae8fbf8e05a6a0d92d5345bb742c1`
 
 Setup installs demo data by default. The archive is downloaded once, cached in `assets/demo-data/`, and reused on subsequent runs.
 

--- a/scripts/setup_dev.py
+++ b/scripts/setup_dev.py
@@ -52,7 +52,7 @@ MIN_PYTHON = (3, 10)
 MAX_PYTHON = (3, 13)  # exclusive
 DATA_STORAGE_DIR = PROJECT_ROOT / "WebAPP" / "DataStorage"
 DEMO_DATA_ARCHIVE = PROJECT_ROOT / "assets" / "demo-data" / "CLEWs.Demo.zip"
-DEMO_DATA_ARCHIVE_SHA256 = "facf4bda703f67b3c8b8697fea19d7d49be72bc2029fc05a68c61fd12ba7edde"
+DEMO_DATA_ARCHIVE_SHA256 = "db92d380b0448f767c4ba56eea5c79b14bcae8fbf8e05a6a0d92d5345bb742c1"
 DEMO_DATA_ARCHIVE_URL = (
     "https://github.com/EAPD-DRB/MUIOGO/releases/download/demo-data/CLEWs.Demo.zip"
 )

--- a/scripts/setup_dev.py
+++ b/scripts/setup_dev.py
@@ -450,6 +450,16 @@ def install_demo_data(force: bool, yes: bool) -> bool:
         _print_pass("Demo data already installed", str(DEMO_DATA_REQUIRED_DIRS[0]))
         return True
 
+    # Self-heal a stale cache: if the cached archive exists but no longer matches
+    # the pinned hash (e.g. the release asset was recompressed/updated), drop it so
+    # the download path below re-fetches the current one. Without this a stale
+    # assets/demo-data/CLEWs.Demo.zip makes the checksum verification further down
+    # fail hard instead of recovering -- notably on --force-demo-data, which clears
+    # the extracted dirs but not the cached archive.
+    if DEMO_DATA_ARCHIVE.exists() and _sha256(DEMO_DATA_ARCHIVE) != DEMO_DATA_ARCHIVE_SHA256:
+        print("  Cached demo-data archive is stale (hash mismatch); re-downloading ...")
+        DEMO_DATA_ARCHIVE.unlink()
+
     if not DEMO_DATA_ARCHIVE.exists():
         print("  Demo-data archive not found locally; downloading from release asset ...")
         DEMO_DATA_ARCHIVE.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Three related changes that cut ZIP/demo size and keep setup robust.

**1. Compress case backups.** `backupCase` opened the archive with `ZipFile(zippedFile, 'w')`, which defaults to `ZIP_STORED` — no compression. Case backups are all JSON/CSV/text (model inputs, solver results, pivot views) and compress 15–30×, so backups were far larger than needed: the demo case backs up to 48 MB and a real country case (Lao PDR CLEWS+WESM) to ~944 MB. The fix is one line — open with `compression=ZIP_DEFLATED`. DEFLATE is the standard zip method, so every reader (Python `zipfile`, `unzip`, OS archivers, upstream MUIO) handles it, and the extract/restore code is untouched; existing uncompressed backups still restore.

**2. Recompress the demo-data archive.** The published `CLEWs.Demo.zip` release asset was also stored uncompressed (48.7 MB). Recompressed with DEFLATE it's 3.2 MB — same files, byte-for-byte identical content (verified across all 226 entries). This bumps the pinned `DEMO_DATA_ARCHIVE_SHA256` in `setup_dev.py` and the README SHA to the new archive's hash (`db92d380…`).

**3. Self-heal a stale demo cache.** Setup verifies the cached `assets/demo-data/CLEWs.Demo.zip` against the pin, but `--force-demo-data` only clears the extracted dirs, not the cached archive — so after a hash change a reinstall would fail the checksum on the old cached file. Setup now drops a cached archive whose hash doesn't match the pin and re-downloads, so reinstalls recover automatically.

Tested: `/backupCase` on a throwaway case returns 200 with every entry DEFLATED, `lp.lp` excluded, paths relative; the recompressed demo verified to extract identical content to `WebAPP/DataStorage/CLEWs Demo/`; the stale-cache self-heal verified to re-download and reinstall (offline). Full suite 49/49, ruff clean.

**Rollout:** the new compressed `CLEWs.Demo.zip` needs to be uploaded to the `demo-data` release. The SHA is checked only on a fresh download — existing installs short-circuit on the marker, and a stale cache now self-heals — so the only thing to coordinate is the same-name swap: upload the asset close to merging this PR so a fresh setup never sees the old asset against the new pin (or vice-versa). CI doesn't download demo data, so the PR's own checks are unaffected by upload timing.
