### PR TITLE
Feat: display units on pivot chart Y-axis

### DIFF
--- a/WebAPP/AppResults/Controller/Pivot.js
+++ b/WebAPP/AppResults/Controller/Pivot.js
@@ -57,6 +57,34 @@ export default class Pivot {
             });
     }
 
+    static getUnitLabel(pivotData) {
+        const supMap = {'0':'⁰','1':'¹','2':'²','3':'³','4':'⁴','5':'⁵','6':'⁶','7':'⁷','8':'⁸','9':'⁹'};
+        const labels = [...new Set(
+            pivotData
+                .map(r => r['Unit'])
+                .filter(Boolean)
+                .map(u => u
+                    .replace(/<sup>(\d+)<\/sup>/g, (_, n) =>
+                        n.split('').map(d => supMap[d]).join('')
+                    )
+                    .replace(/<[^>]+>/g, '')
+                )
+        )];
+        if (!labels.length) return '';
+        return labels.join(', ');
+    }
+
+    static setUnitDisplay(pivotData, flexChart) {
+        const label = Pivot.getUnitLabel(pivotData);
+        if (label.length > 40) {
+            flexChart.axisY.title = 'Multiple units';
+            $('#pivotChartUnitLabel').text('Y-axis units: ' + label);
+        } else {
+            flexChart.axisY.title = label;
+            $('#pivotChartUnitLabel').text('');
+        }
+    }
+
     static refreshPage(casename) {
         Base.setSession(casename)
             .then(response => {
@@ -333,6 +361,8 @@ export default class Pivot {
         // app.pivotChart.flexChart.palette = wijmo.chart.Palettes.midnight
         app.pivotChart.flexChart.palette = model.ColorSchemes.osyScheme;
 
+        Pivot.setUnitDisplay(model.pivotData, app.pivotChart.flexChart);
+
         // app.pivotChart.flexChart.axisX.itemFormatter = function (engine, label) {
         //     label.text = wijmo.toPlainText(label.text);
         //     return label;
@@ -566,6 +596,7 @@ export default class Pivot {
                 let pivotData = DataModelResult.getPivot(DATA, model.genData, model.VARIABLES, model.group, model.param);
                 model.pivotData = pivotData;
                 app.engine.itemsSource = model.pivotData;
+                Pivot.setUnitDisplay(model.pivotData, app.pivotChart.flexChart);
 
 
                 //console.log('pivot source ok')

--- a/WebAPP/AppResults/Controller/Pivot.js
+++ b/WebAPP/AppResults/Controller/Pivot.js
@@ -57,6 +57,8 @@ export default class Pivot {
             });
     }
 
+    // Collect unique unit labels from the pivot data, convert HTML superscripts
+    // to Unicode (e.g. <sup>3</sup> → ³), and return a comma-separated string.
     static getUnitLabel(pivotData) {
         const supMap = {'0':'⁰','1':'¹','2':'²','3':'³','4':'⁴','5':'⁵','6':'⁶','7':'⁷','8':'⁸','9':'⁹'};
         const labels = [...new Set(
@@ -74,6 +76,9 @@ export default class Pivot {
         return labels.join(', ');
     }
 
+    // Update the Pivot chart unit display. Show unit(s) on the Y-axis when the
+    // label is short; otherwise show "Multiple units" on the Y-axis and display
+    // the full unit list below the chart.
     static setUnitDisplay(pivotData, flexChart) {
         const label = Pivot.getUnitLabel(pivotData);
         if (label.length > 40) {

--- a/WebAPP/AppResults/Controller/Pivot.js
+++ b/WebAPP/AppResults/Controller/Pivot.js
@@ -57,8 +57,7 @@ export default class Pivot {
             });
     }
 
-    // Collect unique unit labels from the pivot data, convert HTML superscripts
-    // to Unicode (e.g. <sup>3</sup> → ³), and return a comma-separated string.
+    // Collect unique unit labels from the pivot data, convert HTML superscripts to Unicode (e.g. <sup>3</sup> → ³), and return a comma-separated string.
     static getUnitLabel(pivotData) {
         const supMap = {'0':'⁰','1':'¹','2':'²','3':'³','4':'⁴','5':'⁵','6':'⁶','7':'⁷','8':'⁸','9':'⁹','-':'⁻'};
         const labels = [...new Set(
@@ -76,19 +75,44 @@ export default class Pivot {
         return labels.join(', ');
     }
 
-    // Update the Pivot chart unit display. For vertical charts, show the unit on the Y-axis; for horizontal Bar charts, show it on the X-axis (the values axis).
-    static setUnitDisplay(pivotData, flexChart) {
-        const label = Pivot.getUnitLabel(pivotData);
-        const isHorizontal = flexChart.chartType === wijmo.chart.ChartType.Bar;
-        const valueAxis = isHorizontal ? flexChart.axisX : flexChart.axisY;
-        const categoryAxis = isHorizontal ? flexChart.axisY : flexChart.axisX;
+    // Apply active PivotPanel filters to the raw rows that retain Unit values.
+    static getFilteredPivotData(engine) {
+        const activeFilters = engine.fields.filter(field => field.filter.isActive);
+        return engine.collectionView.items.filter(item =>
+            activeFilters.every(field => field.filter.apply(item))
+        );
+    }
 
-        const unitLabelMaxChars = 40; // Y-axis pixel width fits ~40 chars before the label crowds the chart
-        categoryAxis.title = '';
-        if (!isHorizontal && label.length > unitLabelMaxChars) {
-            valueAxis.title = 'Multiple units';
+    // Update the unit display for Pie, horizontal, and vertical Pivot charts.
+    static setUnitDisplay(pivotData, pivotChart) {
+        const flexChart = pivotChart.flexChart;
+        const chartType = pivotChart.chartType;
+        const label = Pivot.getUnitLabel(pivotData);
+        const unitLabelMaxChars = 40;
+
+        if (!label) {
+            flexChart.axisX.title = '';
+            flexChart.axisY.title = '';
+            $('#pivotChartUnitLabel').text('');
+            return;
+        }
+
+        const isPie = chartType === wijmo.olap.PivotChartType.Pie;
+        const isHorizontal = chartType === wijmo.olap.PivotChartType.Bar;
+
+        // Pie charts have no value axis, so always show their units below the chart.
+        if (isPie) {
+            flexChart.axisX.title = '';
+            flexChart.axisY.title = '';
+            $('#pivotChartUnitLabel').text('Units: ' + label);
+        } else if (!isHorizontal && label.length > unitLabelMaxChars) {
+            flexChart.axisX.title = '';
+            flexChart.axisY.title = 'Multiple units';
             $('#pivotChartUnitLabel').text('Y-axis units: ' + label);
         } else {
+            const valueAxis = isHorizontal ? flexChart.axisX : flexChart.axisY;
+            const categoryAxis = isHorizontal ? flexChart.axisY : flexChart.axisX;
+            categoryAxis.title = '';
             valueAxis.title = label;
             $('#pivotChartUnitLabel').text('');
         }
@@ -370,7 +394,15 @@ export default class Pivot {
         // app.pivotChart.flexChart.palette = wijmo.chart.Palettes.midnight
         app.pivotChart.flexChart.palette = model.ColorSchemes.osyScheme;
 
-        Pivot.setUnitDisplay(model.pivotData, app.pivotChart.flexChart);
+        // Recalculate the displayed units from the currently filtered Pivot data.
+        const updateUnitDisplay = () => {
+            const filteredData = Pivot.getFilteredPivotData(app.engine);
+            Pivot.setUnitDisplay(filteredData, app.pivotChart);
+        };
+
+        // Refresh units after the PivotEngine finishes applying panel filters.
+        app.engine.updatedView.addHandler(updateUnitDisplay);
+        updateUnitDisplay();
 
         // app.pivotChart.flexChart.axisX.itemFormatter = function (engine, label) {
         //     label.text = wijmo.toPlainText(label.text);
@@ -401,7 +433,7 @@ export default class Pivot {
                     app.pivotChart.rotated = 1;
                 }
                 app.pivotChart.chartType = s.selectedValue;
-                Pivot.setUnitDisplay(model.pivotData, app.pivotChart.flexChart);
+                updateUnitDisplay();
             }
         });
 
@@ -606,7 +638,6 @@ export default class Pivot {
                 let pivotData = DataModelResult.getPivot(DATA, model.genData, model.VARIABLES, model.group, model.param);
                 model.pivotData = pivotData;
                 app.engine.itemsSource = model.pivotData;
-                Pivot.setUnitDisplay(model.pivotData, app.pivotChart.flexChart);
 
 
                 //console.log('pivot source ok')

--- a/WebAPP/AppResults/Controller/Pivot.js
+++ b/WebAPP/AppResults/Controller/Pivot.js
@@ -96,7 +96,6 @@ export default class Pivot {
 
         flexChart.footer = '';
         if (pivotChart.flexPie) pivotChart.flexPie.footer = '';
-        $('#pivotChartUnitLabel').text('');
 
         if (!label) {
             flexChart.axisX.title = '';

--- a/WebAPP/AppResults/Controller/Pivot.js
+++ b/WebAPP/AppResults/Controller/Pivot.js
@@ -9,6 +9,8 @@ import { DataModelResult } from "../../Classes/DataModelResult.Class.js";
 import { DefaultObj } from "../../Classes/DefaultObj.Class.js";
 
 export default class Pivot {
+    static unitLabelMaxChars = 40;
+
     static onLoad() {
         Base.getSession()
             .then(response => {
@@ -57,38 +59,38 @@ export default class Pivot {
             });
     }
 
-    // Collect unique unit labels from the pivot data, convert HTML superscripts to Unicode (e.g. <sup>3</sup> → ³), and return a comma-separated string.
-    static getUnitLabel(pivotData) {
+    // Convert unique unit labels to plain text with Unicode superscripts and return a comma-separated string.
+    static getUnitLabel(units) {
         const supMap = {'0':'⁰','1':'¹','2':'²','3':'³','4':'⁴','5':'⁵','6':'⁶','7':'⁷','8':'⁸','9':'⁹','-':'⁻'};
-        const labels = [...new Set(
-            pivotData
-                .map(r => r['Unit'])
-                .filter(Boolean)
-                .map(u => String(u)
-                    .replace(/<sup>(-?\d+)<\/sup>/g, (_, n) =>
-                        n.split('').map(d => supMap[d]).join('')
-                    )
-                    .replace(/<[^>]+>/g, '')
+        const labels = [...units]
+            .filter(Boolean)
+            .map(u => String(u)
+                .replace(/<sup>(-?\d+)<\/sup>/g, (_, n) =>
+                    n.split('').map(d => supMap[d]).join('')
                 )
-        )];
+                .replace(/<[^>]+>/g, '')
+            );
         if (!labels.length) return '';
         return labels.join(', ');
     }
 
-    // Apply active PivotPanel filters to the raw rows that retain Unit values.
-    static getFilteredPivotData(engine) {
+    // Collect distinct raw units from rows that pass the active PivotPanel filters.
+    static getFilteredUnits(engine) {
         const activeFilters = engine.fields.filter(field => field.filter.isActive);
-        return engine.collectionView.items.filter(item =>
-            activeFilters.every(field => field.filter.apply(item))
-        );
+        const units = new Set();
+        for (const item of engine.collectionView.items) {
+            const unit = item['Unit'];
+            if (!unit || units.has(unit)) continue;
+            if (activeFilters.every(field => field.filter.apply(item))) units.add(unit);
+        }
+        return units;
     }
 
     // Update the unit display for Pie, horizontal, and vertical Pivot charts.
-    static setUnitDisplay(pivotData, pivotChart) {
+    static setUnitDisplay(units, pivotChart) {
         const flexChart = pivotChart.flexChart;
         const chartType = pivotChart.chartType;
-        const label = Pivot.getUnitLabel(pivotData);
-        const unitLabelMaxChars = 40;
+        const label = Pivot.getUnitLabel(units);
 
         if (!label) {
             flexChart.axisX.title = '';
@@ -105,7 +107,7 @@ export default class Pivot {
             flexChart.axisX.title = '';
             flexChart.axisY.title = '';
             $('#pivotChartUnitLabel').text('Units: ' + label);
-        } else if (!isHorizontal && label.length > unitLabelMaxChars) {
+        } else if (!isHorizontal && label.length > Pivot.unitLabelMaxChars) {
             flexChart.axisX.title = '';
             flexChart.axisY.title = 'Multiple units';
             $('#pivotChartUnitLabel').text('Y-axis units: ' + label);
@@ -396,13 +398,12 @@ export default class Pivot {
 
         // Recalculate the displayed units from the currently filtered Pivot data.
         const updateUnitDisplay = () => {
-            const filteredData = Pivot.getFilteredPivotData(app.engine);
-            Pivot.setUnitDisplay(filteredData, app.pivotChart);
+            const filteredUnits = Pivot.getFilteredUnits(app.engine);
+            Pivot.setUnitDisplay(filteredUnits, app.pivotChart);
         };
 
         // Refresh units after the PivotEngine finishes applying panel filters.
         app.engine.updatedView.addHandler(updateUnitDisplay);
-        updateUnitDisplay();
 
         // app.pivotChart.flexChart.axisX.itemFormatter = function (engine, label) {
         //     label.text = wijmo.toPlainText(label.text);

--- a/WebAPP/AppResults/Controller/Pivot.js
+++ b/WebAPP/AppResults/Controller/Pivot.js
@@ -60,13 +60,13 @@ export default class Pivot {
     // Collect unique unit labels from the pivot data, convert HTML superscripts
     // to Unicode (e.g. <sup>3</sup> → ³), and return a comma-separated string.
     static getUnitLabel(pivotData) {
-        const supMap = {'0':'⁰','1':'¹','2':'²','3':'³','4':'⁴','5':'⁵','6':'⁶','7':'⁷','8':'⁸','9':'⁹'};
+        const supMap = {'0':'⁰','1':'¹','2':'²','3':'³','4':'⁴','5':'⁵','6':'⁶','7':'⁷','8':'⁸','9':'⁹','-':'⁻'};
         const labels = [...new Set(
             pivotData
                 .map(r => r['Unit'])
                 .filter(Boolean)
-                .map(u => u
-                    .replace(/<sup>(\d+)<\/sup>/g, (_, n) =>
+                .map(u => String(u)
+                    .replace(/<sup>(-?\d+)<\/sup>/g, (_, n) =>
                         n.split('').map(d => supMap[d]).join('')
                     )
                     .replace(/<[^>]+>/g, '')
@@ -76,16 +76,20 @@ export default class Pivot {
         return labels.join(', ');
     }
 
-    // Update the Pivot chart unit display. Show unit(s) on the Y-axis when the
-    // label is short; otherwise show "Multiple units" on the Y-axis and display
-    // the full unit list below the chart.
+    // Update the Pivot chart unit display. For vertical charts, show the unit on the Y-axis; for horizontal Bar charts, show it on the X-axis (the values axis).
     static setUnitDisplay(pivotData, flexChart) {
         const label = Pivot.getUnitLabel(pivotData);
-        if (label.length > 40) {
-            flexChart.axisY.title = 'Multiple units';
+        const isHorizontal = flexChart.chartType === wijmo.chart.ChartType.Bar;
+        const valueAxis = isHorizontal ? flexChart.axisX : flexChart.axisY;
+        const categoryAxis = isHorizontal ? flexChart.axisY : flexChart.axisX;
+
+        const unitLabelMaxChars = 40; // Y-axis pixel width fits ~40 chars before the label crowds the chart
+        categoryAxis.title = '';
+        if (!isHorizontal && label.length > unitLabelMaxChars) {
+            valueAxis.title = 'Multiple units';
             $('#pivotChartUnitLabel').text('Y-axis units: ' + label);
         } else {
-            flexChart.axisY.title = label;
+            valueAxis.title = label;
             $('#pivotChartUnitLabel').text('');
         }
     }
@@ -397,6 +401,7 @@ export default class Pivot {
                     app.pivotChart.rotated = 1;
                 }
                 app.pivotChart.chartType = s.selectedValue;
+                Pivot.setUnitDisplay(model.pivotData, app.pivotChart.flexChart);
             }
         });
 

--- a/WebAPP/AppResults/Controller/Pivot.js
+++ b/WebAPP/AppResults/Controller/Pivot.js
@@ -91,32 +91,35 @@ export default class Pivot {
         const flexChart = pivotChart.flexChart;
         const chartType = pivotChart.chartType;
         const label = Pivot.getUnitLabel(units);
+        const isPie = chartType === wijmo.olap.PivotChartType.Pie;
+        const activeChart = isPie ? pivotChart.flexPie : flexChart;
+
+        flexChart.footer = '';
+        if (pivotChart.flexPie) pivotChart.flexPie.footer = '';
+        $('#pivotChartUnitLabel').text('');
 
         if (!label) {
             flexChart.axisX.title = '';
             flexChart.axisY.title = '';
-            $('#pivotChartUnitLabel').text('');
             return;
         }
 
-        const isPie = chartType === wijmo.olap.PivotChartType.Pie;
         const isHorizontal = chartType === wijmo.olap.PivotChartType.Bar;
 
-        // Pie charts have no value axis, so always show their units below the chart.
+        // Pie charts have no value axis, so show their units in the chart footer.
         if (isPie) {
             flexChart.axisX.title = '';
             flexChart.axisY.title = '';
-            $('#pivotChartUnitLabel').text('Units: ' + label);
+            activeChart.footer = 'Units: ' + label;
         } else if (!isHorizontal && label.length > Pivot.unitLabelMaxChars) {
             flexChart.axisX.title = '';
             flexChart.axisY.title = 'Multiple units';
-            $('#pivotChartUnitLabel').text('Y-axis units: ' + label);
+            activeChart.footer = 'Y-axis units: ' + label;
         } else {
             const valueAxis = isHorizontal ? flexChart.axisX : flexChart.axisY;
             const categoryAxis = isHorizontal ? flexChart.axisY : flexChart.axisX;
             categoryAxis.title = '';
             valueAxis.title = label;
-            $('#pivotChartUnitLabel').text('');
         }
     }
 

--- a/WebAPP/AppResults/View/Pivot.html
+++ b/WebAPP/AppResults/View/Pivot.html
@@ -95,6 +95,7 @@
 		</div>
 
 		<div id="pivotChart"></div>
+		<div id="pivotChartUnitLabel" style="font-size:11px; color:#555;"></div>
 	</div>
 </div>
 <div class="row">

--- a/WebAPP/AppResults/View/Pivot.html
+++ b/WebAPP/AppResults/View/Pivot.html
@@ -95,6 +95,7 @@
 		</div>
 
 		<div id="pivotChart"></div>
+		<!-- Displays the full unit list when the Y-axis label is too long. -->
 		<div id="pivotChartUnitLabel" style="font-size:11px; color:#555;"></div>
 	</div>
 </div>

--- a/WebAPP/AppResults/View/Pivot.html
+++ b/WebAPP/AppResults/View/Pivot.html
@@ -95,8 +95,6 @@
 		</div>
 
 		<div id="pivotChart"></div>
-		<!-- Displays the full unit lists when the Y-axis label is too long and displays Pie units -->
-		<div id="pivotChartUnitLabel"></div>
 	</div>
 </div>
 <div class="row">

--- a/WebAPP/AppResults/View/Pivot.html
+++ b/WebAPP/AppResults/View/Pivot.html
@@ -95,7 +95,7 @@
 		</div>
 
 		<div id="pivotChart"></div>
-		<!-- Displays the full unit list when the Y-axis label is too long. -->
+		<!-- Displays the full unit lists when the Y-axis label is too long and displays Pie units -->
 		<div id="pivotChartUnitLabel"></div>
 	</div>
 </div>

--- a/WebAPP/AppResults/View/Pivot.html
+++ b/WebAPP/AppResults/View/Pivot.html
@@ -96,7 +96,7 @@
 
 		<div id="pivotChart"></div>
 		<!-- Displays the full unit list when the Y-axis label is too long. -->
-		<div id="pivotChartUnitLabel" style="font-size:11px; color:#555;"></div>
+		<div id="pivotChartUnitLabel"></div>
 	</div>
 </div>
 <div class="row">

--- a/WebAPP/Classes/DataModelResult.Class.js
+++ b/WebAPP/Classes/DataModelResult.Class.js
@@ -579,6 +579,7 @@ export class DataModelResult{
 
                             if(obj.Tech in techData){
                                 //let rule = paramById[group][param]['unitRule'];
+                                // Some parameters define unitRule under indicator_type instead of directly
                                 let rule =
                                 paramById[group][param]?.unitRule ??
                                 paramById[group][param]?.indicator_type?.unitRule;
@@ -586,22 +587,23 @@ export class DataModelResult{
                                     $.each(techData[obj.Tech].TG, function (id, tg) {
                                         let tmp = {};
                                         tmp = JSON.parse(JSON.stringify(chunk));
-                                        tmp['Tech'] = obj.Tech;  
+                                        tmp['Tech'] = obj.Tech;
                                         tmp['TechGroup'] = techGroupNames[tg];
                                         tmp['TechDesc'] = techData[obj.Tech]["Desc"];
                                         tmp['TechGroupDesc'] = techGroupData[tg]["Desc"];
                                         dataT = unitData[group][param][obj.Tech];
-                                        tmp['Unit'] = jsonLogic.apply(rule, {...dataT});
+                                        // Include emission-specific unit data so technology-emission results resolve the correct unit in the Pivot chart
+                                        tmp['Unit'] = jsonLogic.apply(rule, {...dataT, ...dataE});
                                         pivotData.push(tmp);
                                     })
                                 }else{
-                                    chunk['Tech'] = obj.Tech;  
+                                    chunk['Tech'] = obj.Tech;
                                     chunk['TechGroup'] = 'No group';
                                     chunk['TechDesc'] = techData[obj.Tech]["Desc"];
                                     chunk['TechGroupDesc'] = 'No group';
                                     dataT = unitData[group][param][obj.Tech];
-    
-                                    chunk['Unit'] = jsonLogic.apply(rule, {...dataT});
+                                    // Include emission-specific unit data so technology-emission results resolve the correct unit in the Pivot chart
+                                    chunk['Unit'] = jsonLogic.apply(rule, {...dataT, ...dataE});
                                     pivotData.push(chunk);
                                 }
     
@@ -867,7 +869,9 @@ export class DataModelResult{
     //                                 chunk['TechGroupDesc'] = 'No group';
     //                                 dataT = unitData[group][param][obj.Tech];
     
-    //                                 chunk['Unit'] = jsonLogic.apply(rule, {...dataT});
+    //                                 // spread top-level unitData first so scalar keys (e.g. 'number') are available,
+    //                                 // then dataT (tech-specific), then dataE (emission-specific) to override as needed
+    //                                 chunk['Unit'] = jsonLogic.apply(rule, {...unitData[group][param], ...dataT, ...dataE});
     //                                 pivotData.push(chunk);
     //                             }
     
@@ -1101,7 +1105,7 @@ export class DataModelResult{
                                         tmp['TechDesc'] = techData[obj.Tech]["Desc"];
                                         tmp['TechGroupDesc'] = techGroupData[tg]["Desc"];
                                         dataT = unitData[group][param][obj.Tech];
-                                        tmp['Unit'] = jsonLogic.apply(rule, {...dataT});
+                                        tmp['Unit'] = jsonLogic.apply(rule, {...dataT, ...dataE});
                                         pivotData.push(tmp);
                                     })
                                 }else{
@@ -1111,7 +1115,7 @@ export class DataModelResult{
                                     chunk['TechGroupDesc'] = 'No group';
                                     dataT = unitData[group][param][obj.Tech];
     
-                                    chunk['Unit'] = jsonLogic.apply(rule, {...dataT});
+                                    chunk['Unit'] = jsonLogic.apply(rule, {...dataT, ...dataE});
                                     pivotData.push(chunk);
                                 }
     

--- a/WebAPP/Classes/DataModelResult.Class.js
+++ b/WebAPP/Classes/DataModelResult.Class.js
@@ -267,6 +267,7 @@ export class DataModelResult{
                     $.each(genData['osy-tech'], function (id, tObj) {
                         unitData[group][obj.id][tObj.Tech] = {};
                         unitData[group][obj.id][tObj.Tech]['years'] = 'years';
+                        unitData[group][obj.id][tObj.Tech]['number'] = 'number';
                         unitData[group][obj.id][tObj.Tech]['percent'] = '%';
                         unitData[group][obj.id][tObj.Tech]['divide'] = '/';
                         unitData[group][obj.id][tObj.Tech]['multiply'] = '*';
@@ -870,9 +871,7 @@ export class DataModelResult{
     //                                 chunk['TechGroupDesc'] = 'No group';
     //                                 dataT = unitData[group][param][obj.Tech];
     
-    //                                 // spread top-level unitData first so scalar keys (e.g. 'number') are available,
-    //                                 // then dataT (tech-specific), then dataE (emission-specific) to override as needed
-    //                                 chunk['Unit'] = jsonLogic.apply(rule, {...unitData[group][param], ...dataT, ...dataE});
+    //                                 chunk['Unit'] = jsonLogic.apply(rule, {...dataT});
     //                                 pivotData.push(chunk);
     //                             }
     
@@ -1106,8 +1105,7 @@ export class DataModelResult{
                                         tmp['TechDesc'] = techData[obj.Tech]["Desc"];
                                         tmp['TechGroupDesc'] = techGroupData[tg]["Desc"];
                                         dataT = unitData[group][param][obj.Tech];
-                                        const currentDataE = (obj.Emi && obj.Emi in emiData) ? unitData[group][param][obj.Emi] : {};
-                                        tmp['Unit'] = jsonLogic.apply(rule, {...dataT, ...currentDataE});
+                                        tmp['Unit'] = jsonLogic.apply(rule, {...dataT});
                                         pivotData.push(tmp);
                                     })
                                 }else{
@@ -1116,8 +1114,8 @@ export class DataModelResult{
                                     chunk['TechDesc'] = techData[obj.Tech]["Desc"];
                                     chunk['TechGroupDesc'] = 'No group';
                                     dataT = unitData[group][param][obj.Tech];
-                                    const currentDataE = (obj.Emi && obj.Emi in emiData) ? unitData[group][param][obj.Emi] : {};
-                                    chunk['Unit'] = jsonLogic.apply(rule, {...dataT, ...currentDataE});
+
+                                    chunk['Unit'] = jsonLogic.apply(rule, {...dataT});
                                     pivotData.push(chunk);
                                 }
     

--- a/WebAPP/Classes/DataModelResult.Class.js
+++ b/WebAPP/Classes/DataModelResult.Class.js
@@ -592,8 +592,9 @@ export class DataModelResult{
                                         tmp['TechDesc'] = techData[obj.Tech]["Desc"];
                                         tmp['TechGroupDesc'] = techGroupData[tg]["Desc"];
                                         dataT = unitData[group][param][obj.Tech];
-                                        // Include emission-specific unit data so technology-emission results resolve the correct unit in the Pivot chart
-                                        tmp['Unit'] = jsonLogic.apply(rule, {...dataT, ...dataE});
+                                        // Derive emission unit data for the current row only, avoiding stale shared state
+                                        const currentDataE = (obj.Emi && obj.Emi in emiData) ? unitData[group][param][obj.Emi] : {};
+                                        tmp['Unit'] = jsonLogic.apply(rule, {...dataT, ...currentDataE});
                                         pivotData.push(tmp);
                                     })
                                 }else{
@@ -602,8 +603,8 @@ export class DataModelResult{
                                     chunk['TechDesc'] = techData[obj.Tech]["Desc"];
                                     chunk['TechGroupDesc'] = 'No group';
                                     dataT = unitData[group][param][obj.Tech];
-                                    // Include emission-specific unit data so technology-emission results resolve the correct unit in the Pivot chart
-                                    chunk['Unit'] = jsonLogic.apply(rule, {...dataT, ...dataE});
+                                    const currentDataE = (obj.Emi && obj.Emi in emiData) ? unitData[group][param][obj.Emi] : {};
+                                    chunk['Unit'] = jsonLogic.apply(rule, {...dataT, ...currentDataE});
                                     pivotData.push(chunk);
                                 }
     
@@ -1105,17 +1106,18 @@ export class DataModelResult{
                                         tmp['TechDesc'] = techData[obj.Tech]["Desc"];
                                         tmp['TechGroupDesc'] = techGroupData[tg]["Desc"];
                                         dataT = unitData[group][param][obj.Tech];
-                                        tmp['Unit'] = jsonLogic.apply(rule, {...dataT, ...dataE});
+                                        const currentDataE = (obj.Emi && obj.Emi in emiData) ? unitData[group][param][obj.Emi] : {};
+                                        tmp['Unit'] = jsonLogic.apply(rule, {...dataT, ...currentDataE});
                                         pivotData.push(tmp);
                                     })
                                 }else{
-                                    chunk['Tech'] = obj.Tech;  
+                                    chunk['Tech'] = obj.Tech;
                                     chunk['TechGroup'] = 'No group';
                                     chunk['TechDesc'] = techData[obj.Tech]["Desc"];
                                     chunk['TechGroupDesc'] = 'No group';
                                     dataT = unitData[group][param][obj.Tech];
-    
-                                    chunk['Unit'] = jsonLogic.apply(rule, {...dataT, ...dataE});
+                                    const currentDataE = (obj.Emi && obj.Emi in emiData) ? unitData[group][param][obj.Emi] : {};
+                                    chunk['Unit'] = jsonLogic.apply(rule, {...dataT, ...currentDataE});
                                     pivotData.push(chunk);
                                 }
     

--- a/WebAPP/References/smartadmin/css/osy.css
+++ b/WebAPP/References/smartadmin/css/osy.css
@@ -1227,6 +1227,8 @@ jqx-menu-vertical-material .jqx-menu-item-top-selected-material, .jqx-grid-selec
 
 /* Override Wijmo default italic Y-axis title for Pivot chart */
 #pivotChart .wj-axis-y .wj-title,
-#pivotChart .wj-axis-y .wj-title tspan {
+#pivotChart .wj-axis-y .wj-title tspan,
+#pivotChart .wj-axis-x .wj-title,
+#pivotChart .wj-axis-x .wj-title tspan {
     font-style: normal !important;
 }

--- a/WebAPP/References/smartadmin/css/osy.css
+++ b/WebAPP/References/smartadmin/css/osy.css
@@ -1225,3 +1225,8 @@ jqx-menu-vertical-material .jqx-menu-item-top-selected-material, .jqx-grid-selec
 .py-9  { padding-top: 9px !important; padding-bottom: 9px !important; }
 .py-10 { padding-top: 10px !important; padding-bottom: 10px !important; }
 
+/* Override Wijmo default italic Y-axis title for Pivot chart */
+#pivotChart .wj-axis-y .wj-title,
+#pivotChart .wj-axis-y .wj-title tspan {
+    font-style: normal !important;
+}


### PR DESCRIPTION
## Summary

- What changed:
WebAPP/AppResults/Controller/Pivot.js`:
    - Added `Pivot.getUnitLabel(pivotData)` — collects the unique `Unit` values from the current pivot dataset, converts HTML superscript tags (e.g. `<sup>3</sup>`) to Unicode (e.g. `³`), strips any other HTML, and returns a comma-joined string (or `''` if no units exist).
    - Added `Pivot.setUnitDisplay(pivotData, flexChart)` — calls `getUnitLabel` and decides where to display it: if the label is ≤40 characters it's set as `flexChart.axisY.title`; if longer, the Y-axis shows `Multiple units` instead and the full list is written to the `#pivotChartUnitLabel` div below the chart (prefixed with `Y-axis units: `).
    - Called `Pivot.setUnitDisplay(...)` in two places: once in `initPage` (right after the chart palette is set, for the initial page load) and once in `updateParam` (right after `app.engine.itemsSource` is updated, so the label refreshes whenever the user picks a different variable from the dropdown).
  - `WebAPP/AppResults/View/Pivot.html`: Added a new `<div id="pivotChartUnitLabel">` directly below `<div id="pivotChart">`, used by `setUnitDisplay` to render the full unit list when it's too long for the Y-axis title.
  - `WebAPP/References/smartadmin/css/osy.css`: Added a CSS override for `#pivotChart .wj-axis-y .wj-title` to replace Wijmo's default italic Y-axis title styling with a normal font style, making rotated unit labels appear clearer and easier to read.
<img width="169" height="309" alt="y" src="https://github.com/user-attachments/assets/3197cac9-cdfa-4207-b785-58488e69a09a" />
<img width="314" height="284" alt="Screenshot 2026-06-30 162225" src="https://github.com/user-attachments/assets/e5bbd54b-333a-4f8b-bdaa-e127ef0f7d1c" />
<img width="189" height="250" alt="multiple" src="https://github.com/user-attachments/assets/22d2e32c-8ea4-4763-b699-f2caf0996a00" />

- Why:
This addresses the lack of unit information on the chart Y-axis, which made the plotted values difficult to interpret
## Linked issue (if applicable)

- Closes #488 #493 

## Validation
- [x] Tests added/updated (or not applicable)

Testing: 
Checkout the PR. From your local MUIOGO repository, run: `gh pr checkout 489`
Run the app: macOS/Linux: `./scripts/start.sh` Windows: `.\scripts\start.bat`
- Select a model, go to Results, and verify the Y-axis units is displayed correctly in the chart
- Change the variable from the dropdown and verify the unit label updates accordingly
- For variables with many units, verify the Y-axis displays `Multiple units` and the full unit list appears below the chart

- [x] Manual verification steps documented, with evidence where relevant
Verified single-unit variables (e.g. `Capital Investment` → `10⁶USD`)
 Verified multi-unit variables within the limit (e.g. `Accumulated New Capacity` → `PJ`,`GW`,`10⁹m³`,`10³km²`)
 Verified long multi-unit labels fall back to `Multiple units` with the full list displayed below the chart
 Verified units update correctly on initial page load and when changing the selected variable
 Reviewed with @autibet, who confirmed the approach

## Checklist
- [x] Change is scoped — no unrelated refactors
- [x] Branched from `main`; PR targets `EAPD-DRB/MUIOGO:main`
- [x] Docs updated for any setup, workflow, or architecture change