### PR TITLE
Add install, update and manage actions to the OG-Core calibration home

### DIFF
--- a/WebAPP/App/Controller/OGCore.js
+++ b/WebAPP/App/Controller/OGCore.js
@@ -22,20 +22,13 @@ const BADGES = {
 const POLL_MS = 3500;
 // running jobs by country_id: { installId, timer }
 let POLLS = {};
-//job ids by country, persisted so a reload can resume the live view
-const JOBS_KEY = 'osy-ogc-jobs';
-function loadJobs(){
-    try { return JSON.parse(localStorage.getItem(JOBS_KEY)) || {}; }
-    catch (e) { return {}; }
-}
-function saveJob(countryId, installId){
-    let jobs = loadJobs();
-    if (installId){ jobs[countryId] = installId; } else { delete jobs[countryId]; }
-    localStorage.setItem(JOBS_KEY, JSON.stringify(jobs));
-}
-let LAST_JOB = loadJobs();
+//response ids are a same-page fallback; the backend registry is authoritative
+//across reloads and clients
+let JOB_IDS = {};
+//remove job ids persisted by older versions; source payloads below remain useful
+try { localStorage.removeItem('osy-ogc-jobs'); } catch (e) {}
 //add-dialog payloads by country, kept until the install succeeds; a failed
-//custom install has no registry record yet, this is its only retry source
+//custom install's minimal registry record does not retain its original source
 const PENDING_KEY = 'osy-ogc-pending-adds';
 function loadPendingAdds(){
     try { return JSON.parse(localStorage.getItem(PENDING_KEY)) || {}; }
@@ -55,8 +48,7 @@ let LOG_COUNTRY = null;
 // older visit must not repaint or restart polling on the new page
 let PAGE_ID = 0;
 
-// last known job state by country; running and failed jobs have no registry
-// record, so this is the dialog's only honest source (B3)
+//last known job state by country, used to keep the live dialog current
 let JOB_STATE = {};
 
 export default class OGCore {
@@ -79,8 +71,7 @@ export default class OGCore {
         OGCore.pageID = PAGE_ID;
         OGCore.stopAllPolls();
         LOG_COUNTRY = null;
-        //per-visit cache only; resumeJobs() rebuilds it from the persisted install
-        //ids on the next visit, so never carry state from a page that is gone
+        //the next visit rebuilds live state from the backend registry
         JOB_STATE = {};
     }
 
@@ -95,7 +86,6 @@ export default class OGCore {
             let model = new Model(catalog.countries, catalog.catalog_source, installed.calibrations);
             OGCore.model = model;
             OGCore.renderGrid(model, pageID);
-            OGCore.resumeJobs(pageID);
             OGCore.autoCheckUpdates(model, pageID);
             if (initEvents){
                 OGCore.initEvents();
@@ -120,8 +110,7 @@ export default class OGCore {
             return;
         }
         $('#ogcGrid').empty();
-        //adds that never succeeded have no catalogue or registry entry; their
-        //cards come from the saved payloads so the job and retry stay reachable
+        //saved adds missing from the current backend lists still need a retry card
         let pendingAdds = {};
         $.each(loadPendingAdds(), function (countryId, p) {
             if (!OGCore.findCalibration(countryId)){
@@ -145,17 +134,17 @@ export default class OGCore {
         $.each(model.calibrations, function (id, c) {
             $('#ogcGrid').append(OGCore.cardHtml(c, model.records[c.country_id]));
             if (c.install_state == 'installing' || c.install_state == 'checking'){
-                // a job is running, possibly started before a reload; resume the
-                // live poll if its id was persisted, else watch the catalogue
-                if (LAST_JOB[c.country_id]){
-                    OGCore.pollJob(c.country_id, LAST_JOB[c.country_id], pageID);
+                //the registry carries the id, so any client can resume the live job
+                let installId = OGCore.jobIdFor(c.country_id);
+                if (installId){
+                    OGCore.pollJob(c.country_id, installId, pageID);
                 }else{
                     OGCore.watchCountry(c.country_id, pageID);
                 }
             }
         });
         $.each(pendingAdds, function (countryId, p) {
-            //failed until a live job says otherwise (resumeJobs repaints)
+            //failed until a live job says otherwise
             $('#ogcGrid').append(OGCore.cardHtml({
                 country_id: countryId, country_name: p.country_name, install_state: 'failed'
             }));
@@ -203,7 +192,10 @@ export default class OGCore {
                     </button>`;
         }
         if (state == 'installed'){
-            return `<button class="btn ogc-btn ogc-btn-ico" data-act="check" title="Check for updates"><i class="fa fa-refresh"></i></button>
+            return `${record && record.last_error
+                        ? '<button class="btn ogc-btn ogc-btn-danger" data-act="log"><i class="fa fa-exclamation-triangle"></i> View update error</button>'
+                        : ''}
+                    <button class="btn ogc-btn ogc-btn-ico" data-act="check" title="Check for updates"><i class="fa fa-refresh"></i></button>
                     <button class="btn ogc-btn ogc-btn-ico" data-act="remove" title="Remove from MUIOGO"><i class="fa fa-times"></i></button>`;
         }
         if (state == 'update_available'){
@@ -246,8 +238,7 @@ export default class OGCore {
         });
     }
 
-    //repaint one card in place; running and failed jobs have no registry
-    //record yet, so the catalogue cannot render them
+    //repaint one card in place while waiting for the next registry refresh
     static setCardState(countryId, state){
         let card = $(`#ogcGrid .ogc-card[data-country="${countryId}"]`);
         let badge = BADGES[state] || ['ogc-b-mut', state];
@@ -286,8 +277,7 @@ export default class OGCore {
             });
         };
         POLLS[countryId] = { installId: installId, timer: setInterval(tick, POLL_MS) };
-        LAST_JOB[countryId] = installId;
-        saveJob(countryId, installId);
+        JOB_IDS[countryId] = installId;
         //first status right away
         tick();
     }
@@ -303,7 +293,7 @@ export default class OGCore {
         }
         if (job.install_state == 'installed'){
             OGCore.stopPoll(countryId);
-            saveJob(countryId, null);
+            delete JOB_IDS[countryId];
             savePendingAdd(countryId, null);
             delete JOB_STATE[countryId];
             Message.smallBoxInfo('OG-Core', esc(job.country_name) + ' is installed.', 4000);
@@ -315,15 +305,24 @@ export default class OGCore {
         }
         if (job.install_state == 'failed'){
             OGCore.stopPoll(countryId);
+            let record = (OGCore.model && OGCore.model.records[countryId]) || null;
+            let workingInstall = record && record.venv_path;
             if (LOG_COUNTRY == countryId){
                 // the open dialog becomes the error view in place
                 $('#ogcModalHead').attr('class', 'ogc-box-head ogc-head-err')
-                    .html(`<i class="fa fa-exclamation-triangle"></i> ${esc(job.country_name)} (${esc(countryId)}): install failed`);
-                if (!$('#ogcModalFoot [data-act="retry-modal"]').length){
-                    $('#ogcModalFoot').append('<button class="btn ogc-btn ogc-btn-danger" data-act="retry-modal"><i class="fa fa-refresh"></i> Retry install</button>');
+                    .html(`<i class="fa fa-exclamation-triangle"></i> ${esc(job.country_name)} (${esc(countryId)}): ${workingInstall ? 'update' : 'install'} failed`);
+                let retryAct = workingInstall ? 'retry-update-modal' : 'retry-modal';
+                if (!$('#ogcModalFoot [data-act="' + retryAct + '"]').length){
+                    $('#ogcModalFoot').append(`<button class="btn ogc-btn ogc-btn-danger" data-act="${retryAct}"><i class="fa fa-refresh"></i> Retry ${workingInstall ? 'update' : 'install'}</button>`);
                 }
             }
-            //no refresh, the catalogue would repaint a failed card as not installed
+            if (workingInstall){
+                //a failed update does not invalidate the existing environment
+                record.last_error = job.error || 'Update failed.';
+                OGCore.setCardState(countryId, 'installed');
+                OGCore.refresh(false, pageID);
+                return;
+            }
             OGCore.setCardState(countryId, 'failed');
             return;
         }
@@ -350,41 +349,7 @@ export default class OGCore {
         });
     }
 
-    //jobs started before this page load are invisible to the catalogue,
-    //ask each persisted job id for its state and repaint the card
-    static resumeJobs(pageID){
-        if (!OGCore.isCurrent(pageID)){
-            return;
-        }
-        $.each(loadJobs(), function (countryId, installId) {
-            if (POLLS[countryId]){
-                return;
-            }
-            Ogc.getInstallStatus(installId)
-            .then(job => {
-                if (!OGCore.isCurrent(pageID)){
-                    return;
-                }
-                if (job.install_state == 'installing' || job.install_state == 'checking'){
-                    JOB_STATE[countryId] = job;
-                    OGCore.setCardBusy(countryId, job.progress_label);
-                    OGCore.pollJob(countryId, installId, pageID);
-                }else if (job.install_state == 'failed'){
-                    //keep the id so the log dialog can refetch it, remember the
-                    //state so a repaint does not resurrect the card
-                    JOB_STATE[countryId] = job;
-                    OGCore.setCardState(countryId, 'failed');
-                }else{
-                        //finished fine, the registry already reflects it
-                    saveJob(countryId, null);
-                }
-            })
-            .catch(e => {});
-        });
-    }
-
-    //fallback when a running job's id is unknown: watch the catalogue until
-    //the state changes, at a wider interval since each call hits the register
+    //fallback for an older backend or a best-effort registry write failure
     static watchCountry(countryId, pageID){
         if (!OGCore.isCurrent(pageID) || POLLS[countryId]){
             return;
@@ -443,18 +408,21 @@ export default class OGCore {
 
     static openLog(countryId, starting){
         let c = OGCore.findCalibration(countryId);
+        let record = (OGCore.model && OGCore.model.records[countryId]) || null;
         let lastJob = JOB_STATE[countryId];
         let failed = !starting && lastJob
             ? lastJob.install_state == 'failed'
-            : !starting && c && c.install_state == 'failed';
+            : !starting && ((c && c.install_state == 'failed') || (record && record.last_error));
+        let updateFailed = failed && record && record.venv_path;
         LOG_COUNTRY = countryId;
         let countryName = (lastJob && lastJob.country_name) || (c && c.country_name) || countryId;
         let head = failed
-            ? `<i class="fa fa-exclamation-triangle"></i> ${esc(countryName)} (${esc(countryId)}): install failed`
+            ? `<i class="fa fa-exclamation-triangle"></i> ${esc(countryName)} (${esc(countryId)}): ${updateFailed ? 'update' : 'install'} failed`
             : `<i class="fa fa-circle-o-notch fa-spin"></i> Installing ${esc(countryName)}`;
+        let retryAct = updateFailed ? 'retry-update-modal' : 'retry-modal';
         let foot = `<button class="btn ogc-btn ogc-btn-line" data-act="copylog"><i class="fa fa-clipboard"></i> Copy log</button>
                     <button class="btn ogc-btn ogc-btn-line" data-act="close">Close</button>
-                    ${failed ? '<button class="btn ogc-btn ogc-btn-danger" data-act="retry-modal"><i class="fa fa-refresh"></i> Retry install</button>' : ''}`;
+                    ${failed ? `<button class="btn ogc-btn ogc-btn-danger" data-act="${retryAct}"><i class="fa fa-refresh"></i> Retry ${updateFailed ? 'update' : 'install'}</button>` : ''}`;
         OGCore.openModal(head, `<div class="ogc-logsum" id="ogcLogSum"></div><div class="ogc-log" id="ogcLog"></div>`, foot, failed ? 'ogc-head-err' : '');
         $('#ogcModal').attr('data-country', countryId);
         if (starting){
@@ -463,8 +431,7 @@ export default class OGCore {
             return;
         }
         //what the job has logged so far, live updates come from the poll
-        let poll = POLLS[countryId];
-        let installId = (poll && poll.installId) || LAST_JOB[countryId];
+        let installId = OGCore.jobIdFor(countryId);
         if (installId){
             let pageID = PAGE_ID;
             Ogc.getInstallStatus(installId)
@@ -650,6 +617,17 @@ export default class OGCore {
         return found;
     }
 
+    static jobIdFor(countryId){
+        let poll = POLLS[countryId];
+        let record = (OGCore.model && OGCore.model.records[countryId]) || null;
+        let calibration = OGCore.model && OGCore.findCalibration(countryId);
+        return (poll && poll.installId)
+            || (record && record.install_id)
+            || (calibration && calibration.install_id)
+            || JOB_IDS[countryId]
+            || null;
+    }
+
     static install(countryId){
         let c = OGCore.findCalibration(countryId);
         if (c && c.catalog_key){
@@ -658,8 +636,8 @@ export default class OGCore {
             }));
             return;
         }
-        // custom calibration: an unfinished add is the latest source, else the
-        // registry record from a previous success
+        //custom calibration: an unfinished add is the latest source, otherwise
+        //retry from a complete registry record
         let pending = loadPendingAdd(countryId);
         if (pending){
             OGCore.startFromPayload(pending);
@@ -720,10 +698,10 @@ export default class OGCore {
     static removeConfirm(countryId){
         let pageID = PAGE_ID;
         OGCore.closeModal();
-        // a pending add that never succeeded has no registry record to remove
+        //fallback for a pending add missing from the backend registry
         if (!OGCore.model.records[countryId]){
             savePendingAdd(countryId, null);
-            saveJob(countryId, null);
+            delete JOB_IDS[countryId];
             delete JOB_STATE[countryId];
             OGCore.refresh(false, pageID);
             return;
@@ -731,6 +709,7 @@ export default class OGCore {
         Ogc.unregisterCalibration(countryId)
         .then(response => {
             savePendingAdd(countryId, null);
+            delete JOB_IDS[countryId];
             delete JOB_STATE[countryId];
             Message.smallBoxInfo('OG-Core', 'Calibration removed.', 3000);
             if (OGCore.isCurrent(pageID)){
@@ -781,6 +760,10 @@ export default class OGCore {
             if (act == 'retry-modal'){
                 OGCore.closeModal();
                 OGCore.install(countryId);
+            }
+            if (act == 'retry-update-modal'){
+                OGCore.closeModal();
+                OGCore.update(countryId);
             }
             if (act == 'remove-confirm') OGCore.removeConfirm(countryId);
             if (act == 'add-check') OGCore.addCheck();

--- a/WebAPP/App/Controller/OGCore.js
+++ b/WebAPP/App/Controller/OGCore.js
@@ -2,67 +2,182 @@ import { Message } from "../../Classes/Message.Class.js";
 import { Ogc } from "../../Classes/Ogc.Class.js";
 import { Model } from "../Model/OGCore.Model.js";
 
-// The register derives country ids from the repo name (OG-ETH -> ETH); the
-// vendored flag files use ISO2 (References/flags, see its README). Covers the
-// register plus every OG country repo published so far. Unmapped countries
-// get an icon fallback.
+//register country ids (repo name suffix) -> vendored flag files (ISO2, see
+//References/flags/README.md); unmapped countries get an icon fallback
 const FLAG_ISO2 = { ETH: 'et', ZAF: 'za', IDN: 'id', PHL: 'ph', USA: 'us', UK: 'gb', THA: 'th', BRA: 'br' };
 
-// register values render into markup, escape them
+//register values render into markup, escape them
 const esc = s => String(s == null ? '' : s).replace(/[&<>"']/g,
     ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
 
+const BADGES = {
+    'installed': ['ogc-b-ok', 'installed'],
+    'update_available': ['ogc-b-upd', 'update available'],
+    'not_installed': ['ogc-b-mut', 'not installed'],
+    'installing': ['ogc-b-run', 'installing...'],
+    'checking': ['ogc-b-run', 'checking...'],
+    'failed': ['ogc-b-err', 'failed']
+};
+
+const POLL_MS = 3500;
+// running jobs by country_id: { installId, timer }
+let POLLS = {};
+//job ids by country, persisted so a reload can resume the live view
+const JOBS_KEY = 'osy-ogc-jobs';
+function loadJobs(){
+    try { return JSON.parse(localStorage.getItem(JOBS_KEY)) || {}; }
+    catch (e) { return {}; }
+}
+function saveJob(countryId, installId){
+    let jobs = loadJobs();
+    if (installId){ jobs[countryId] = installId; } else { delete jobs[countryId]; }
+    localStorage.setItem(JOBS_KEY, JSON.stringify(jobs));
+}
+let LAST_JOB = loadJobs();
+//add-dialog payloads by country, kept until the install succeeds; a failed
+//custom install has no registry record yet, this is its only retry source
+const PENDING_KEY = 'osy-ogc-pending-adds';
+function loadPendingAdds(){
+    try { return JSON.parse(localStorage.getItem(PENDING_KEY)) || {}; }
+    catch (e) { return {}; }
+}
+function loadPendingAdd(countryId){
+    return loadPendingAdds()[countryId] || null;
+}
+function savePendingAdd(countryId, payload){
+    let pending = loadPendingAdds();
+    if (payload){ pending[countryId] = payload; } else { delete pending[countryId]; }
+    localStorage.setItem(PENDING_KEY, JSON.stringify(pending));
+}
+// which country's live log the dialog is showing, or null
+let LOG_COUNTRY = null;
+// incremented for every OG page visit and route change; async work from an
+// older visit must not repaint or restart polling on the new page
+let PAGE_ID = 0;
+
+// last known job state by country; running and failed jobs have no registry
+// record, so this is the dialog's only honest source (B3)
+let JOB_STATE = {};
+
 export default class OGCore {
     static onLoad(){
-        Ogc.getCalibrationCatalog()
-        .then(response => {
-            let model = new Model(response.countries, response.catalog_source);
-            this.initPage(model);
+        OGCore.stopAllPolls();
+        OGCore.checkedThisVisit = false;
+        PAGE_ID++;
+        OGCore.pageID = PAGE_ID;
+        OGCore.refresh(true, PAGE_ID);
+    }
+
+    //a missing or older id is treated as stale, so callers must pass the id they
+    //captured; guards fail closed rather than letting stale work through
+    static isCurrent(pageID){
+        return pageID == PAGE_ID;
+    }
+
+    static invalidatePage(){
+        PAGE_ID++;
+        OGCore.pageID = PAGE_ID;
+        OGCore.stopAllPolls();
+        LOG_COUNTRY = null;
+        //per-visit cache only; resumeJobs() rebuilds it from the persisted install
+        //ids on the next visit, so never carry state from a page that is gone
+        JOB_STATE = {};
+    }
+
+    // Reload catalogue + registry and re-render the grid.
+    static refresh(initEvents, pageID){
+        Promise.all([Ogc.getCalibrationCatalog(), Ogc.getInstalledCalibrations()])
+        .then(data => {
+            if (!OGCore.isCurrent(pageID)){
+                return;
+            }
+            let [catalog, installed] = data;
+            let model = new Model(catalog.countries, catalog.catalog_source, installed.calibrations);
+            OGCore.model = model;
+            OGCore.renderGrid(model, pageID);
+            OGCore.resumeJobs(pageID);
+            OGCore.autoCheckUpdates(model, pageID);
+            if (initEvents){
+                OGCore.initEvents();
+            }
         })
         .catch(error => {
+            if (!OGCore.isCurrent(pageID)){
+                return;
+            }
             Message.danger(error);
-            let model = new Model([], 'none');
-            this.initPage(model);
+            let model = new Model([], 'none', []);
+            OGCore.model = model;
+            OGCore.renderGrid(model, pageID);
+            if (initEvents){
+                OGCore.initEvents();
+            }
         });
     }
 
-    static initPage(model){
-        Message.clearMessages();
-        OGCore.renderGrid(model);
-        OGCore.initEvents(model);
-    }
-
-    // One compact card per country. install_state drives the badge:
-    // installed | update_available | not_installed | installing | failed.
-    static renderGrid(model){
-        $('#ogcGrid').empty();
-        if (model.calibrations.length == 0){
-            if (model.catalogSource == 'none'){
-                $('#ogcEmptyTitle').text('The calibration catalogue is not reachable');
-                $('#ogcEmptyText').text('Check the connection and reload the page.');
-            }
-            $('#ogcEmptyState').show();
+    static renderGrid(model, pageID){
+        if (!OGCore.isCurrent(pageID)){
             return;
         }
-        $('#ogcEmptyState').hide();
+        $('#ogcGrid').empty();
+        //adds that never succeeded have no catalogue or registry entry; their
+        //cards come from the saved payloads so the job and retry stay reachable
+        let pendingAdds = {};
+        $.each(loadPendingAdds(), function (countryId, p) {
+            if (!OGCore.findCalibration(countryId)){
+                pendingAdds[countryId] = p;
+            }
+        });
+        if (model.calibrations.length == 0 && $.isEmptyObject(pendingAdds)){
+            if (model.catalogSource == 'none'){
+                $('#ogcEmptyTitle').text('The calibration catalogue is not reachable');
+                $('#ogcEmptyText').text('Check the connection and reload the page, or add a calibration from a local folder or a Git URL.');
+            }
+            $('#ogcEmptyState').show();
+        }else{
+            $('#ogcEmptyState').hide();
+        }
         if (model.catalogSource == 'cache'){
             $('#ogcSourceNote').show();
+        }else{
+            $('#ogcSourceNote').hide();
         }
         $.each(model.calibrations, function (id, c) {
-            let badge = {
-                'installed': ['ogc-b-ok', 'installed'],
-                'update_available': ['ogc-b-upd', 'update available'],
-                'not_installed': ['ogc-b-mut', 'not installed'],
-                'installing': ['ogc-b-run', 'installing...'],
-                'failed': ['ogc-b-err', 'failed']
-            }[c.install_state] || ['ogc-b-mut', c.install_state];
-            let active = c.install_state == 'installed' || c.install_state == 'update_available';
-            let iso2 = FLAG_ISO2[c.country_id];
-            let flag = iso2
-                ? `<img class="ogc-flag" src="References/flags/4x3/${iso2}.svg" alt="">`
-                : `<span class="ogc-flag ogc-flag-none"><i class="fa fa-flag-o"></i></span>`;
-            let card = `
-            <div class="ogc-card ${active ? 'ogc-on' : ''}" data-country="${esc(c.country_id)}">
+            $('#ogcGrid').append(OGCore.cardHtml(c, model.records[c.country_id]));
+            if (c.install_state == 'installing' || c.install_state == 'checking'){
+                // a job is running, possibly started before a reload; resume the
+                // live poll if its id was persisted, else watch the catalogue
+                if (LAST_JOB[c.country_id]){
+                    OGCore.pollJob(c.country_id, LAST_JOB[c.country_id], pageID);
+                }else{
+                    OGCore.watchCountry(c.country_id, pageID);
+                }
+            }
+        });
+        $.each(pendingAdds, function (countryId, p) {
+            //failed until a live job says otherwise (resumeJobs repaints)
+            $('#ogcGrid').append(OGCore.cardHtml({
+                country_id: countryId, country_name: p.country_name, install_state: 'failed'
+            }));
+        });
+        // the add card is part of the grid, after the countries
+        $('#ogcGrid').append(`
+            <div class="ogc-card ogc-addcard" data-act="add" title="Add a calibration from a local folder or a Git URL">
+                <i class="fa fa-plus-circle"></i>
+                <b>Add calibration</b>
+                <span>local folder or Git URL</span>
+            </div>`);
+    }
+
+    static cardHtml(c, record){
+        let badge = BADGES[c.install_state] || ['ogc-b-mut', c.install_state];
+        let active = c.install_state == 'installed' || c.install_state == 'update_available';
+        let iso2 = FLAG_ISO2[c.country_id];
+        let flag = iso2
+            ? `<img class="ogc-flag" src="References/flags/4x3/${iso2}.svg" alt="">`
+            : `<span class="ogc-flag ogc-flag-none"><i class="fa fa-flag-o"></i></span>`;
+        return `
+            <div class="ogc-card ${active ? 'ogc-on' : ''}" data-country="${esc(c.country_id)}" ${c.catalog_key ? `data-key="${esc(c.catalog_key)}"` : ''}>
                 <div class="ogc-card-head">
                     ${flag}
                     <div class="ogc-card-title">
@@ -71,13 +186,619 @@ export default class OGCore {
                     </div>
                     <span class="ogc-badge ${badge[0]}">${esc(badge[1])}</span>
                 </div>
-                <div class="ogc-card-actions" data-state="${esc(c.install_state)}"></div>
+                <div class="ogc-card-actions">${OGCore.actionsHtml(c, record)}</div>
             </div>`;
-            $('#ogcGrid').append(card);
+    }
+
+    //register calibrations (catalog_key, no record) and repo_url customs are
+    //updatable by MUIOGO; a local_path record is not, the user owns that folder
+    static actionsHtml(c, record){
+        let state = c.install_state;
+        if (state == 'not_installed'){
+            return `<button class="btn ogc-btn ogc-btn-line" data-act="install"><i class="fa fa-download"></i> Install</button>`;
+        }
+        if (state == 'installing' || state == 'checking'){
+            return `<button class="btn ogc-btn ogc-btn-line ogc-btn-busy" data-act="log" title="Show the install log">
+                        <i class="fa fa-circle-o-notch fa-spin"></i> <span class="ogc-busylabel">Installing...</span>
+                    </button>`;
+        }
+        if (state == 'installed'){
+            return `<button class="btn ogc-btn ogc-btn-ico" data-act="check" title="Check for updates"><i class="fa fa-refresh"></i></button>
+                    <button class="btn ogc-btn ogc-btn-ico" data-act="remove" title="Remove from MUIOGO"><i class="fa fa-times"></i></button>`;
+        }
+        if (state == 'update_available'){
+            if (record && record.source_type == 'local_path'){
+                return `<div class="ogc-updatenote" title="This calibration comes from a local folder. Update the folder yourself, then check again.">Update the local folder to get this version</div>
+                        <button class="btn ogc-btn ogc-btn-line" data-act="check"><i class="fa fa-refresh"></i> Check again</button>
+                        <button class="btn ogc-btn ogc-btn-ico" data-act="remove" title="Remove from MUIOGO"><i class="fa fa-times"></i></button>`;
+            }
+            return `<button class="btn ogc-btn ogc-btn-main" data-act="update"><i class="fa fa-arrow-circle-up"></i> Update</button>
+                    <button class="btn ogc-btn ogc-btn-ico" data-act="remove" title="Remove from MUIOGO"><i class="fa fa-times"></i></button>`;
+        }
+        if (state == 'failed'){
+            return `<button class="btn ogc-btn ogc-btn-line" data-act="log"><i class="fa fa-file-text-o"></i> View error</button>
+                    <button class="btn ogc-btn ogc-btn-danger" data-act="retry"><i class="fa fa-refresh"></i> Retry</button>
+                    <button class="btn ogc-btn ogc-btn-ico" data-act="remove" title="Remove from MUIOGO"><i class="fa fa-times"></i></button>`;
+        }
+        return '';
+    }
+
+    //jobs
+
+    static startJob(countryId, promise){
+        let pageID = PAGE_ID;
+        //instant feedback, even a seconds long install stays visible
+        OGCore.setCardBusy(countryId, 'Starting...');
+        OGCore.openLog(countryId, true);
+        promise
+        .then(response => {
+            if (OGCore.isCurrent(pageID)){
+                OGCore.pollJob(countryId, response.install_id, pageID);
+            }
+        })
+        .catch(error => {
+            if (!OGCore.isCurrent(pageID)){
+                return;
+            }
+            OGCore.closeModal();
+            Message.danger(error);
+            OGCore.refresh(false, pageID);
         });
     }
 
-    static initEvents(model){
-        // card actions (open, install, retry, add) attach here
+    //repaint one card in place; running and failed jobs have no registry
+    //record yet, so the catalogue cannot render them
+    static setCardState(countryId, state){
+        let card = $(`#ogcGrid .ogc-card[data-country="${countryId}"]`);
+        let badge = BADGES[state] || ['ogc-b-mut', state];
+        card.find('.ogc-badge').attr('class', 'ogc-badge ' + badge[0]).text(badge[1]);
+        let record = (OGCore.model && OGCore.model.records[countryId]) || null;
+        //pass the real calibration with the new state applied; a one-field stub
+        //would hide source_type from the card actions
+        let c = (OGCore.model && OGCore.findCalibration(countryId)) || { country_id: countryId };
+        card.find('.ogc-card-actions').html(OGCore.actionsHtml($.extend({}, c, { install_state: state }), record));
+    }
+
+    static setCardBusy(countryId, label){
+        OGCore.setCardState(countryId, 'installing');
+        let card = $(`#ogcGrid .ogc-card[data-country="${countryId}"]`);
+        card.find('.ogc-busylabel').text(label || 'Installing...');
+    }
+
+    static pollJob(countryId, installId, pageID){
+        if (!OGCore.isCurrent(pageID)){
+            return;
+        }
+        OGCore.stopPoll(countryId);
+        let tick = function () {
+            if (!OGCore.isCurrent(pageID)){
+                OGCore.stopPoll(countryId);
+                return;
+            }
+            Ogc.getInstallStatus(installId)
+            .then(job => {
+                if (OGCore.isCurrent(pageID)){
+                    OGCore.applyJob(countryId, job, pageID);
+                }
+            })
+            .catch(error => {
+                //transient poll errors keep the timer, the job continues server side
+            });
+        };
+        POLLS[countryId] = { installId: installId, timer: setInterval(tick, POLL_MS) };
+        LAST_JOB[countryId] = installId;
+        saveJob(countryId, installId);
+        //first status right away
+        tick();
+    }
+
+    static applyJob(countryId, job, pageID){
+        if (!OGCore.isCurrent(pageID)){
+            return;
+        }
+        JOB_STATE[countryId] = job;
+        let card = $(`#ogcGrid .ogc-card[data-country="${countryId}"]`);
+        if (LOG_COUNTRY == countryId){
+            OGCore.renderLog(job.log_tail || [], job.error);
+        }
+        if (job.install_state == 'installed'){
+            OGCore.stopPoll(countryId);
+            saveJob(countryId, null);
+            savePendingAdd(countryId, null);
+            delete JOB_STATE[countryId];
+            Message.smallBoxInfo('OG-Core', esc(job.country_name) + ' is installed.', 4000);
+            if (LOG_COUNTRY == countryId){
+                OGCore.closeModal();
+            }
+            OGCore.refresh(false, pageID);
+            return;
+        }
+        if (job.install_state == 'failed'){
+            OGCore.stopPoll(countryId);
+            if (LOG_COUNTRY == countryId){
+                // the open dialog becomes the error view in place
+                $('#ogcModalHead').attr('class', 'ogc-box-head ogc-head-err')
+                    .html(`<i class="fa fa-exclamation-triangle"></i> ${esc(job.country_name)} (${esc(countryId)}): install failed`);
+                if (!$('#ogcModalFoot [data-act="retry-modal"]').length){
+                    $('#ogcModalFoot').append('<button class="btn ogc-btn ogc-btn-danger" data-act="retry-modal"><i class="fa fa-refresh"></i> Retry install</button>');
+                }
+            }
+            //no refresh, the catalogue would repaint a failed card as not installed
+            OGCore.setCardState(countryId, 'failed');
+            return;
+        }
+        card.find('.ogc-busylabel').text(job.progress_label || 'Installing...');
+    }
+
+    //background update check, one upstream query per installed country, once
+    //per page visit; failures stay silent so offline is fine
+    static autoCheckUpdates(model, pageID){
+        if (OGCore.checkedThisVisit || !OGCore.isCurrent(pageID)){
+            return;
+        }
+        OGCore.checkedThisVisit = true;
+        $.each(model.calibrations, function (id, c) {
+            if (c.install_state == 'installed'){
+                Ogc.refreshCalibration({ country_id: c.country_id, check_only: true })
+                .then(result => {
+                    if (OGCore.isCurrent(pageID) && result.install_state == 'update_available'){
+                        OGCore.setCardState(c.country_id, 'update_available');
+                    }
+                })
+                .catch(e => {});
+            }
+        });
+    }
+
+    //jobs started before this page load are invisible to the catalogue,
+    //ask each persisted job id for its state and repaint the card
+    static resumeJobs(pageID){
+        if (!OGCore.isCurrent(pageID)){
+            return;
+        }
+        $.each(loadJobs(), function (countryId, installId) {
+            if (POLLS[countryId]){
+                return;
+            }
+            Ogc.getInstallStatus(installId)
+            .then(job => {
+                if (!OGCore.isCurrent(pageID)){
+                    return;
+                }
+                if (job.install_state == 'installing' || job.install_state == 'checking'){
+                    JOB_STATE[countryId] = job;
+                    OGCore.setCardBusy(countryId, job.progress_label);
+                    OGCore.pollJob(countryId, installId, pageID);
+                }else if (job.install_state == 'failed'){
+                    //keep the id so the log dialog can refetch it, remember the
+                    //state so a repaint does not resurrect the card
+                    JOB_STATE[countryId] = job;
+                    OGCore.setCardState(countryId, 'failed');
+                }else{
+                        //finished fine, the registry already reflects it
+                    saveJob(countryId, null);
+                }
+            })
+            .catch(e => {});
+        });
+    }
+
+    //fallback when a running job's id is unknown: watch the catalogue until
+    //the state changes, at a wider interval since each call hits the register
+    static watchCountry(countryId, pageID){
+        if (!OGCore.isCurrent(pageID) || POLLS[countryId]){
+            return;
+        }
+        let timer = setInterval(function () {
+            if (!OGCore.isCurrent(pageID)){
+                OGCore.stopPoll(countryId);
+                return;
+            }
+            Ogc.getCalibrationCatalog()
+            .then(catalog => {
+                if (!OGCore.isCurrent(pageID)){
+                    return;
+                }
+                let entry = null;
+                $.each(catalog.countries || [], function (id, c) {
+                    if (c.country_id == countryId) entry = c;
+                });
+                if (entry && entry.install_state != 'installing' && entry.install_state != 'checking'){
+                    OGCore.stopPoll(countryId);
+                    OGCore.refresh(false, pageID);
+                }
+            })
+            .catch(error => {});
+        }, POLL_MS * 3);
+        POLLS[countryId] = { installId: null, timer: timer };
+    }
+
+    static stopPoll(countryId){
+        if (POLLS[countryId]){
+            clearInterval(POLLS[countryId].timer);
+            delete POLLS[countryId];
+        }
+    }
+
+    static stopAllPolls(){
+        $.each(POLLS, function (countryId, p) { clearInterval(p.timer); });
+        POLLS = {};
+    }
+
+    //modal
+
+    static openModal(head, body, foot, headClass){
+        $('#ogcModalHead').attr('class', 'ogc-box-head ' + (headClass || '')).html(head);
+        $('#ogcModalBody').html(body);
+        $('#ogcModalFoot').html(foot);
+        $('#ogcModal').show();
+    }
+
+    static closeModal(){
+        LOG_COUNTRY = null;
+        $('#ogcModal').hide();
+    }
+
+    //log dialog
+
+    static openLog(countryId, starting){
+        let c = OGCore.findCalibration(countryId);
+        let lastJob = JOB_STATE[countryId];
+        let failed = !starting && lastJob
+            ? lastJob.install_state == 'failed'
+            : !starting && c && c.install_state == 'failed';
+        LOG_COUNTRY = countryId;
+        let countryName = (lastJob && lastJob.country_name) || (c && c.country_name) || countryId;
+        let head = failed
+            ? `<i class="fa fa-exclamation-triangle"></i> ${esc(countryName)} (${esc(countryId)}): install failed`
+            : `<i class="fa fa-circle-o-notch fa-spin"></i> Installing ${esc(countryName)}`;
+        let foot = `<button class="btn ogc-btn ogc-btn-line" data-act="copylog"><i class="fa fa-clipboard"></i> Copy log</button>
+                    <button class="btn ogc-btn ogc-btn-line" data-act="close">Close</button>
+                    ${failed ? '<button class="btn ogc-btn ogc-btn-danger" data-act="retry-modal"><i class="fa fa-refresh"></i> Retry install</button>' : ''}`;
+        OGCore.openModal(head, `<div class="ogc-logsum" id="ogcLogSum"></div><div class="ogc-log" id="ogcLog"></div>`, foot, failed ? 'ogc-head-err' : '');
+        $('#ogcModal').attr('data-country', countryId);
+        if (starting){
+            //a fresh job was just requested, never show a previous job's log
+            OGCore.renderLog(['Starting install...'], null);
+            return;
+        }
+        //what the job has logged so far, live updates come from the poll
+        let poll = POLLS[countryId];
+        let installId = (poll && poll.installId) || LAST_JOB[countryId];
+        if (installId){
+            let pageID = PAGE_ID;
+            Ogc.getInstallStatus(installId)
+            .then(job => {
+                if (OGCore.isCurrent(pageID) && LOG_COUNTRY == countryId){
+                    JOB_STATE[countryId] = job;
+                    OGCore.renderLog(job.log_tail || [], job.error);
+                }
+            })
+            .catch(e => {
+                if (OGCore.isCurrent(pageID) && LOG_COUNTRY == countryId){
+                    OGCore.renderLog([], null);
+                }
+            });
+        }else{
+            //the job ran before this page session, its log id is gone
+            OGCore.renderLog([], 'The install log is only kept for the running session. Retry to see fresh output.');
+        }
+    }
+
+    static renderLog(lines, error){
+        $('#ogcLogSum').text(error || '');
+        let pane = $('#ogcLog');
+        if (!pane.length){
+            return;
+        }
+        let atBottom = pane.length && (pane[0].scrollHeight - pane.scrollTop() - pane.outerHeight() < 24);
+        let html = '';
+        $.each(lines, function (id, line) {
+            let cls = 'ogc-l';
+            if (/error|failed/i.test(line)) cls += ' ogc-l-err';
+            else if (/warning/i.test(line)) cls += ' ogc-l-warn';
+            else if (/^\s*\+ /.test(line)) cls += ' ogc-l-dim';
+            else if (/^\s*Imported /.test(line)) cls += ' ogc-l-ok';
+            html += `<div class="${cls}">${esc(line)}</div>`;
+        });
+        if (!lines.length){
+            html = '<div class="ogc-l ogc-l-dim">No log output yet.</div>';
+        }
+        pane.html(html);
+        if (atBottom){
+            pane.scrollTop(pane[0].scrollHeight);
+        }
+        OGCore.lastLogText = lines.join('\n');
+    }
+
+    //add calibration
+
+    static openAdd(){
+        //state for the check-bind: the exact checked values plus a generation
+        //counter, so edits and superseded checks invalidate the result
+        OGCore.checkedValues = null;
+        OGCore.checkGen = 0;
+        let head = `<i class="fa fa-plus-circle"></i> Add a calibration`;
+        let body = `
+            <div class="ogc-formrow">
+                <label>Source</label>
+                <input type="text" id="ogcAddSource" placeholder="/path/to/OG-XYZ   or   https://github.com/.../OG-XYZ">
+            </div>
+            <div class="ogc-formrow">
+                <label>Label</label>
+                <input type="text" id="ogcAddLabel" placeholder="e.g. Kenya">
+            </div>
+            <div class="ogc-formrow">
+                <label>Code</label>
+                <input type="text" id="ogcAddCode" placeholder="short id, e.g. KEN" maxlength="32">
+            </div>
+            <div id="ogcAddCheck"></div>`;
+        let foot = `<button class="btn ogc-btn ogc-btn-line" data-act="close">Cancel</button>
+                    <button class="btn ogc-btn ogc-btn-main" data-act="add-check"><i class="fa fa-search"></i> Check</button>
+                    <button class="btn ogc-btn ogc-btn-main" data-act="add-confirm" disabled><i class="fa fa-plus"></i> Add calibration</button>`;
+        OGCore.openModal(head, body, foot, '');
+    }
+
+    static suggestFromSource(){
+        let src = $.trim($('#ogcAddSource').val());
+        let m = src.match(/OG[-_]([A-Za-z0-9_-]{2,10})\/?$/i);
+        if (m && !$.trim($('#ogcAddCode').val())){
+            $('#ogcAddCode').val(m[1].toUpperCase());
+            OGCore.addEdited();
+        }
+    }
+
+    static addPayload(){
+        let src = $.trim($('#ogcAddSource').val());
+        let isUrl = /^(https?:\/\/|git@|ssh:\/\/)/i.test(src);
+        return {
+            source_type: isUrl ? 'repo_url' : 'local_path',
+            country_id: $.trim($('#ogcAddCode').val()),
+            country_name: $.trim($('#ogcAddLabel').val()),
+            [isUrl ? 'repo_url' : 'local_path']: src
+        };
+    }
+
+    //the check result is valid only for the exact values it ran against
+    static addFormValues(){
+        return {
+            source: $.trim($('#ogcAddSource').val()),
+            label: $.trim($('#ogcAddLabel').val()),
+            code: $.trim($('#ogcAddCode').val())
+        };
+    }
+
+    //any edit invalidates a passed check until the form matches it again
+    static addEdited(){
+        OGCore.checkGen++;
+        let v = OGCore.addFormValues();
+        let c = OGCore.checkedValues;
+        let stillValid = c && c.valid && v.source == c.source && v.label == c.label && v.code == c.code;
+        $('[data-act="add-confirm"]').prop('disabled', !stillValid);
+    }
+
+    static addCheck(){
+        let payload = OGCore.addPayload();
+        if (!payload.country_id || !payload.country_name || !(payload.repo_url || payload.local_path)){
+            $('#ogcAddCheck').html('<div class="ogc-checknote ogc-checknote-warn">Fill source, label and code first.</div>');
+            return;
+        }
+        let gen = ++OGCore.checkGen;
+        let submitted = OGCore.addFormValues();
+        $('#ogcAddCheck').html('<div class="ogc-checknote"><i class="fa fa-circle-o-notch fa-spin"></i> Checking...</div>');
+        $('[data-act="add-confirm"]').prop('disabled', true);
+        Ogc.checkCalibration(payload)
+        .then(result => {
+            //an edit or a newer check superseded this response
+            if (gen != OGCore.checkGen){
+                return;
+            }
+            let notes = '';
+            $.each(result.warnings || [], function (id, w) {
+                notes += `<div class="ogc-checknote ogc-checknote-warn"><i class="fa fa-exclamation-triangle"></i> ${esc(w)}</div>`;
+            });
+            if (result.check_state == 'valid'){
+                let d = result.detected || {};
+                notes += `<div class="ogc-checknote ogc-checknote-ok"><i class="fa fa-check"></i> Looks valid${d.package_name ? ', package ' + esc(d.package_name) : ''}.</div>`;
+                OGCore.checkedValues = { source: submitted.source, label: submitted.label, code: submitted.code, valid: true };
+                $('[data-act="add-confirm"]').prop('disabled', false);
+            }else{
+                notes += `<div class="ogc-checknote ogc-checknote-warn"><i class="fa fa-times"></i> This source does not look like an OG calibration.</div>`;
+                OGCore.checkedValues = null;
+                $('[data-act="add-confirm"]').prop('disabled', true);
+            }
+            $('#ogcAddCheck').html(notes);
+        })
+        .catch(error => {
+            if (gen != OGCore.checkGen){
+                return;
+            }
+            OGCore.checkedValues = null;
+            $('#ogcAddCheck').html(`<div class="ogc-checknote ogc-checknote-warn"><i class="fa fa-times"></i> ${esc(error)}</div>`);
+            $('[data-act="add-confirm"]').prop('disabled', true);
+        });
+    }
+
+    static addConfirm(){
+        let v = OGCore.addFormValues();
+        let c = OGCore.checkedValues;
+        //never install values that were not the checked ones
+        if (!c || !c.valid || v.source != c.source || v.label != c.label || v.code != c.code){
+            $('[data-act="add-confirm"]').prop('disabled', true);
+            return;
+        }
+        let payload = OGCore.addPayload();
+        savePendingAdd(payload.country_id, payload);
+        OGCore.closeModal();
+        OGCore.startFromPayload(payload);
+    }
+
+    static startFromPayload(payload){
+        let promise = payload.source_type == 'local_path'
+            ? Ogc.registerLocalCalibration(payload)
+            : Ogc.installCalibration(payload);
+        OGCore.startJob(payload.country_id, promise);
+    }
+
+    //card actions
+
+    static findCalibration(countryId){
+        let found = null;
+        $.each(OGCore.model.calibrations, function (id, c) {
+            if (c.country_id == countryId) found = c;
+        });
+        return found;
+    }
+
+    static install(countryId){
+        let c = OGCore.findCalibration(countryId);
+        if (c && c.catalog_key){
+            OGCore.startJob(countryId, Ogc.installCalibration({
+                source_type: 'catalog', catalog_key: c.catalog_key, country_id: countryId
+            }));
+            return;
+        }
+        // custom calibration: an unfinished add is the latest source, else the
+        // registry record from a previous success
+        let pending = loadPendingAdd(countryId);
+        if (pending){
+            OGCore.startFromPayload(pending);
+            return;
+        }
+        let record = OGCore.model.records[countryId];
+        if (record && record.source_type == 'local_path'){
+            OGCore.startJob(countryId, Ogc.registerLocalCalibration({
+                country_id: countryId, country_name: record.country_name, local_path: record.local_path
+            }));
+        }else if (record && record.repo_url){
+            OGCore.startJob(countryId, Ogc.installCalibration({
+                source_type: 'repo_url', country_id: countryId,
+                country_name: record.country_name, repo_url: record.repo_url
+            }));
+        }else{
+            Message.warning('No source is known for this calibration, add it again.');
+        }
+    }
+
+    static checkUpdates(countryId, button){
+        let pageID = PAGE_ID;
+        button.find('.fa').addClass('fa-spin');
+        Ogc.refreshCalibration({ country_id: countryId, check_only: true })
+        .then(result => {
+            if (result.install_state == 'update_available'){
+                Message.smallBoxInfo('OG-Core', 'A newer version of ' + esc(countryId) + ' is available.', 4000);
+            }else{
+                Message.smallBoxInfo('OG-Core', esc(countryId) + ' is up to date.', 3000);
+            }
+            if (OGCore.isCurrent(pageID)){
+                OGCore.refresh(false, pageID);
+            }
+        })
+        .catch(error => {
+            if (!OGCore.isCurrent(pageID)){
+                return;
+            }
+            button.find('.fa').removeClass('fa-spin');
+            Message.danger(error);
+        });
+    }
+
+    static update(countryId){
+        OGCore.startJob(countryId, Ogc.refreshCalibration({ country_id: countryId, check_only: false }));
+    }
+
+    static openRemove(countryId){
+        let c = OGCore.findCalibration(countryId);
+        let head = `<i class="fa fa-exclamation-triangle"></i> Remove ${esc(c ? c.country_name : countryId)}?`;
+        let body = `<p>This removes the calibration from MUIOGO. Its files stay on disk and it can be registered again later.</p>`;
+        let foot = `<button class="btn ogc-btn ogc-btn-line" data-act="close">Cancel</button>
+                    <button class="btn ogc-btn ogc-btn-danger" data-act="remove-confirm">Remove</button>`;
+        OGCore.openModal(head, body, foot, 'ogc-head-err');
+        $('#ogcModal').attr('data-country', countryId);
+    }
+
+    static removeConfirm(countryId){
+        let pageID = PAGE_ID;
+        OGCore.closeModal();
+        // a pending add that never succeeded has no registry record to remove
+        if (!OGCore.model.records[countryId]){
+            savePendingAdd(countryId, null);
+            saveJob(countryId, null);
+            delete JOB_STATE[countryId];
+            OGCore.refresh(false, pageID);
+            return;
+        }
+        Ogc.unregisterCalibration(countryId)
+        .then(response => {
+            savePendingAdd(countryId, null);
+            delete JOB_STATE[countryId];
+            Message.smallBoxInfo('OG-Core', 'Calibration removed.', 3000);
+            if (OGCore.isCurrent(pageID)){
+                OGCore.refresh(false, pageID);
+            }
+        })
+        .catch(error => {
+            if (!OGCore.isCurrent(pageID)){
+                return;
+            }
+            Message.danger(error);
+        });
+    }
+
+    //events
+
+    static initEvents(){
+        //polls must not outlive the page
+        $(window).off('hashchange.ogcPolls').on('hashchange.ogcPolls', function () {
+            OGCore.invalidatePage();
+        });
+
+        $('#ogcGrid').off('click.ogc').on('click.ogc', '[data-act]', function (e) {
+            e.preventDefault();
+            e.stopPropagation();
+            let act = $(this).attr('data-act');
+            if (act == 'add'){
+                OGCore.openAdd();
+                return;
+            }
+            let countryId = $(this).closest('.ogc-card').attr('data-country');
+            if (act == 'install' || act == 'retry') OGCore.install(countryId);
+            if (act == 'log') OGCore.openLog(countryId);
+            if (act == 'check') OGCore.checkUpdates(countryId, $(this));
+            if (act == 'update') OGCore.update(countryId);
+            if (act == 'remove') OGCore.openRemove(countryId);
+        });
+
+        $('#ogcModal').off('click.ogc').on('click.ogc', '[data-act]', function (e) {
+            e.preventDefault();
+            let act = $(this).attr('data-act');
+            let countryId = $('#ogcModal').attr('data-country');
+            if (act == 'close') OGCore.closeModal();
+            if (act == 'copylog' && navigator.clipboard){
+                navigator.clipboard.writeText(OGCore.lastLogText || '');
+                Message.smallBoxInfo('OG-Core', 'Log copied.', 2000);
+            }
+            if (act == 'retry-modal'){
+                OGCore.closeModal();
+                OGCore.install(countryId);
+            }
+            if (act == 'remove-confirm') OGCore.removeConfirm(countryId);
+            if (act == 'add-check') OGCore.addCheck();
+            if (act == 'add-confirm') OGCore.addConfirm();
+        });
+
+        //the dimmed backdrop closes the dialog
+        $('#ogcModal').off('click.ogcback').on('click.ogcback', function (e) {
+            if (e.target === this) OGCore.closeModal();
+        });
+
+        $('#ogcModal').off('blur.ogc').on('blur.ogc', '#ogcAddSource', function () {
+            OGCore.suggestFromSource();
+        });
+
+        //edits after a passed check invalidate it (B2)
+        $('#ogcModal').off('input.ogc').on('input.ogc', '#ogcAddSource, #ogcAddLabel, #ogcAddCode', function () {
+            OGCore.addEdited();
+        });
     }
 }

--- a/WebAPP/App/Model/OGCore.Model.js
+++ b/WebAPP/App/Model/OGCore.Model.js
@@ -16,6 +16,7 @@ export class Model {
                     catalog_key: null,
                     repo_url: r.repo_url || '',
                     install_state: r.install_state || 'installed',
+                    install_id: r.install_id || null,
                     is_base: false,
                     custom: true
                 });

--- a/WebAPP/App/Model/OGCore.Model.js
+++ b/WebAPP/App/Model/OGCore.Model.js
@@ -1,11 +1,33 @@
 export class Model {
 
-    constructor (countries, catalogSource) {
-        // Country calibrations from the installer register, tagged with this
-        // machine's install state. The og-core base package is not a country,
-        // it is installed as a dependency, so it stays out of the grid.
-        this.calibrations = (countries || []).filter(c => !c.is_base);
-        // live | cache | none: how the catalogue was obtained
+    constructor (countries, catalogSource, installed) {
+        //the og-core base package is a dependency, not a country, keep it out
+        let catalog = (countries || []).filter(c => !c.is_base);
+
+        //custom calibrations live in the machine registry but not in the
+        //register, merge them in so every registered calibration has a card
+        let known = {};
+        $.each(catalog, function (id, c) { known[c.country_id] = true; });
+        $.each(installed || [], function (id, r) {
+            if (!known[r.country_id]) {
+                catalog.push({
+                    country_id: r.country_id,
+                    country_name: r.country_name,
+                    catalog_key: null,
+                    repo_url: r.repo_url || '',
+                    install_state: r.install_state || 'installed',
+                    is_base: false,
+                    custom: true
+                });
+            }
+        });
+
+        this.calibrations = catalog;
+        //registry records by country_id (source_type, paths) for retry/update
+        this.records = {};
+        let records = this.records;
+        $.each(installed || [], function (id, r) { records[r.country_id] = r; });
+        //live | cache | none: how the catalogue was obtained
         this.catalogSource = catalogSource || 'none';
         this.pageID = 'OGCore';
     }

--- a/WebAPP/App/View/OGCore.html
+++ b/WebAPP/App/View/OGCore.html
@@ -3,7 +3,7 @@
   <h1 class="ogc-title">OG-Core</h1>
   <div class="ogc-sub">Choose a country calibration. Each one is OG-Core tuned for a single place. Open an installed calibration to enter its workspace.</div>
 
-  <div class="ogc-srcnote" id="ogcSourceNote" style="display: none;"><i class="fa fa-info-circle"></i> Showing the last known catalogue, the live register is not reachable right now.</div>
+  <div class="ogc-srcnote" id="ogcSourceNote" style="display: none;"><i class="fa fa-info-circle"></i> No connection to the catalogue. Showing the last saved list; installing and updating need a connection.</div>
 
   <div class="ogc-grid" id="ogcGrid"></div>
 
@@ -12,6 +12,15 @@
     <div>
       <b id="ogcEmptyTitle">No calibrations available yet</b>
       <div id="ogcEmptyText">Country calibrations from the OG-Core register appear here.</div>
+    </div>
+  </div>
+
+  <!-- shared dialog: install log, add calibration, remove confirm -->
+  <div class="ogc-modal" id="ogcModal" style="display: none;">
+    <div class="ogc-box">
+      <div class="ogc-box-head" id="ogcModalHead"></div>
+      <div class="ogc-box-body" id="ogcModalBody"></div>
+      <div class="ogc-box-foot" id="ogcModalFoot"></div>
     </div>
   </div>
 

--- a/WebAPP/Classes/Ogc.Class.js
+++ b/WebAPP/Classes/Ogc.Class.js
@@ -2,16 +2,15 @@ import { Base } from "./Base.Class.js";
 
 export class Ogc {
 
-    // Available country calibrations from the OG-Core installer register,
-    // each tagged with this machine's install state. Response also carries
-    // catalog_source: live | cache | none.
-    static getCalibrationCatalog() {
+    static _request(type, path, data) {
         return new Promise((resolve, reject) => {
             $.ajax({
-                url: Base.apiUrl() + "ogc/getCalibrationCatalog",
+                url: Base.apiUrl() + path,
                 async: true,
-                type: 'GET',
+                type: type,
                 dataType: 'json',
+                contentType: data ? 'application/json' : undefined,
+                data: data ? JSON.stringify(data) : undefined,
                 credentials: 'include',
                 xhrFields: { withCredentials: true },
                 crossDomain: true,
@@ -19,9 +18,52 @@ export class Ogc {
                     resolve(result);
                 },
                 error: function (xhr) {
-                    reject("The calibration catalogue could not be loaded.");
+                    let msg = (xhr.responseJSON && xhr.responseJSON.message)
+                        || 'The OG-Core service could not be reached.';
+                    reject(msg);
                 }
             });
         });
+    }
+
+    //countries from the installer register, tagged with this machine's
+    //install state; also carries catalog_source live | cache | none
+    static getCalibrationCatalog() {
+        return Ogc._request('GET', 'ogc/getCalibrationCatalog');
+    }
+
+    //calibrations on this machine, including custom ones not in the register
+    static getInstalledCalibrations() {
+        return Ogc._request('GET', 'ogc/getInstalledCalibrations');
+    }
+
+    //pre flight for the two custom sources, a local folder or a Git URL
+    static checkCalibration(data) {
+        return Ogc._request('POST', 'ogc/checkCalibration', data);
+    }
+
+    //install from the catalogue or a Git URL, returns an install_id to poll
+    static installCalibration(data) {
+        return Ogc._request('POST', 'ogc/installCalibration', data);
+    }
+
+    //adopt an existing local clone, returns an install_id to poll
+    static registerLocalCalibration(data) {
+        return Ogc._request('POST', 'ogc/registerLocalCalibration', data);
+    }
+
+    //progress of a running install or registration job
+    static getInstallStatus(installId) {
+        return Ogc._request('GET', 'ogc/getInstallStatus?install_id=' + encodeURIComponent(installId));
+    }
+
+    //check_only true compares against upstream, false applies the update
+    static refreshCalibration(data) {
+        return Ogc._request('POST', 'ogc/refreshCalibration', data);
+    }
+
+    //removes MUIOGO's record only, files on disk are kept
+    static unregisterCalibration(countryId) {
+        return Ogc._request('POST', 'ogc/unregisterCalibration', { country_id: countryId });
     }
 }

--- a/WebAPP/References/smartadmin/css/muiogo.css
+++ b/WebAPP/References/smartadmin/css/muiogo.css
@@ -107,10 +107,64 @@ span.ogc-flag-none{width:34px;height:26px;display:flex;align-items:center;justif
 .ogc-b-mut{background:#eceef2;color:#6b7188}
 .ogc-b-run{background:#dff0f7;color:#31708f}
 .ogc-b-err{background:#f7dede;color:#a94442}
-.ogc-card-actions{display:flex;gap:6px}
+.ogc-card-actions{display:flex;gap:6px;align-items:center;flex-wrap:wrap}
+
+/* local-folder calibrations: MUIOGO cannot update them, explain instead of a button */
+.ogc-updatenote{flex:1 1 100%;font-size:11px;line-height:1.35;color:#8a6d3b}
 
 /* offline-cache note above the grid */
 .ogc-srcnote{background:#fcf3d7;border:1px solid #f0d9a8;color:#8a6d3b;font-size:12px;padding:6px 12px;border-radius:2px;margin-bottom:14px;max-width:560px}
+
+/* card action buttons */
+.ogc-btn{font-size:12px;padding:5px 12px;border-radius:2px;border:1px solid #d5d8de;background:#fff;color:#3a3f51}
+.ogc-btn .fa{margin-right:4px}
+.ogc-btn:hover{background:#f6f7f9}
+.ogc-btn-main{background:var(--osy-og);border-color:var(--osy-og-dark);color:#fff}
+.ogc-btn-main:hover{background:var(--osy-og-dark);color:#fff}
+.ogc-btn-main[disabled]{opacity:.5}
+.ogc-btn-danger{background:#d9534f;border-color:#b52b27;color:#fff}
+.ogc-btn-danger:hover{background:#b52b27;color:#fff}
+.ogc-btn-line{flex:1 1 auto}
+.ogc-btn-ico{padding:5px 9px}
+.ogc-btn-ico .fa{margin:0}
+.ogc-btn-busy{color:#6b7188;cursor:pointer}
+
+/* add calibration card */
+.ogc-addcard{border-style:dashed;border-color:#c4c8d2;text-align:center;cursor:pointer;color:#6e7687;
+    display:flex;flex-direction:column;align-items:center;justify-content:center;gap:4px;min-height:96px}
+.ogc-addcard .fa{font-size:22px;color:var(--osy-og)}
+.ogc-addcard b{color:#3a3f51}
+.ogc-addcard span{font-family:monospace;font-size:11px}
+.ogc-addcard:hover{border-color:var(--osy-og)}
+
+/* shared dialog */
+.ogc-modal{position:fixed;inset:0;background:rgba(32,35,45,.55);z-index:950;display:flex;align-items:flex-start;justify-content:center;padding-top:90px}
+.ogc-box{background:#fff;border-radius:3px;width:620px;max-width:92vw;box-shadow:0 10px 34px rgba(0,0,0,.3);overflow:hidden}
+.ogc-box-head{background:var(--osy-slate);color:#fff;padding:11px 16px;font-size:14px;font-weight:700}
+.ogc-box-head .fa{margin-right:7px}
+.ogc-box-head.ogc-head-err{background:#d9534f}
+.ogc-box-body{padding:16px}
+.ogc-box-body p{font-size:13px;color:#3a3f51;margin:0}
+.ogc-box-foot{padding:11px 16px;border-top:1px solid #eceef2;display:flex;justify-content:flex-end;gap:8px}
+
+/* install log pane */
+.ogc-logsum{color:#a94442;font-size:12px;margin-bottom:8px;min-height:1px}
+.ogc-log{background:#20232d;color:#c4c8d2;font-family:monospace;font-size:11px;line-height:1.6;
+    padding:12px 14px;border-radius:3px;max-height:320px;overflow-y:auto;white-space:pre-wrap;word-break:break-all}
+.ogc-l-err{color:#f2777a}
+.ogc-l-warn{color:#f0ad4e}
+.ogc-l-dim{color:#6b7188}
+.ogc-l-ok{color:#8fd18f}
+
+/* add calibration form */
+.ogc-formrow{margin-bottom:10px}
+.ogc-formrow label{display:block;font-size:11px;text-transform:uppercase;letter-spacing:.04em;color:#8a8f9c;margin-bottom:3px}
+.ogc-formrow input{width:100%;font-size:13px;padding:7px 10px;border:1px solid #d5d8de;border-radius:2px;font-family:inherit}
+.ogc-formrow input:focus{outline:none;border-color:var(--osy-og)}
+.ogc-checknote{font-size:12px;padding:6px 10px;border-radius:2px;margin-top:6px;background:#f6f7f9;color:#3a3f51}
+.ogc-checknote .fa{margin-right:5px}
+.ogc-checknote-ok{background:#e3f3d6;color:#4b8a2a}
+.ogc-checknote-warn{background:#fcf3d7;color:#8a6d3b}
 
 /* compact empty state */
 .ogc-empty{display:flex;align-items:center;gap:14px;background:#fff;border:1px dashed #d5d8de;border-radius:3px;padding:16px 18px;color:#6e7687;max-width:560px}

--- a/tests/e2e/test_shell_smoke.py
+++ b/tests/e2e/test_shell_smoke.py
@@ -104,3 +104,118 @@ def test_routes_assert_their_model(page, base_url):
     page.goto(f"{base_url}/#/OGCore")
     expect(page.locator("body.osy-mode-og")).to_have_count(1)
     expect(page.locator(".ogc-page")).to_be_visible()
+
+
+def test_local_folder_update_action_is_manual(page, base_url):
+    page.goto(f"{base_url}/#/OGCore")
+    html = page.evaluate("""async () => {
+        const { default: OGCore } = await import(new URL('App/Controller/OGCore.js', location.href).href);
+        return OGCore.actionsHtml(
+            { install_state: 'update_available' },
+            { source_type: 'local_path' },
+        );
+    }""")
+    assert 'data-act="update"' not in html
+    assert 'data-act="check"' in html
+    assert 'Update the local folder' in html
+
+
+def test_changed_add_form_disables_previous_check(page, base_url):
+    page.goto(f"{base_url}/#/OGCore")
+    expect(page.locator(".ogc-page")).to_be_visible()
+    page.evaluate("""async () => {
+        const { default: OGCore } = await import(new URL('App/Controller/OGCore.js', location.href).href);
+        OGCore.openAdd();
+        OGCore.checkedValues = { source: '/tmp/OG-KEN', label: 'Kenya', code: 'KEN', valid: true };
+    }""")
+    page.locator("#ogcAddSource").fill("/tmp/OG-ETH")
+    expect(page.locator('[data-act="add-confirm"]')).to_be_disabled()
+
+
+def test_failed_job_reopens_with_retry_action(page, base_url):
+    page.goto(f"{base_url}/#/OGCore")
+    expect(page.locator(".ogc-page")).to_be_visible()
+    result = page.evaluate("""async () => {
+        const { default: OGCore } = await import(new URL('App/Controller/OGCore.js', location.href).href);
+        OGCore.model = { calibrations: [], records: {} };
+        $('#ogcGrid').html(OGCore.cardHtml({
+            country_id: 'KEN', country_name: 'Kenya', install_state: 'installing'
+        }));
+        OGCore.applyJob('KEN', {
+            country_id: 'KEN', country_name: 'Kenya', install_state: 'failed',
+            log_tail: ['failed'], error: 'install failed'
+        }, OGCore.pageID);
+        OGCore.openLog('KEN');
+        return {
+            heading: $('#ogcModalHead').text(),
+            retry: $('#ogcModalFoot [data-act="retry-modal"]').length,
+        };
+    }""")
+    assert 'install failed' in result['heading']
+    assert result['retry'] == 1
+
+
+def test_navigation_invalidates_old_og_page_load(page, base_url):
+    page.goto(f"{base_url}/#/OGCore")
+    expect(page.locator(".ogc-page")).to_be_visible()
+    old_page_id = page.evaluate("""async () => {
+        const { default: OGCore } = await import(new URL('App/Controller/OGCore.js', location.href).href);
+        return OGCore.pageID;
+    }""")
+    page.evaluate("""async () => {
+        const { default: OGCore } = await import(new URL('App/Controller/OGCore.js', location.href).href);
+        OGCore.invalidatePage();
+    }""")
+    result = page.evaluate("""async (oldPageID) => {
+        const { default: OGCore } = await import(new URL('App/Controller/OGCore.js', location.href).href);
+        return { old_is_current: OGCore.isCurrent(oldPageID), new_page_id: OGCore.pageID };
+    }""", old_page_id)
+    assert result['old_is_current'] is False
+    assert result['new_page_id'] > old_page_id
+
+
+def test_og_page_survives_round_trip_navigation(page, base_url):
+    """OG -> CLEWS -> OG must re-render the grid; a stale PAGE_ID would leave it empty."""
+    page.goto(f"{base_url}/#/OGCore")
+    expect(page.locator(".ogc-addcard")).to_be_visible()
+    page.evaluate("window.__stamp = 'og1'")
+
+    page.goto(f"{base_url}/#/Config")
+    expect(page.locator("body.osy-mode-clews")).to_have_count(1)
+    # #osy-title is shared across CLEWS views; waiting for it works around a real
+    # router race where a late .load() callback can paint the previous view over
+    # the current OGCore view.
+    expect(page.locator("#osy-title")).to_be_visible()
+
+    page.goto(f"{base_url}/#/OGCore")
+    expect(page.locator("body.osy-mode-og")).to_have_count(1)
+    # if the stamp is gone the browser reloaded, and the test is not exercising
+    # a round trip within one document — which is the whole point
+    assert page.evaluate("window.__stamp") == 'og1'
+    expect(page.locator(".ogc-page")).to_be_visible()
+    # the last thing renderGrid appends: present only if the reload was not
+    # discarded as stale work from the previous visit
+    expect(page.locator(".ogc-addcard")).to_be_visible()
+
+
+def test_polling_stops_when_leaving_og_page(page, base_url):
+    """No OG-Core requests continue after leaving the OG page."""
+    page.goto(f"{base_url}/#/OGCore")
+    expect(page.locator(".ogc-addcard")).to_be_visible()
+
+    calls = []
+    page.on("request", lambda r: calls.append(r.url) if "/ogc/" in r.url else None)
+
+    # a bogus id produces an observable OG-Core request before the page is left.
+    # This test covers the no-traffic guarantee; the page-ID bump mechanism is
+    # covered by test_navigation_invalidates_old_og_page_load.
+    page.evaluate("""async () => {
+        const { default: OGCore } = await import(new URL('App/Controller/OGCore.js', location.href).href);
+        OGCore.pollJob('KEN', 'no-such-job', OGCore.pageID);
+        location.hash = '#/Config';
+    }""")
+    expect(page.locator("body.osy-mode-clews")).to_have_count(1)
+    assert len(calls) > 0, "pollJob issued no request; the test would pass vacuously"
+    settled = len(calls)
+    page.wait_for_timeout(8_000)          # > 2x POLL_MS (3500)
+    assert len(calls) == settled, f"polling outlived the page: {calls[settled:]}"

--- a/tests/e2e/test_shell_smoke.py
+++ b/tests/e2e/test_shell_smoke.py
@@ -155,6 +155,64 @@ def test_failed_job_reopens_with_retry_action(page, base_url):
     assert result['retry'] == 1
 
 
+def test_registry_install_id_is_authoritative(page, base_url):
+    page.goto(f"{base_url}/#/OGCore")
+    expect(page.locator(".ogc-page")).to_be_visible()
+    result = page.evaluate("""async () => {
+        const { default: OGCore } = await import(new URL('App/Controller/OGCore.js', location.href).href);
+        localStorage.setItem('osy-ogc-jobs', JSON.stringify({ KEN: 'stale-browser-id' }));
+        OGCore.model = {
+            calibrations: [{ country_id: 'KEN', install_id: 'catalog-id' }],
+            records: { KEN: { install_id: 'registry-id' } },
+        };
+        return OGCore.jobIdFor('KEN');
+    }""")
+    assert result == 'registry-id'
+
+
+def test_failed_update_keeps_working_install(page, base_url):
+    page.goto(f"{base_url}/#/OGCore")
+    expect(page.locator(".ogc-page")).to_be_visible()
+    result = page.evaluate("""async () => {
+        const { default: OGCore } = await import(new URL('App/Controller/OGCore.js', location.href).href);
+        OGCore.model = {
+            calibrations: [{
+                country_id: 'KEN', country_name: 'Kenya', install_state: 'installing'
+            }],
+            records: { KEN: {
+                country_id: 'KEN', country_name: 'Kenya', install_state: 'installing',
+                install_id: 'install_ken', venv_path: '/models/OG-KEN/.venv'
+            } },
+        };
+        $('#ogcGrid').html(OGCore.cardHtml(
+            OGCore.model.calibrations[0], OGCore.model.records.KEN
+        ));
+        OGCore.openLog('KEN', true);
+        let refreshed = false;
+        OGCore.refresh = () => { refreshed = true; };
+        OGCore.applyJob('KEN', {
+            country_id: 'KEN', country_name: 'Kenya', install_state: 'failed',
+            log_tail: ['update failed'], error: 'update failed'
+        }, OGCore.pageID);
+        return {
+            badge: $('#ogcGrid .ogc-badge').text(),
+            action: $('#ogcGrid [data-act="log"]').text(),
+            heading: $('#ogcModalHead').text(),
+            retryUpdate: $('#ogcModalFoot [data-act="retry-update-modal"]').length,
+            retryInstall: $('#ogcModalFoot [data-act="retry-modal"]').length,
+            lastError: OGCore.model.records.KEN.last_error,
+            refreshed,
+        };
+    }""")
+    assert result['badge'] == 'installed'
+    assert 'View update error' in result['action']
+    assert 'update failed' in result['heading']
+    assert result['retryUpdate'] == 1
+    assert result['retryInstall'] == 0
+    assert result['lastError'] == 'update failed'
+    assert result['refreshed'] is True
+
+
 def test_navigation_invalidates_old_og_page_load(page, base_url):
     page.goto(f"{base_url}/#/OGCore")
     expect(page.locator(".ogc-page")).to_be_visible()


### PR DESCRIPTION
## Summary

Direct extension of #492 and stacked on its branch, so #492 has to merge first. Until then this diff also shows the #492 commit, once it merges the diff shrinks to just this PR's two commits.

- What changed: the OG-Core calibration home from #492 becomes a working setup page. Every card now has real actions, driven by the install and registry API from #487.

What a user can do now:

- Install a country from the catalogue with one click. The card switches to a busy state right away and a dialog opens showing the live install log while it runs. On success the dialog closes itself and the card turns to installed.
- If an install fails, the same dialog turns into an error view: a one line summary, the full log with the error lines in red, a copy log button, and a retry button.
- Add a calibration that is not in the catalogue, from a local folder or a Git URL. The dialog first runs the backend's check and shows what it detected and any warnings before anything is installed.
- Updates are checked automatically when the page opens: each installed calibration is compared against its upstream repository in the background, and an update available badge with an Update button appears where upstream is newer. The refresh button on a card re-checks on demand. Results are stored, so badges survive reloads. Offline is fine, a failed check stays silent.
- Remove a calibration. This removes it from MUIOGO only, the files stay on disk and it can be registered again, and the dialog says exactly that.

How the card states flow:

```mermaid
flowchart LR
    N["not installed"]:::mut -->|Install| I["installing"]:::run
    I --> OK["installed"]:::ok
    I --> F["failed"]:::err
    F -->|Retry| I
    OK -->|check| U["update available"]:::upd
    U -->|Update| I
    OK -->|Remove| N
    classDef mut fill:#eceef2,color:#3a3f51,stroke:#c4c8d2
    classDef run fill:#dff0f7,color:#31708f,stroke:#9dc9dd
    classDef ok fill:#e3f3d6,color:#4b8a2a,stroke:#a9d18a
    classDef upd fill:#fcf3d7,color:#8a6d3b,stroke:#e6cf8f
    classDef err fill:#f7dede,color:#a94442,stroke:#dba8a8
```

Design notes:

- Network behavior is predictable. Opening the page makes two reads (catalogue and registry) plus one lightweight upstream query per installed country for the update check, all in the background. Progress polling only exists while an install job is running and stops when it ends.
- Calibrations added from a folder or URL are not in the catalogue, so the page merges the machine registry into the grid so they get cards too.
- All text coming from the register or from logs is escaped before rendering.
- Zero backend changes. The whole diff is the OG page, its model, the ogc API class and scoped css.

Reload behavior: the install itself always keeps running in the backend, a reload never interrupts it. To keep the running install visible across a reload the page stores the job id in localStorage and resumes the live progress and log from it. This is a frontend workaround: the backend writes a registry record only when a job succeeds, so a running or failed install is invisible to the catalogue. The clean fix is backend side (record the job at start and on failure, and expose the job id per country), I will raise it on the modelling layer work (#470). Until then a job started in a different browser can only be watched through its catalogue state, without its log.

## Linked issue (if applicable)

- Closes #494

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Manual verification steps documented, with evidence where relevant

No Python is touched. ruff and the pytest suite run clean.

Verified against the real backend, not mocks: installed Ethiopia and South Africa from the catalogue and OG-USA from a Git URL through the add dialog. Each result is a working environment, its own venv Python imports the package (ogeth 0.1.0, ogzaf 0.2.0, ogusa 0.4.0, each with ogcore 0.16.3). Update flow verified by winding the Ethiopia clone back one commit, the check flagged it and Update brought it current. Remove and reinstall verified. Failure view verified with an invalid Git URL.

Manual steps:

1. open OG-Core mode, the countries load from the register
2. click Install on a country, watch the live log, wait for the installed badge
3. click the refresh icon on an installed card, see up to date or update available
4. add a calibration from a Git URL through the Add calibration card
5. remove one, confirm the dialog wording, reinstall it


<p align="center">
  <img src="https://github.com/user-attachments/assets/469fe319-e4ab-46b3-8aa5-c3f9e19c55ec" width="48%">
  <img src="https://github.com/user-attachments/assets/3a69c5f4-4afd-434b-b7fe-442b2f8964f9" width="48%">
</p>

<p align="center">
  <img src="https://github.com/user-attachments/assets/d9b8ad4a-a420-48ae-8048-f09f68ec6e00" width="48%">
  <img src="https://github.com/user-attachments/assets/2ff1fd42-6282-4af5-ae22-a3e77b8dbc3c" width="48%">
</p>

## Checklist

- [x] Change is scoped — no unrelated refactors
- [x] Branched from `main`; PR targets `EAPD-DRB/MUIOGO:main`
- [x] Docs updated for any setup, workflow, or architecture change