### PR TITLE
Relocate OG-Core storage so it stops showing up as a CLEWS case

### DIFF
--- a/API/Classes/Base/Config.py
+++ b/API/Classes/Base/Config.py
@@ -80,13 +80,16 @@ if not os.access(DATA_STORAGE, os.W_OK):
 # -------------------------
 # OG country models live in their OWN uv environments, installed by the OG-Core
 # Universal Installer. MUIOGO neither installs nor imports OG-Core; it drives the
-# installer and tracks what is installed. See:
-#   universal installer setup OGC/Universal-Installer-Master-Doc.md
-#   Track1-API-Schema-Discussion/OGCore-API-Schema-FINAL.md
+# installer and tracks what is installed.
 
-# MUIOGO-side storage (registry + install-job state) lives under DataStorage,
-# never inside a calibration's .venv.
-OGC_DATA_STORAGE = DATA_STORAGE / "OGCore"
+# MUIOGO-side OG state (registry, install-job state, caches) lives at the user level
+# under ~/.muiogo, never inside the CLEWS DataStorage tree and never inside a
+# calibration's .venv. Keeping it out of DataStorage is what stops the CLEWS case
+# picker (and the other DataStorage walkers) from treating it as a case. See #500.
+OGC_DATA_STORAGE = Path(
+    os.environ.get("MUIOGO_OG_DATA_DIR", "").strip()
+    or (Path.home() / ".muiogo" / "og-state")
+)
 OGC_INSTALLED_REGISTRY = OGC_DATA_STORAGE / "og_calibrations_installed.json"
 OGC_INSTALL_JOBS_DIR = OGC_DATA_STORAGE / "install_jobs"
 OGC_CATALOG_CACHE = OGC_DATA_STORAGE / "catalog_cache.json"


### PR DESCRIPTION
Fixes #500.

## Summary
Once any OG-Core page ran, an "OGCore" entry appeared in the CLEWS case picker as if it were a model. This moves OG-Core's own state out of the CLEWS data folder so that can no longer happen.

> The Problem : The structure of the case picker for clews wasn't made for verifying if additions serve as cases as well.  There is no 'filtering' or test to verify the structure of the intake. 

What changed: `OGC_DATA_STORAGE` used to live at `WebAPP/DataStorage/OGCore`, inside the CLEWS DataStorage tree ( Oirginally placed to keep data storage parallel) . The get cases method builds the model list by listing every folder in the data Storage, so the first OG call created the folder and from then on CLEWS listed it as a case.
It now lives at the user level, `~/.muiogo/og-state`, right next to the installed models.

Why move it instead of filtering (other appraoches considered) : getCases is not the only place that treats every folder in Data Storage as a case. Upload and the OsemosysClass loader walk the same tree. Filtering would mean special casing "OGCore" in each of them. Moving the folder out fixes all of them at once, and ensures we dont touch any upstream behaviour.

---


### NOTE : If you already ran an OG-Core page before this change and need to migrate models 

**Option 1: move the folder (keeps what you installed)**
The registry and caches are just files, so moving the folder is enough. Run from the CLEWS repo root.

Windows (PowerShell):

```
$old = "$PWD\WebAPP\DataStorage\OGCore"
$new = "$HOME\.muiogo\og-state"
if (Test-Path $old) {
    New-Item -ItemType Directory -Force (Split-Path $new) | Out-Null
    Move-Item $old $new
}
```
macOS / Linux:
```
old="WebAPP/DataStorage/OGCore"
new="$HOME/.muiogo/og-state"
[ -d "$old" ] && mkdir -p "$(dirname "$new")" && mv "$old" "$new"
```
If you set MUIOGO_OG_DATA_DIR, move the folder to that path instead of ~/.muiogo/og-state.

**Option 2: reinstall (download fresh)**
Delete the old folder and install the calibration again from the setup page. Nothing else changes: the new install lands at the new location on its own, and the app reads from there automatically.

---
## Testing

Validated with isolated runs, each in its own interpreter so `Config` resolves paths fresh, and
each driving the real OG write path (`CalibrationRegistry.upsert`) and the real `getCases` listing.

- Default location resolves to `~/.muiogo/og-state`, outside `DataStorage`.
- `MUIOGO_OG_DATA_DIR` override is honoured, and every derived path follows it.
- An existing legacy folder is left untouched (no auto migration), and importing Config creates
  nothing.
- After a real OG write, the case picker list is unchanged and no folder is created under
  `DataStorage`.
- Control: pointing the OG root back under `DataStorage` reproduces the bug (OGCore reappears), so
  the pass above is meaningful.

## Checklist

- [x] Change is scoped, no unrelated refactors
- [x] Branched from `main`; PR targets `EAPD-DRB/MUIOGO:main`
- [x] Docs updated for any setup, workflow, or architecture change (the storage location and the
  manual move steps are documented in this PR body)


