### PR TITLE
Fix/start script local venv

### DIFF
--- a/scripts/setup_dev.py
+++ b/scripts/setup_dev.py
@@ -44,7 +44,7 @@ import tempfile
 # ──────────────────────────────────────────────────────────────────────────────
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
-VENV_DIR = (Path.home() / ".venvs" / "muiogo").resolve()
+VENV_DIR = (PROJECT_ROOT / ".venv").resolve()
 REQUIREMENTS = PROJECT_ROOT / "requirements.txt"
 ENV_FILE = PROJECT_ROOT / ".env"
 # Where a prebuilt CBC (cbcbox) is copied so it survives 'uv sync', which prunes
@@ -355,7 +355,7 @@ def _resolve_venv_dir(venv_dir_arg: str | None) -> Path:
         return Path(env_override).expanduser().resolve()
 
     # Project-local .venv, matching the uv installer and the start/smoke scripts.
-    return (Path(__file__).resolve().parents[1] / ".venv").resolve()
+    return (PROJECT_ROOT / ".venv").resolve()
 
 
 def _sha256(path: Path) -> str:
@@ -1509,12 +1509,6 @@ def main() -> int:
     print(f"  Support  : >={MIN_PYTHON[0]}.{MIN_PYTHON[1]}, <{MAX_PYTHON[0]}.{MAX_PYTHON[1]}")
     print(f"  Project  : {PROJECT_ROOT}")
     print(f"  Venv dir : {VENV_DIR}")
-
-    if not args.platform_only and PROJECT_ROOT.resolve() in VENV_DIR.resolve().parents:
-        _print_warn(
-            "Using in-repo virtual environment",
-            "This can cause high CPU in Codex Desktop. External venv is recommended.",
-        )
 
     if args.check:
         demo_ok = True

--- a/scripts/setup_dev.py
+++ b/scripts/setup_dev.py
@@ -20,7 +20,7 @@ Supports: macOS, Linux (apt/dnf/pacman), Windows
 
 Python support: >=3.10 and <3.13 (recommended: 3.11)
 
-Default venv location: ~/.venvs/muiogo (outside repo)
+Default venv location: <project root>/.venv (matches the uv installer and start scripts)
 """
 
 import argparse
@@ -354,7 +354,8 @@ def _resolve_venv_dir(venv_dir_arg: str | None) -> Path:
     if env_override:
         return Path(env_override).expanduser().resolve()
 
-    return (Path.home() / ".venvs" / "muiogo").resolve()
+    # Project-local .venv, matching the uv installer and the start/smoke scripts.
+    return (Path(__file__).resolve().parents[1] / ".venv").resolve()
 
 
 def _sha256(path: Path) -> str:
@@ -1423,7 +1424,7 @@ def main() -> int:
         "--venv-dir",
         help=(
             "Virtual environment directory path. "
-            "Default: ~/.venvs/muiogo (or MUIOGO_VENV_DIR if set)."
+            "Default: <project root>/.venv (or MUIOGO_VENV_DIR if set)."
         ),
     )
     parser.add_argument(

--- a/scripts/smoke.bat
+++ b/scripts/smoke.bat
@@ -3,7 +3,7 @@ setlocal enabledelayedexpansion
 
 set "SCRIPT_DIR=%~dp0"
 set "PROJECT_ROOT=%SCRIPT_DIR%.."
-set "DEFAULT_VENV_PY=%USERPROFILE%\.venvs\muiogo\Scripts\python.exe"
+set "DEFAULT_VENV_PY=%PROJECT_ROOT%\.venv\Scripts\python.exe"
 set "ACTIVE_VENV_PY=%VIRTUAL_ENV%\Scripts\python.exe"
 
 if not "%CONDA_DEFAULT_ENV%"=="" (

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-DEFAULT_VENV_PY="${HOME}/.venvs/muiogo/bin/python"
+DEFAULT_VENV_PY="${PROJECT_ROOT}/.venv/bin/python"
 ACTIVE_VENV_PY="${VIRTUAL_ENV:-}/bin/python"
 CONFIGURED_VENV_PY="${MUIOGO_VENV_PYTHON:-}"
 

--- a/scripts/start.bat
+++ b/scripts/start.bat
@@ -2,7 +2,7 @@
 REM ─────────────────────────────────────────────────────────────────────────────
 REM MUIOGO Launcher (Windows)
 REM
-REM Starts the API with the setup venv and opens the browser automatically.
+REM Starts the API with the project-local venv and opens the browser automatically.
 REM Usage:
 REM   scripts\start.bat
 REM ─────────────────────────────────────────────────────────────────────────────
@@ -17,7 +17,8 @@ if not "%CONDA_DEFAULT_ENV%"=="" (
 set "SCRIPT_DIR=%~dp0"
 set "PROJECT_ROOT=%SCRIPT_DIR%.."
 set "VENV_DIR=%MUIOGO_VENV_DIR%"
-if "%VENV_DIR%"=="" set "VENV_DIR=%USERPROFILE%\.venvs\muiogo"
+REM if "%VENV_DIR%"=="" set "VENV_DIR=%USERPROFILE%\.venvs\muiogo" - use project-local venv instead
+if "%VENV_DIR%"=="" set "VENV_DIR=%PROJECT_ROOT%\.venv"
 set "PYTHON=%VENV_DIR%\Scripts\python.exe"
 set "HOST=127.0.0.1"
 if "%PORT%"=="" (set "PORT=5002")

--- a/scripts/start.bat
+++ b/scripts/start.bat
@@ -17,7 +17,6 @@ if not "%CONDA_DEFAULT_ENV%"=="" (
 set "SCRIPT_DIR=%~dp0"
 set "PROJECT_ROOT=%SCRIPT_DIR%.."
 set "VENV_DIR=%MUIOGO_VENV_DIR%"
-REM if "%VENV_DIR%"=="" set "VENV_DIR=%USERPROFILE%\.venvs\muiogo" - use project-local venv instead
 if "%VENV_DIR%"=="" set "VENV_DIR=%PROJECT_ROOT%\.venv"
 set "PYTHON=%VENV_DIR%\Scripts\python.exe"
 set "HOST=127.0.0.1"
@@ -26,8 +25,7 @@ set "URL=http://%HOST%:%PORT%/"
 
 if not exist "%PYTHON%" (
     echo ERROR: Venv Python not found at: %PYTHON%
-    echo Run setup first:
-    echo   scripts\setup.bat
+    echo From the MUIOGO project directory, run 'uv sync'.
     exit /b 1
 )
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -17,7 +17,6 @@ if [ -n "${CONDA_DEFAULT_ENV:-}" ]; then
     exit 1
 fi
 
-#VENV_DIR="${MUIOGO_VENV_DIR:-$HOME/.venvs/muiogo}" - use project-local venv instead
 VENV_DIR="${MUIOGO_VENV_DIR:-$PROJECT_ROOT/.venv}"
 PYTHON="$VENV_DIR/bin/python"
 HOST="127.0.0.1"
@@ -27,8 +26,7 @@ TIMEOUT_SECONDS=30
 
 if [ ! -x "$PYTHON" ]; then
     echo "ERROR: Venv Python not found at: $PYTHON"
-    echo "Run setup first:"
-    echo "  ./scripts/setup.sh"
+    echo "From the MUIOGO project directory, run 'uv sync'."
     exit 1
 fi
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -2,7 +2,7 @@
 # ──────────────────────────────────────────────────────────────────────────────
 # MUIOGO Launcher (macOS / Linux)
 #
-# Starts the API with the setup venv and opens the browser automatically.
+# Starts the API with the project-local venv and opens the browser automatically.
 # Usage:
 #   ./scripts/start.sh
 # ──────────────────────────────────────────────────────────────────────────────
@@ -17,7 +17,8 @@ if [ -n "${CONDA_DEFAULT_ENV:-}" ]; then
     exit 1
 fi
 
-VENV_DIR="${MUIOGO_VENV_DIR:-$HOME/.venvs/muiogo}"
+#VENV_DIR="${MUIOGO_VENV_DIR:-$HOME/.venvs/muiogo}" - use project-local venv instead
+VENV_DIR="${MUIOGO_VENV_DIR:-$PROJECT_ROOT/.venv}"
 PYTHON="$VENV_DIR/bin/python"
 HOST="127.0.0.1"
 PORT="${PORT:-5002}"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3,34 +3,49 @@ Smoke tests -- does the app start at all?
 
 These catch the obvious stuff early: missing deps, syntax errors, broken imports.
 If these fail, nothing else will work either.
+
+Written as unittest.TestCase so both runners execute them: pytest (CI) collects
+unittest classes natively, and the smoke scripts use `unittest discover`.
 """
+
+import sys
+import unittest
+from pathlib import Path
+
+# pytest puts API/ on the path via pyproject.toml pythonpath; the smoke scripts run
+# this file under `unittest discover`, which does not read that config.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "API"))
 
 from flask import Flask
 
 import app as api_app
 
 
-def test_app_is_flask_instance():
-    """app.py needs to give us a Flask object, not something broken."""
-    assert isinstance(api_app.app, Flask)
+class AppSmokeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Mirror tests/conftest.py: TESTING stays False so routes return real
+        # HTTP responses instead of re-raising exceptions.
+        api_app.app.config.update({"SECRET_KEY": "test-secret-key", "TESTING": False})
 
+    def test_app_is_flask_instance(self):
+        """app.py needs to give us a Flask object, not something broken."""
+        self.assertIsInstance(api_app.app, Flask)
 
-def test_case_blueprint_is_registered():
-    """If CaseRoute isn't wired up, all case endpoints silently return 404."""
-    assert "CaseRoute" in api_app.app.blueprints
+    def test_case_blueprint_is_registered(self):
+        """If CaseRoute isn't wired up, all case endpoints silently return 404."""
+        self.assertIn("CaseRoute", api_app.app.blueprints)
 
+    def test_datafile_blueprint_is_registered(self):
+        """If DataFileRoute isn't wired up, all run and datafile endpoints silently return 404."""
+        self.assertIn("DataFileRoute", api_app.app.blueprints)
 
-def test_datafile_blueprint_is_registered():
-    """If DataFileRoute isn't wired up, all run and datafile endpoints silently return 404."""
-    assert "DataFileRoute" in api_app.app.blueprints
+    def test_app_has_secret_key(self):
+        """Sessions break silently if there's no secret key set."""
+        self.assertNotIn(api_app.app.config.get("SECRET_KEY"), (None, ""))
 
-
-def test_app_has_secret_key(app):
-    """Sessions break silently if there's no secret key set."""
-    assert app.config.get("SECRET_KEY") not in (None, "")
-
-
-def test_home_returns_200(client):
-    """The home route should render without crashing."""
-    resp = client.get("/")
-    assert resp.status_code == 200
+    def test_home_returns_200(self):
+        """The home route should render without crashing."""
+        with api_app.app.test_client() as client:
+            resp = client.get("/")
+        self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
# Summary

- What changed: 
Updated `scripts/start.sh` and `scripts/start.bat` to use the project-local `.venv` by default instead of `~/.venvs/muiogo`.
Updated the installer error message.

- Why:
Aligns the launcher with the new `uv` installer workflow and fixes startup after installation.
## Linked issue (if applicable)

- Closes #

## Validation

- [x] Tests added/updated (or not applicable)

From MUIOGO directory, check out this PR: ` gh pr checkout 496`
Then temporarily rename .venvs so the installer can test if the local .vevn works at startup. After tests, rename it back. 

macOS: 
```bash
mv ~/.venvs/muiogo ~/.venvs/muiogo-backup
./scripts/start.sh
mv ~/.venvs/muiogo-backup ~/.venvs/muiogo
```
Windows:
```powershell
Rename-Item $HOME\.venvs\muiogo muiogo-backup
.\scripts\start.bat
Rename-Item $HOME\.venvs\muiogo-backup muiogo
```

- [x] Manual verification steps documented, with evidence where relevant
Verified that `start.bat` launches successfully using the project-local `.venv` after temporarily renaming `\.venvs\muiogo`.
Verified the running process uses `.venv\Scripts\python.exe`.

## Checklist

- [x] Change is scoped — no unrelated refactors
- [x] Branched from `main`; PR targets `EAPD-DRB/MUIOGO:main`
- [x] Docs updated for any setup, workflow, or architecture change
