### PR TITLE
Track OG install jobs in the registry, and harden the install lifecycle

### DIFF
--- a/API/Classes/OGCore/CalibrationCatalog.py
+++ b/API/Classes/OGCore/CalibrationCatalog.py
@@ -118,6 +118,9 @@ class CalibrationCatalog:
             entry["install_state"] = (
                 record.get("install_state", "installed") if record else "not_installed"
             )
+            # Carry the running/last job id so a reloaded page can reach getInstallStatus
+            # from this one call, without also fetching the installed list.
+            entry["install_id"] = record.get("install_id") if record else None
         return entries, source
 
     @classmethod

--- a/API/Classes/OGCore/InstallJob.py
+++ b/API/Classes/OGCore/InstallJob.py
@@ -40,6 +40,7 @@ class InstallJob:
     _lock = threading.RLock()
     _jobs = {}               # install_id -> job dict
     _active_by_country = {}  # country_id -> install_id (only while running)
+    _cancel_by_id = {}       # install_id -> threading.Event (only while running)
 
     # ── id + persistence ─────────────────────────────────────────────────────
     @classmethod
@@ -82,6 +83,49 @@ class InstallJob:
     def is_country_active(cls, country_id):
         with cls._lock:
             return country_id in cls._active_by_country
+
+    # ── startup housekeeping ─────────────────────────────────────────────────────
+    @classmethod
+    def reconcile_interrupted_jobs(cls):
+        """Fail any job left mid-flight by a previous server restart.
+
+        A job persisted as installing/checking with no live thread behind it (always
+        true right after a restart) would otherwise read as installing forever. Mark
+        such jobs, and the registry records they left behind, as failed, preserving a
+        still-usable install. Best-effort: startup housekeeping must never crash the app.
+        """
+        # Only genuinely in-flight states are "interrupted". An allowlist, not "everything
+        # non-terminal", so a healthy idle record (e.g. install_state "update_available"
+        # from a refresh check) is never rewritten with a false restart error.
+        transient = {"installing", "checking"}
+        try:
+            for record in CalibrationRegistry.list_all():
+                country_id = record.get("country_id")
+                if (country_id and record.get("install_state") in transient
+                        and not cls.is_country_active(country_id)):
+                    cls._mark_registry_failed(country_id, "Interrupted by a server restart.")
+        except Exception:
+            pass
+        try:
+            job_files = list(Config.OGC_INSTALL_JOBS_DIR.glob("*.json"))
+        except OSError:
+            job_files = []
+        for path in job_files:
+            try:
+                job = File.readFile(path)
+                if (not isinstance(job, dict)
+                        or job.get("install_state") not in transient
+                        or cls.is_country_active(job.get("country_id"))):
+                    continue
+                job.update(
+                    install_state="failed",
+                    progress_label="Install failed",
+                    error="Interrupted by a server restart.",
+                    updated_at=_now_iso(),
+                )
+                cls._persist(job)
+            except (OSError, ValueError, IndexError):
+                continue
 
     # ── job lifecycle ────────────────────────────────────────────────────────
     @classmethod
@@ -134,9 +178,12 @@ class InstallJob:
     def _finalize_success(cls, install_id, *, source_type, country_id,
                           country_name, result):
         now = _now_iso()
-        # Preserve the original install date across an update (re-running over an
-        # existing calibration); only a first install sets installed_at.
+        # Preserve the original install date across an update. A prior *successful*
+        # install is the one that recorded installed_at; the installing/failed record
+        # now written at job start is not a prior install and must not be counted as an
+        # update. Rebuilding the record from scratch also drops any stale last_error.
         existing = CalibrationRegistry.get(country_id)
+        prior_installed_at = existing.get("installed_at") if existing else None
         record = {
             "country_id": country_id,
             "country_name": country_name,
@@ -148,11 +195,15 @@ class InstallJob:
             "repo_url": result.get("repo_url"),
             "commit_sha": result.get("commit_sha"),
             "install_state": "installed",
-            "installed_at": existing.get("installed_at", now) if existing else now,
+            "install_id": install_id,
+            "installed_at": prior_installed_at or now,
             "last_checked_at": now,
         }
-        if existing:
+        if prior_installed_at:
             record["last_updated_at"] = now
+        # Not best-effort: this record is the hand-off the run layer needs (python_path).
+        # If it cannot be persisted, _run treats the job as failed rather than reporting
+        # a success the run layer could never act on.
         CalibrationRegistry.upsert(record)
         with cls._lock:
             job = cls._jobs.get(install_id)
@@ -170,6 +221,8 @@ class InstallJob:
 
     @classmethod
     def _finalize_failure(cls, install_id, message, local_path=None):
+        country_id = None
+        snapshot = None
         with cls._lock:
             job = cls._jobs.get(install_id)
             if job is not None:
@@ -182,14 +235,64 @@ class InstallJob:
                 if local_path:
                     job["local_path"] = local_path
                 snapshot = dict(job)
-                cls._persist(snapshot)
+                country_id = job["country_id"]
+        if snapshot is not None:
+            cls._persist(snapshot)
+        if country_id is not None:
+            cls._mark_registry_failed(country_id, message)
 
     @classmethod
-    def _run(cls, install_id, country_id, source_type, country_name, work_fn):
-        """Thread target: run work_fn(progress, log) -> result, finalize, release."""
+    def _mark_registry_failed(cls, country_id, message):
+        """Reflect a failed job in the installed registry, so any client sees it.
+
+        A failed *update* must not hide a still-working install: if the record still
+        points at an installed venv, keep it installed and note the failure in
+        last_error; only a country with no usable install is marked failed. Best-effort,
+        because recording status must not mask the failure already being handled.
+        """
+        try:
+            record = CalibrationRegistry.get(country_id)
+            if record and record.get("venv_path"):
+                CalibrationRegistry.update_fields(
+                    country_id, install_state="installed", last_error=message)
+            else:
+                CalibrationRegistry.update_fields(
+                    country_id, install_state="failed", last_error=message)
+        except Exception:
+            # Best-effort: recording status must never mask the failure being handled.
+            pass
+
+    @classmethod
+    def _record_started(cls, *, country_id, country_name, source_type, install_id):
+        """Put the job in the installed registry the moment it starts.
+
+        This is what lets any client, not just the one that launched it, see the country
+        as installing and reach the running job by id after a reload. Patch an existing
+        record so an update keeps venv_path and friends; create a minimal one otherwise.
+        Best-effort: failing to record status must not abort a real install.
+        """
+        try:
+            patched = CalibrationRegistry.update_fields(
+                country_id, install_state="installing", install_id=install_id)
+            if patched is None:
+                CalibrationRegistry.upsert({
+                    "country_id": country_id,
+                    "country_name": country_name,
+                    "source_type": source_type,
+                    "install_state": "installing",
+                    "install_id": install_id,
+                })
+        except Exception:
+            # Best-effort: recording status must never abort a real install, and must
+            # not leave the country claimed (this runs before the worker thread starts).
+            pass
+
+    @classmethod
+    def _run(cls, install_id, country_id, source_type, country_name, work_fn, cancel_event):
+        """Thread target: run work_fn(progress, log, cancel) -> result, finalize, release."""
         progress, log = cls._callbacks(install_id)
         try:
-            result = work_fn(progress, log)
+            result = work_fn(progress, log, cancel_event)
             if result.get("ok"):
                 cls._finalize_success(
                     install_id, source_type=source_type, country_id=country_id,
@@ -208,6 +311,7 @@ class InstallJob:
             with cls._lock:
                 if cls._active_by_country.get(country_id) == install_id:
                     cls._active_by_country.pop(country_id, None)
+                cls._cancel_by_id.pop(install_id, None)
 
     @classmethod
     def _launch(cls, *, country_id, country_name, source_type, work_fn):
@@ -224,16 +328,37 @@ class InstallJob:
             )
             cls._jobs[install_id] = job
             cls._active_by_country[country_id] = install_id
+            cancel_event = threading.Event()
+            cls._cancel_by_id[install_id] = cancel_event
             initial = dict(job)  # snapshot before the thread can advance it
         cls._persist(initial)
+        cls._record_started(
+            country_id=country_id, country_name=country_name,
+            source_type=source_type, install_id=install_id,
+        )
 
         thread = CustomThread(
             target=cls._run,
-            args=(install_id, country_id, source_type, country_name, work_fn),
+            args=(install_id, country_id, source_type, country_name, work_fn,
+                  cancel_event),
         )
         thread.daemon = True
         thread.start()
         return initial
+
+    @classmethod
+    def cancel(cls, install_id):
+        """Ask a running job to stop. Returns True if one was signalled, else False.
+
+        The worker sees the event, kills the install's process tree, and finalizes as a
+        failure with 'Cancelled by user.' (a cancelled update keeps its working install).
+        """
+        with cls._lock:
+            event = cls._cancel_by_id.get(install_id)
+        if event is None:
+            return False
+        event.set()
+        return True
 
     # ── public entry points ──────────────────────────────────────────────────
     @classmethod
@@ -241,12 +366,12 @@ class InstallJob:
                       dest_parent, catalog_key=None, repo_url=None, branch=None,
                       package_name=None):
         """Start a catalog or repo_url install. Returns the initial job dict."""
-        def work(progress, log):
+        def work(progress, log, cancel):
             return Installer.run_installer(
                 source_type=source_type, repo_name=repo_name,
                 dest_parent=dest_parent, catalog_key=catalog_key,
                 repo_url=repo_url, branch=branch, package_name=package_name,
-                log=log, progress=progress,
+                log=log, progress=progress, cancel=cancel,
             )
 
         return cls._launch(
@@ -258,10 +383,10 @@ class InstallJob:
     def start_local_register(cls, *, country_id, country_name, local_path,
                              package_name=None, run_uv_sync=True):
         """Start a local-path registration. Returns the initial job dict."""
-        def work(progress, log):
+        def work(progress, log, cancel):
             return Installer.register_local(
                 local_path=local_path, package_name=package_name,
-                run_uv_sync=run_uv_sync, log=log, progress=progress,
+                run_uv_sync=run_uv_sync, log=log, progress=progress, cancel=cancel,
             )
 
         return cls._launch(

--- a/API/Classes/OGCore/InstallJob.py
+++ b/API/Classes/OGCore/InstallJob.py
@@ -41,6 +41,7 @@ class InstallJob:
     _jobs = {}               # install_id -> job dict
     _active_by_country = {}  # country_id -> install_id (only while running)
     _cancel_by_id = {}       # install_id -> threading.Event (only while running)
+    _shutting_down = False   # set by cancel_all so no new install starts during shutdown
 
     # ── id + persistence ─────────────────────────────────────────────────────
     @classmethod
@@ -317,8 +318,11 @@ class InstallJob:
     def _launch(cls, *, country_id, country_name, source_type, work_fn):
         # Check-and-claim the country under one lock so two concurrent requests for
         # the same country cannot both start and clone into the same directory.
-        # Returns None if an install for this country is already running.
+        # Returns None if an install for this country is already running, or if the
+        # server is shutting down (so a late request cannot orphan a fresh process tree).
         with cls._lock:
+            if cls._shutting_down:
+                return None
             if country_id in cls._active_by_country:
                 return None
             install_id = cls._new_install_id()  # RLock is reentrant
@@ -359,6 +363,33 @@ class InstallJob:
             return False
         event.set()
         return True
+
+    @classmethod
+    def active_count(cls):
+        """How many installs are running in this process right now."""
+        with cls._lock:
+            return len(cls._active_by_country)
+
+    @classmethod
+    def cancel_all(cls):
+        """Signal every running install to stop. Returns the install_ids signalled.
+
+        For server shutdown: installs run in their own process group so cancel can
+        tree-kill them, which also means a plain server stop would orphan them. Setting
+        each cancel event lets the running supervisors tear their trees down and finalize
+        as failures, exactly like a user cancel. Idempotent: a second call after the jobs
+        clear sees an empty map and returns nothing.
+
+        Also latches a shutting-down flag (under the same lock as the snapshot) so a
+        request racing in on another thread cannot start a new, unsignalled install after
+        this snapshot and leave its process tree orphaned.
+        """
+        with cls._lock:
+            cls._shutting_down = True
+            events = list(cls._cancel_by_id.items())
+        for _install_id, event in events:
+            event.set()
+        return [install_id for install_id, _ in events]
 
     # ── public entry points ──────────────────────────────────────────────────
     @classmethod

--- a/API/Classes/OGCore/Installer.py
+++ b/API/Classes/OGCore/Installer.py
@@ -41,6 +41,8 @@ try:
     )
 except ValueError:
     _INACTIVITY_TIMEOUT_SECONDS = 600.0
+if _INACTIVITY_TIMEOUT_SECONDS <= 0:
+    _INACTIVITY_TIMEOUT_SECONDS = 600.0
 
 
 class InstallerError(Exception):
@@ -445,6 +447,13 @@ class Installer:
         def _capture(line):
             captured.append(line)
             log(line)
+
+        # A killed install can leave a .git with no working tree; the update path
+        # cannot recover it and cleanup skips pre-existing dirs, so clear it.
+        if pre_existed and not (local_path / "pyproject.toml").exists():
+            log(f"Removing unusable leftover at {local_path}; starting a fresh clone.")
+            rmtree_force(local_path)
+            pre_existed = local_path.exists()  # rmtree is best-effort
 
         rc, reason = cls._stream(cmd, _capture, cancel=cancel)
 

--- a/API/Classes/OGCore/Installer.py
+++ b/API/Classes/OGCore/Installer.py
@@ -449,8 +449,12 @@ class Installer:
             log(line)
 
         # A killed install can leave a .git with no working tree; the update path
-        # cannot recover it and cleanup skips pre-existing dirs, so clear it.
-        if pre_existed and not (local_path / "pyproject.toml").exists():
+        # cannot recover it and cleanup skips pre-existing dirs, so clear it. The
+        # .git check keeps that scoped: dest_parent is caller-supplied, and without
+        # it an unrelated folder of the same name would be deleted.
+        if (pre_existed
+                and (local_path / ".git").exists()
+                and not (local_path / "pyproject.toml").exists()):
             log(f"Removing unusable leftover at {local_path}; starting a fresh clone.")
             rmtree_force(local_path)
             pre_existed = local_path.exists()  # rmtree is best-effort

--- a/API/Classes/OGCore/Installer.py
+++ b/API/Classes/OGCore/Installer.py
@@ -18,6 +18,7 @@ import codecs
 import os
 import re
 import shutil
+import signal
 import stat
 import subprocess
 import threading
@@ -29,7 +30,17 @@ from pathlib import Path
 from Classes.Base import Config
 
 _FETCH_TIMEOUT_SECONDS = 30
-_SUBPROCESS_TIMEOUT_SECONDS = 60 * 60  # an install can clone + uv sync large deps
+# Kill an install that produces no output for this long (a stalled clone/download). There is
+# deliberately no overall wall-clock cap: an OG-Core install can legitimately run for hours, so
+# a fixed ceiling would guillotine a healthy long install. A real build keeps logging progress,
+# so only a genuine hang goes silent and trips this; the cancel endpoint covers everything else.
+# Overridable for tests/slow links; a bad value falls back to the default rather than crashing import.
+try:
+    _INACTIVITY_TIMEOUT_SECONDS = float(
+        os.environ.get("MUIOGO_OG_INSTALL_INACTIVITY_TIMEOUT", "").strip() or 600
+    )
+except ValueError:
+    _INACTIVITY_TIMEOUT_SECONDS = 600.0
 
 
 class InstallerError(Exception):
@@ -94,7 +105,15 @@ def rmtree_force(path):
         except OSError:
             pass
 
-    shutil.rmtree(path, onerror=_on_error)
+    # A just-killed git/uv child (on Windows especially) can hold a handle for a
+    # moment, so a single rmtree may leave locked files behind (onerror swallows the
+    # in-use error). Retry a few times, then give up quietly; cleanup is best-effort.
+    for attempt in range(3):
+        shutil.rmtree(path, onerror=_on_error)
+        if not os.path.exists(path):
+            return
+        if attempt < 2:
+            time.sleep(0.5)
 
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
@@ -264,23 +283,60 @@ class Installer:
         return cmd
 
     @staticmethod
-    def _stream(cmd, log, cwd=None, timeout=_SUBPROCESS_TIMEOUT_SECONDS):
+    def _kill_tree(proc):
+        """Kill the child and everything it spawned (the installer launches git and uv).
+
+        A plain proc.kill() only stops the shell/powershell we launched, leaving a git or
+        uv child running and the country still effectively busy. Kill the whole tree.
+        """
+        try:
+            if Config.SYSTEM == "Windows":
+                subprocess.run(
+                    ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                    capture_output=True,
+                )
+            else:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (OSError, subprocess.SubprocessError):
+            pass
+        finally:
+            try:
+                proc.kill()
+            except OSError:
+                pass
+
+    @staticmethod
+    def _stream(cmd, log, cwd=None,
+                inactivity_timeout=_INACTIVITY_TIMEOUT_SECONDS, cancel=None):
         """Run cmd, stream output into `log`, return the exit code.
 
-        A reader thread drains stdout and splits on both newline and carriage-return,
-        so git and uv progress bars (which update in place with \\r) surface as they
-        arrive. The reader runs under a wall-clock deadline: if the child hangs and
-        produces nothing, the blocking read cannot stall us forever, we kill it and
-        return, so the job finishes and its country lock is released.
+        A reader thread drains stdout and splits on both newline and carriage-return, so
+        git and uv progress bars (which update in place with \\r) surface as they arrive.
+        The main thread supervises and kills the whole child tree early on a cancel request
+        or an inactivity stall (no output for inactivity_timeout, i.e. a hung clone). There is
+        no overall wall-clock cap, because an OG-Core install can legitimately run for hours;
+        a healthy install keeps logging so it never trips the stall guard, and cancel covers
+        the rest. The country lock is still released the moment the child exits or is killed.
+
+        Returns (returncode, reason): reason is None on a normal exit (returncode is the
+        child's real code), "cancelled" if a cancel was honored, or "timeout" on an inactivity
+        stall (returncode is None on those kill paths, so a child that legitimately exits
+        124/130 is never mistaken for our timeout/cancel).
         """
-        proc = subprocess.Popen(
-            cmd,
+        if cancel is not None and cancel.is_set():
+            return None, "cancelled"  # cancelled before we spawned anything
+        popen_kwargs = dict(
             cwd=str(cwd) if cwd else None,
             env=Config.ogc_clean_env(),
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             bufsize=0,  # unbuffered: deliver bytes as the child flushes them
         )
+        if Config.SYSTEM != "Windows":
+            popen_kwargs["start_new_session"] = True  # own process group, for killpg
+        proc = subprocess.Popen(cmd, **popen_kwargs)
+
+        last_activity = [time.monotonic()]
 
         def _reader():
             decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
@@ -290,6 +346,7 @@ class Installer:
                     chunk = proc.stdout.read(256)
                     if not chunk:
                         break
+                    last_activity[0] = time.monotonic()
                     pending += decoder.decode(chunk)
                     while True:
                         match = re.search(r"[\r\n]", pending)
@@ -307,32 +364,54 @@ class Installer:
 
         reader = threading.Thread(target=_reader, daemon=True)
         reader.start()
-        reader.join(timeout=timeout)
 
-        if reader.is_alive():
-            # Deadline hit while the child was still running (possibly hung).
-            proc.kill()
-            log("Install timed out and was stopped.")
+        reason = None  # None -> child exited on its own; else "cancelled"/"timeout"
+        while True:
+            reader.join(timeout=1.0)  # wake at least once a second to supervise
+            if not reader.is_alive():
+                break  # EOF: the child closed its pipe and should be exiting
+            if cancel is not None and cancel.is_set():
+                log("Install cancelled.")
+                reason = "cancelled"
+                break
+            if inactivity_timeout and (time.monotonic() - last_activity[0]) > inactivity_timeout:
+                log("Install stalled with no output and was stopped.")
+                reason = "timeout"
+                break
+
+        if reason is not None:
+            Installer._kill_tree(proc)
+            try:
+                proc.wait(timeout=5)  # reap so the killed child is not left a zombie
+            except subprocess.TimeoutExpired:
+                pass
             reader.join(timeout=5)
-            if proc.stdout:
-                proc.stdout.close()
-            return 124
+            if proc.stdout and not reader.is_alive():
+                proc.stdout.close()  # only when the reader is done, to avoid an fd race
+            return None, reason
 
         # Reader saw EOF, so the child has closed its pipe and should be exiting.
         try:
             rc = proc.wait(timeout=30)
         except subprocess.TimeoutExpired:
-            proc.kill()
-            rc = 124
-        if proc.stdout:
+            Installer._kill_tree(proc)
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+            reader.join(timeout=5)
+            if proc.stdout and not reader.is_alive():
+                proc.stdout.close()
+            return None, "timeout"
+        if proc.stdout and not reader.is_alive():
             proc.stdout.close()
-        return rc
+        return rc, None
 
     # ── orchestration: catalog / repo_url install ────────────────────────────
     @classmethod
     def run_installer(cls, *, source_type, repo_name, dest_parent,
                       catalog_key=None, repo_url=None, branch=None,
-                      package_name=None, log=None, progress=None):
+                      package_name=None, log=None, progress=None, cancel=None):
         """Clone + uv sync + verify one repo via the universal installer.
 
         Returns a result dict: ok, local_path, venv_path, python_path,
@@ -367,7 +446,7 @@ class Installer:
             captured.append(line)
             log(line)
 
-        rc = cls._stream(cmd, _capture)
+        rc, reason = cls._stream(cmd, _capture, cancel=cancel)
 
         venv_path = local_path / ".venv"
         python_path = Config.venv_python_path(venv_path)
@@ -377,11 +456,15 @@ class Installer:
                 rmtree_force(local_path)
             return cls._fail(local_path, venv_path, python_path, message)
 
+        if reason == "cancelled":
+            return _fresh_fail("Cancelled by user.")
+        if reason == "timeout":
+            return _fresh_fail("Install timed out and was stopped.")
         if rc != 0:
-            reason = summarize_failure(captured)
+            summary = summarize_failure(captured)
             message = (
-                f"Installer failed (exit {rc}): {reason}"
-                if reason
+                f"Installer failed (exit {rc}): {summary}"
+                if summary
                 else f"Installer exited with code {rc}."
             )
             return _fresh_fail(message)
@@ -393,6 +476,8 @@ class Installer:
         if not pkg:
             return _fresh_fail("Could not determine the package name to verify.")
 
+        if cancel is not None and cancel.is_set():
+            return _fresh_fail("Cancelled by user.")
         progress("verify_import", "Verifying the model imports")
         ok, detail = cls.verify_import(python_path, pkg)
         if not ok:
@@ -415,7 +500,7 @@ class Installer:
     # ── orchestration: register an existing local copy ───────────────────────
     @classmethod
     def register_local(cls, *, local_path, package_name=None, run_uv_sync=True,
-                       log=None, progress=None):
+                       log=None, progress=None, cancel=None):
         """Validate a local repo, optionally uv sync, verify import, return result."""
         log = log or _noop
         progress = progress or _noop
@@ -445,7 +530,13 @@ class Installer:
                 )
             progress("uv_sync", "Building the environment with uv sync")
             log("Running uv sync...")
-            rc = cls._stream(["uv", "sync", "--extra", "dev"], log, cwd=local_path)
+            rc, reason = cls._stream(["uv", "sync", "--extra", "dev"], log, cwd=local_path,
+                                     cancel=cancel)
+            if reason == "cancelled":
+                return cls._fail(local_path, venv_path, python_path, "Cancelled by user.")
+            if reason == "timeout":
+                return cls._fail(local_path, venv_path, python_path,
+                                 "uv sync timed out and was stopped.")
             if rc != 0:
                 return cls._fail(local_path, venv_path, python_path,
                                  f"uv sync exited with code {rc}.")
@@ -457,6 +548,8 @@ class Installer:
                 "No .venv found. Re-run with environment build enabled.",
             )
 
+        if cancel is not None and cancel.is_set():
+            return cls._fail(local_path, venv_path, python_path, "Cancelled by user.")
         progress("verify_import", "Verifying the model imports")
         ok, detail = cls.verify_import(python_path, pkg)
         if not ok:

--- a/API/Routes/OGCore/OGCoreInstallRoute.py
+++ b/API/Routes/OGCore/OGCoreInstallRoute.py
@@ -2,8 +2,7 @@
 
 All routes live under /ogc. The frontend never runs uv or shell directly; it calls
 these endpoints and the backend either wraps the OG-Core universal installer
-(catalog / repo URL) or validates and records a local copy. See:
-    Track1-API-Schema-Discussion/OGCore-API-Schema-FINAL.md
+(catalog / repo URL) or validates and records a local copy.
 """
 import os
 import re
@@ -380,6 +379,12 @@ def refreshCalibration():
     if record is None:
         return _err("That calibration is not registered.", http=404)
 
+    # A record exists from the moment an install starts (install_state "installing"),
+    # so a refresh must not run over a job in flight and overwrite its state. Let the
+    # running job finish first.
+    if InstallJob.is_country_active(country_id):
+        return _err("An install or update is already running for this country.")
+
     check_only = data.get("check_only", True)
     local_path = record.get("local_path")
 
@@ -438,4 +443,27 @@ def refreshCalibration():
         "install_id": job["install_id"],
         "install_state": job["install_state"],
         "message": "Calibration update started.",
+    }), 200
+
+
+# ── 9. cancel a running install ───────────────────────────────────────────────
+@ogcore_install_api.route("/cancelInstall", methods=["POST"])
+def cancelInstall():
+    blocked = _blocked_cross_site()
+    if blocked:
+        return blocked
+    data = _body()
+    if data is None:
+        return _err("Request body must be valid JSON.")
+    install_id = data.get("install_id")
+    if not install_id:
+        return _err("Missing required field: install_id")
+    if not isinstance(install_id, str) or not _INSTALL_ID_RE.match(install_id):
+        return _err("Invalid install_id.")
+    if not InstallJob.cancel(install_id):
+        return _err("No running install with that id to cancel.", http=404)
+    return jsonify({
+        "status_code": "success",
+        "install_id": install_id,
+        "message": "Cancellation requested.",
     }), 200

--- a/API/app.py
+++ b/API/app.py
@@ -36,6 +36,7 @@ from Routes.Case.SyncS3Route import syncs3_api
 from Routes.Case.ViewDataRoute import viewdata_api
 from Routes.DataFile.DataFileRoute import datafile_api
 from Routes.OGCore.OGCoreInstallRoute import ogcore_install_api
+from Classes.OGCore.InstallJob import InstallJob
 
 def _configure_logging():
     if getattr(_configure_logging, "_configured", False):
@@ -177,6 +178,12 @@ if __name__ == '__main__':
     import mimetypes
     mimetypes.add_type('application/javascript', '.js')
     port = int(os.environ.get("PORT", 5002))
+
+    # Fail any OG install left mid-flight by a previous restart, so it does not read as
+    # installing forever. Runs when the server actually starts, not on mere import. Note:
+    # this is tied to launching via `python app.py`; a WSGI loader that imports app:app
+    # would need to call this itself.
+    InstallJob.reconcile_interrupted_jobs()
 
     def print_startup_info(host, current_port, server_name):
         mode = 'local' if Config.HEROKU_DEPLOY == 0 else 'heroku'

--- a/API/app.py
+++ b/API/app.py
@@ -1,8 +1,11 @@
 from pathlib import Path
+import atexit
 import logging
 import os
 import secrets
+import signal
 import sys
+import time
 import warnings
 from logging.handlers import TimedRotatingFileHandler
 
@@ -171,6 +174,63 @@ def setSession():
         return jsonify('No selected parameters!'), 404
 
 
+def _stop_inflight_installs():
+    """Cancel any in-flight OG install and wait briefly for it to tear down.
+
+    Installs run in their own process group so cancel/timeout can kill the whole tree;
+    that detachment also means a plain server stop would leave them running orphaned.
+    Signalling cancel lets the running supervisors kill their trees and record the
+    failure. Best-effort and idempotent: called from the shutdown signal handler and
+    again from atexit.
+    """
+    try:
+        ids = InstallJob.cancel_all()
+        if not ids:
+            return
+        logging.getLogger(__name__).info(
+            "Server stopping: cancelling %d in-flight OG install(s).", len(ids))
+        deadline = time.monotonic() + 5.0
+        while InstallJob.active_count() and time.monotonic() < deadline:
+            time.sleep(0.1)
+    except Exception:
+        # Shutdown cleanup must never raise out of a signal handler or atexit.
+        pass
+
+
+def _install_shutdown_handlers():
+    """Run install cleanup on Ctrl+C / SIGTERM and at normal interpreter exit.
+
+    atexit covers any clean shutdown (including waitress returning on Ctrl+C); the
+    signal handlers cover a SIGTERM/SIGINT that would otherwise kill the process before
+    atexit can run. On Windows only console Ctrl+C (SIGINT) and clean exits are really
+    covered: a service/taskkill stop is uncatchable there, so cleanup then relies on the
+    next start's reconcile pass. The handler re-raises the default disposition so the
+    process still exits the way that signal normally would, and a second signal during
+    the cleanup wait force-quits instead of nesting another wait.
+    """
+    atexit.register(_stop_inflight_installs)
+
+    shutting_down = {"active": False}
+
+    def _handler(signum, _frame):
+        if shutting_down["active"]:
+            # Second Ctrl+C/SIGTERM while cleanup is running: give up and terminate now.
+            signal.signal(signum, signal.SIG_DFL)
+            os.kill(os.getpid(), signum)
+            return
+        shutting_down["active"] = True
+        _stop_inflight_installs()
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            signal.signal(sig, _handler)
+        except (ValueError, OSError):
+            # Not the main thread, or a platform without this signal: skip.
+            pass
+
+
 if __name__ == '__main__':
 # if __name__ == 'app':
     #potrebno radi module js importa u index.html ES6 modules
@@ -184,6 +244,10 @@ if __name__ == '__main__':
     # this is tied to launching via `python app.py`; a WSGI loader that imports app:app
     # would need to call this itself.
     InstallJob.reconcile_interrupted_jobs()
+
+    # Stop any running install cleanly when the server is stopped, so its detached
+    # process tree is not orphaned. Same deployment assumption as reconcile above.
+    _install_shutdown_handlers()
 
     def print_startup_info(host, current_port, server_name):
         mode = 'local' if Config.HEROKU_DEPLOY == 0 else 'heroku'

--- a/tests/ogc/conftest.py
+++ b/tests/ogc/conftest.py
@@ -1,0 +1,54 @@
+"""Shared setup for the OG-Core install tests.
+
+Points all OG on-disk state at a per-test temp dir and resets InstallJob's in-memory
+class state, so every test runs against a clean registry with no leftover jobs. Autouse,
+but scoped to this package only, so it never touches the rest of the suite.
+"""
+import time
+
+import pytest
+
+from Classes.Base import Config
+from Classes.OGCore.CalibrationCatalog import CalibrationCatalog
+from Classes.OGCore.InstallJob import InstallJob
+
+
+def _clear_jobs():
+    with InstallJob._lock:
+        InstallJob._jobs.clear()
+        InstallJob._active_by_country.clear()
+        InstallJob._cancel_by_id.clear()
+        InstallJob._shutting_down = False
+
+
+def _drain_jobs(timeout=6.0):
+    """Wait for any launched worker to finish before clearing state.
+
+    A test that fails before releasing a gated worker leaves a daemon thread that would
+    otherwise wake later and finalize into the next test's (freshly monkeypatched)
+    registry. Draining here keeps one failure from cascading into unrelated tests.
+    """
+    deadline = time.monotonic() + timeout
+    while InstallJob.active_count() and time.monotonic() < deadline:
+        time.sleep(0.05)
+
+
+@pytest.fixture(autouse=True)
+def ogc_state(tmp_path, monkeypatch):
+    monkeypatch.setattr(Config, "OGC_DATA_STORAGE", tmp_path)
+    monkeypatch.setattr(
+        Config, "OGC_INSTALLED_REGISTRY", tmp_path / "og_calibrations_installed.json"
+    )
+    monkeypatch.setattr(Config, "OGC_INSTALL_JOBS_DIR", tmp_path / "install_jobs")
+    monkeypatch.setattr(Config, "OGC_CATALOG_CACHE", tmp_path / "catalog_cache.json")
+    monkeypatch.setattr(Config, "OGC_MODELS_DIR", tmp_path / "models")
+    monkeypatch.setattr(Config, "OGC_INSTALLER_CACHE_DIR", tmp_path / "installer")
+    # Hard sandbox: never let a test reach the live register over the network. A test
+    # that needs catalogue entries stubs fetch_register itself; this is the safe default.
+    monkeypatch.setattr(
+        CalibrationCatalog, "fetch_register", classmethod(lambda cls: ([], "none"))
+    )
+    _clear_jobs()
+    yield
+    _drain_jobs()
+    _clear_jobs()

--- a/tests/ogc/test_install_reconcile.py
+++ b/tests/ogc/test_install_reconcile.py
@@ -1,0 +1,74 @@
+"""Restart reconciliation (issue #501 additions).
+
+After a restart, a job left mid-flight (installing/checking) with no live thread is
+marked failed, a working install caught mid-update is preserved, and healthy idle
+records are left alone. Drives reconcile over seeded on-disk state.
+"""
+from Classes.OGCore.CalibrationRegistry import CalibrationRegistry
+from Classes.OGCore.InstallJob import InstallJob
+
+
+def _seed_job(install_id, country_id, state):
+    InstallJob._persist({
+        "install_id": install_id, "country_id": country_id,
+        "country_name": country_id, "source_type": "catalog",
+        "install_state": state, "install_stage": "uv_sync",
+        "progress_label": "Installing", "log_tail": [], "error": None,
+    })
+
+
+def _seed_crashed_state():
+    """On-disk state as if the server died mid-install (no in-memory jobs)."""
+    CalibrationRegistry.upsert({"country_id": "ETH", "country_name": "Ethiopia",
+                                "source_type": "catalog", "install_state": "installing",
+                                "install_id": "install_2026_07_20_001"})
+    CalibrationRegistry.upsert({"country_id": "ZAF", "country_name": "South Africa",
+                                "source_type": "catalog", "install_state": "installing",
+                                "install_id": "install_2026_07_20_002",
+                                "venv_path": "/models/OG-ZAF/.venv",
+                                "installed_at": "2026-01-01T00:00:00Z"})
+    CalibrationRegistry.upsert({"country_id": "KEN", "country_name": "Kenya",
+                                "source_type": "catalog", "install_state": "installed",
+                                "venv_path": "/models/OG-KEN/.venv",
+                                "installed_at": "2026-01-01T00:00:00Z"})
+    # Healthy idle record a refresh flagged for update; must not be treated as interrupted.
+    CalibrationRegistry.upsert({"country_id": "GHA", "country_name": "Ghana",
+                                "source_type": "catalog", "install_state": "update_available",
+                                "venv_path": "/models/OG-GHA/.venv",
+                                "installed_at": "2026-01-01T00:00:00Z"})
+    _seed_job("install_2026_07_20_001", "ETH", "installing")
+    _seed_job("install_2026_07_20_002", "ZAF", "installing")
+    _seed_job("install_2026_07_20_003", "KEN", "installed")  # terminal, leave alone
+
+
+def test_reconcile_marks_interrupted_and_preserves_working():
+    _seed_crashed_state()
+    InstallJob.reconcile_interrupted_jobs()
+
+    eth = CalibrationRegistry.get("ETH")
+    zaf = CalibrationRegistry.get("ZAF")
+    ken = CalibrationRegistry.get("KEN")
+    gha = CalibrationRegistry.get("GHA")
+    assert eth["install_state"] == "failed"
+    assert eth.get("last_error") == "Interrupted by a server restart."
+    assert zaf["install_state"] == "installed", "interrupted update preserved"
+    assert zaf.get("last_error") == "Interrupted by a server restart."
+    assert zaf.get("venv_path") == "/models/OG-ZAF/.venv"
+    assert ken["install_state"] == "installed" and "last_error" not in ken
+    assert gha["install_state"] == "update_available" and "last_error" not in gha, \
+        "healthy update_available left untouched"
+
+    j1 = InstallJob.get_status("install_2026_07_20_001")
+    j2 = InstallJob.get_status("install_2026_07_20_002")
+    j3 = InstallJob.get_status("install_2026_07_20_003")
+    assert j1["install_state"] == "failed" and j1["error"] == "Interrupted by a server restart."
+    assert j2["install_state"] == "failed"
+    assert j3["install_state"] == "installed" and j3.get("error") is None
+
+
+def test_reconcile_is_idempotent():
+    _seed_crashed_state()
+    InstallJob.reconcile_interrupted_jobs()
+    InstallJob.reconcile_interrupted_jobs()
+    assert CalibrationRegistry.get("ZAF")["install_state"] == "installed"
+    assert CalibrationRegistry.get("ETH")["install_state"] == "failed"

--- a/tests/ogc/test_install_registry.py
+++ b/tests/ogc/test_install_registry.py
@@ -1,0 +1,170 @@
+"""Registry tracking for install jobs (issue #501).
+
+A record is written the moment an install starts and updated on failure, not only on
+success; a failed update over a working install is preserved; the catalogue reflects
+every state and carries the install_id. Drives the real InstallJob thread path against
+a temp registry, and the real routes through the app test client.
+"""
+import threading
+import time
+
+from Classes.OGCore.CalibrationCatalog import CalibrationCatalog
+from Classes.OGCore.CalibrationRegistry import CalibrationRegistry
+from Classes.OGCore.InstallJob import InstallJob
+
+
+def wait_done(country_id, timeout=10.0):
+    end = time.time() + timeout
+    while time.time() < end:
+        if not InstallJob.is_country_active(country_id):
+            return True
+        time.sleep(0.02)
+    return False
+
+
+def good_result():
+    return {
+        "ok": True,
+        "local_path": "/models/OG-ETH",
+        "venv_path": "/models/OG-ETH/.venv",
+        "python_path": "/models/OG-ETH/.venv/bin/python",
+        "package_name": "ogeth",
+        "repo_url": "https://github.com/EAPD-DRB/OG-ETH",
+        "commit_sha": "abc123",
+    }
+
+
+def test_fresh_install_installing_then_installed():
+    entered, release = threading.Event(), threading.Event()
+
+    def gated_ok(progress, log, cancel):
+        entered.set()
+        release.wait(5)
+        return good_result()
+
+    InstallJob._launch(country_id="ETH", country_name="Ethiopia",
+                       source_type="catalog", work_fn=gated_ok)
+    try:
+        assert entered.wait(5), "job thread started"
+
+        mid = CalibrationRegistry.get("ETH")
+        assert mid is not None and mid.get("install_state") == "installing"
+        assert mid.get("install_id"), "record carries install_id mid-job"
+        assert not mid.get("venv_path"), "fresh record has no venv_path yet"
+
+        release.set()
+        assert wait_done("ETH"), "job finished"
+        done = CalibrationRegistry.get("ETH")
+        assert done.get("install_state") == "installed"
+        assert done.get("install_id"), "install_id retained on success"
+        assert done.get("installed_at") and not done.get("last_updated_at"), \
+            "first install sets installed_at, not last_updated_at"
+        assert done.get("venv_path") == "/models/OG-ETH/.venv"
+    finally:
+        # Always let the worker finish, so a failed assertion above cannot leave a
+        # daemon thread that later writes into the next test's registry.
+        release.set()
+        wait_done("ETH")
+
+
+def test_fresh_install_failure_records_last_error():
+    InstallJob._launch(country_id="ETH", country_name="Ethiopia", source_type="catalog",
+                       work_fn=lambda p, l, c: {"ok": False, "error": "clone died"})
+    assert wait_done("ETH")
+    rec = CalibrationRegistry.get("ETH")
+    assert rec and rec.get("install_state") == "failed"
+    assert rec.get("last_error") == "clone died"
+
+
+def test_failed_update_preserves_working_install():
+    CalibrationRegistry.upsert({
+        "country_id": "ETH", "country_name": "Ethiopia", "source_type": "catalog",
+        "venv_path": "/models/OG-ETH/.venv",
+        "python_path": "/models/OG-ETH/.venv/bin/python",
+        "install_state": "installed", "installed_at": "2026-01-01T00:00:00Z",
+    })
+    InstallJob._launch(country_id="ETH", country_name="Ethiopia", source_type="catalog",
+                       work_fn=lambda p, l, c: {"ok": False, "error": "update failed"})
+    assert wait_done("ETH")
+    rec = CalibrationRegistry.get("ETH")
+    assert rec.get("install_state") == "installed", "working install preserved"
+    assert rec.get("last_error") == "update failed"
+    assert rec.get("venv_path") == "/models/OG-ETH/.venv"
+    assert rec.get("installed_at") == "2026-01-01T00:00:00Z"
+
+
+def test_successful_update_sets_last_updated_at():
+    CalibrationRegistry.upsert({
+        "country_id": "ETH", "country_name": "Ethiopia", "source_type": "catalog",
+        "venv_path": "/old/.venv", "python_path": "/old/.venv/bin/python",
+        "install_state": "installed", "installed_at": "2026-01-01T00:00:00Z",
+    })
+    InstallJob._launch(country_id="ETH", country_name="Ethiopia", source_type="catalog",
+                       work_fn=lambda p, l, c: good_result())
+    assert wait_done("ETH")
+    rec = CalibrationRegistry.get("ETH")
+    assert rec.get("install_state") == "installed"
+    assert rec.get("installed_at") == "2026-01-01T00:00:00Z", "installed_at preserved"
+    assert rec.get("last_updated_at"), "last_updated_at set on a real update"
+    assert "last_error" not in rec, "stale last_error dropped on success"
+
+
+def test_catalog_reflects_state_and_install_id(monkeypatch):
+    monkeypatch.setattr(CalibrationCatalog, "fetch_register", classmethod(lambda cls: (
+        [{"country_id": "ETH", "country_name": "Ethiopia", "catalog_key": "og-eth"},
+         {"country_id": "ZAF", "country_name": "South Africa", "catalog_key": "og-zaf"}],
+        "live",
+    )))
+    CalibrationRegistry.upsert({"country_id": "ETH", "country_name": "Ethiopia",
+                                "source_type": "catalog", "install_state": "installing",
+                                "install_id": "install_x"})
+    countries, _ = CalibrationCatalog.get_catalog_with_state()
+    by_id = {c["country_id"]: c for c in countries}
+    assert by_id["ETH"]["install_state"] == "installing"
+    assert by_id["ETH"].get("install_id") == "install_x", "carries install_id"
+    assert by_id["ZAF"]["install_state"] == "not_installed"
+    assert by_id["ZAF"].get("install_id") is None
+
+    CalibrationRegistry.update_fields("ETH", install_state="failed", last_error="boom")
+    countries, _ = CalibrationCatalog.get_catalog_with_state()
+    by_id = {c["country_id"]: c for c in countries}
+    assert by_id["ETH"]["install_state"] == "failed"
+
+
+def test_refresh_during_active_install_is_refused(client):
+    """Regression guard: a record exists at start, so refresh must not clobber it."""
+    entered, release = threading.Event(), threading.Event()
+
+    def gated_ok(progress, log, cancel):
+        entered.set()
+        release.wait(5)
+        return good_result()
+
+    InstallJob._launch(country_id="ETH", country_name="Ethiopia",
+                       source_type="catalog", work_fn=gated_ok)
+    try:
+        assert entered.wait(5), "install job is running"
+
+        resp = client.post("/ogc/refreshCalibration",
+                           json={"country_id": "ETH", "check_only": True})
+        body = resp.get_json()
+        assert body.get("status_code") == "error", f"refresh refused while installing: {body}"
+        assert "already running" in body.get("message", "").lower()
+        mid = CalibrationRegistry.get("ETH")
+        assert mid.get("install_state") == "installing", "state not clobbered by refresh"
+
+        release.set()
+        assert wait_done("ETH")
+        assert CalibrationRegistry.get("ETH").get("install_state") == "installed"
+    finally:
+        release.set()
+        wait_done("ETH")
+
+
+def test_cancel_install_input_validation(client):
+    r = client.post("/ogc/cancelInstall", json={"install_id": 123})
+    assert r.status_code == 400, "non-string install_id -> 400 not 500"
+    r = client.post("/ogc/cancelInstall", json={"install_id": "install_2026_07_20_777"})
+    assert r.status_code == 404, "unknown well-formed install_id -> 404"
+    r = client.post("/ogc/cancelInstall", json={})
+    assert r.status_code == 400, "missing install_id -> 400"

--- a/tests/ogc/test_install_shutdown.py
+++ b/tests/ogc/test_install_shutdown.py
@@ -1,0 +1,56 @@
+"""Shutdown cleanup: cancel_all / active_count and the server-stop handler.
+
+Installs run detached in their own process group, so a plain server stop would orphan
+them. cancel_all signals every running job; _stop_inflight_installs (called from the
+signal handler and atexit) does that and waits briefly for them to tear down.
+"""
+import threading
+import time
+
+from app import _stop_inflight_installs
+from Classes.OGCore.InstallJob import InstallJob
+
+
+def test_cancel_all_sets_every_event_and_reports_ids():
+    ev1, ev2 = threading.Event(), threading.Event()
+    with InstallJob._lock:
+        InstallJob._cancel_by_id["install_a"] = ev1
+        InstallJob._cancel_by_id["install_b"] = ev2
+        InstallJob._active_by_country["ETH"] = "install_a"
+        InstallJob._active_by_country["ZAF"] = "install_b"
+    assert InstallJob.active_count() == 2
+    ids = InstallJob.cancel_all()
+    assert set(ids) == {"install_a", "install_b"}
+    assert ev1.is_set() and ev2.is_set()
+
+
+def test_cancel_all_empty_is_noop():
+    assert InstallJob.cancel_all() == []
+    assert InstallJob.active_count() == 0
+
+
+def test_stop_inflight_installs_cancels_running_job():
+    entered = threading.Event()
+
+    def work(progress, log, cancel):
+        entered.set()
+        cancel.wait(5)
+        return {"ok": False, "error": "Cancelled by user.", "local_path": None}
+
+    InstallJob._launch(country_id="ETH", country_name="Ethiopia",
+                       source_type="catalog", work_fn=work)
+    assert entered.wait(5), "job is running"
+    assert InstallJob.active_count() == 1
+
+    t0 = time.monotonic()
+    _stop_inflight_installs()
+    dt = time.monotonic() - t0
+    assert InstallJob.active_count() == 0, "job torn down after shutdown cleanup"
+    assert dt < 5.0, "cleanup returns promptly once the job clears"
+
+
+def test_stop_inflight_installs_noop_when_idle():
+    # No running jobs: returns immediately without waiting out the deadline.
+    t0 = time.monotonic()
+    _stop_inflight_installs()
+    assert time.monotonic() - t0 < 1.0

--- a/tests/ogc/test_install_supervisor.py
+++ b/tests/ogc/test_install_supervisor.py
@@ -158,3 +158,50 @@ def test_run_installer_maps_cancel_timeout_and_real_exit(tmp_path, monkeypatch):
     res = Installer.run_installer(source_type="catalog", repo_name="OG-XX",
                                  dest_parent=str(tmp_path), catalog_key="og-xx", cancel=None)
     assert res["ok"] is False and "124" in res["error"] and "timed out" not in res["error"]
+
+
+def _run_over(tmp_path, monkeypatch):
+    """Drive run_installer over an existing dir without running a real installer."""
+    monkeypatch.setattr(
+        Installer, "ensure_installer_script", staticmethod(lambda: "dummy_script")
+    )
+    monkeypatch.setattr(Installer, "_stream", staticmethod(lambda *a, **k: (1, None)))
+    return Installer.run_installer(
+        source_type="catalog", repo_name="OG-XX",
+        dest_parent=str(tmp_path), catalog_key="og-xx", cancel=None,
+    )
+
+
+def test_unusable_git_leftover_is_cleared(tmp_path, monkeypatch):
+    # A clone killed part way leaves .git behind with no working tree. The update
+    # path cannot recover that, so it is removed and the install starts fresh.
+    leftover = tmp_path / "OG-XX"
+    (leftover / ".git").mkdir(parents=True)
+    (leftover / ".git" / "HEAD").write_text("ref: refs/heads/main\n")
+
+    _run_over(tmp_path, monkeypatch)
+
+    assert not leftover.exists(), "the half-clone is cleared before re-cloning"
+
+
+def test_unrelated_folder_of_the_same_name_is_kept(tmp_path, monkeypatch):
+    # dest_parent comes from the caller, so a folder that was never a clone can sit
+    # at the target path. It has no .git, so it must survive untouched.
+    mine = tmp_path / "OG-XX"
+    mine.mkdir()
+    (mine / "notes.txt").write_text("do not delete me")
+
+    _run_over(tmp_path, monkeypatch)
+
+    assert (mine / "notes.txt").read_text() == "do not delete me"
+
+
+def test_healthy_clone_is_not_cleared(tmp_path, monkeypatch):
+    # A real clone has both, and an update over it must never delete it.
+    clone = tmp_path / "OG-XX"
+    (clone / ".git").mkdir(parents=True)
+    (clone / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+
+    _run_over(tmp_path, monkeypatch)
+
+    assert (clone / "pyproject.toml").exists() and (clone / ".git").exists()

--- a/tests/ogc/test_install_supervisor.py
+++ b/tests/ogc/test_install_supervisor.py
@@ -1,0 +1,160 @@
+"""Install supervisor: cancel, inactivity timeout, and process-tree kill (#501 additions).
+
+Uses real subprocesses and the real code paths, not mocks. `_stream` returns
+(returncode, reason) with reason in {None, 'cancelled', 'timeout'}.
+"""
+import sys
+import threading
+import time
+
+from Classes.OGCore.CalibrationRegistry import CalibrationRegistry
+from Classes.OGCore.InstallJob import InstallJob
+from Classes.OGCore.Installer import Installer
+
+PY = sys.executable
+
+
+def wait_done(country_id, timeout=15.0):
+    end = time.time() + timeout
+    while time.time() < end:
+        if not InstallJob.is_country_active(country_id):
+            return True
+        time.sleep(0.02)
+    return False
+
+
+def test_stream_normal_exit_streams_output():
+    lines = []
+    rc, reason = Installer._stream([PY, "-c", "print('hello'); print('world')"], lines.append)
+    assert rc == 0 and reason is None
+    assert "hello" in lines and "world" in lines
+
+
+def test_stream_preset_cancel_does_not_spawn():
+    ev = threading.Event()
+    ev.set()
+    t0 = time.monotonic()
+    rc, reason = Installer._stream([PY, "-c", "import time; time.sleep(30)"],
+                                  lambda *_: None, cancel=ev)
+    dt = time.monotonic() - t0
+    assert reason == "cancelled"
+    assert dt < 0.5, "pre-set cancel returns without spawning"
+
+
+def test_stream_cancel_is_prompt():
+    ev = threading.Event()
+    holder = {}
+
+    def run():
+        t = time.monotonic()
+        holder["rc"], holder["reason"] = Installer._stream(
+            [PY, "-c", "import time; time.sleep(30)"], lambda *_: None,
+            inactivity_timeout=600, cancel=ev)
+        holder["dt"] = time.monotonic() - t
+
+    t = threading.Thread(target=run)
+    t.start()
+    time.sleep(0.7)
+    ev.set()
+    t.join(10)
+    assert holder.get("reason") == "cancelled"
+    assert holder.get("dt", 99) < 3.0, "cancel takes effect within the ~1s poll"
+
+
+def test_stream_inactivity_timeout():
+    t0 = time.monotonic()
+    rc, reason = Installer._stream([PY, "-c", "import time; time.sleep(30)"],
+                                  lambda *_: None, inactivity_timeout=2, cancel=None)
+    dt = time.monotonic() - t0
+    assert reason == "timeout"
+    assert dt < 5.0, "inactivity kill is prompt"
+
+
+def test_process_tree_kill(tmp_path, monkeypatch):
+    sentinel = tmp_path / "grandchild_ran.txt"
+    monkeypatch.setenv("OGC_TEST_SENTINEL", str(sentinel))
+    parent_code = (
+        "import os,sys,subprocess,time;"
+        "subprocess.Popen([sys.executable,'-c',"
+        "\"import os,time,pathlib; time.sleep(3); "
+        "pathlib.Path(os.environ['OGC_TEST_SENTINEL']).write_text('x')\"]);"
+        "time.sleep(30)"
+    )
+    ev = threading.Event()
+    t = threading.Thread(target=lambda: Installer._stream(
+        [PY, "-c", parent_code], lambda *_: None, inactivity_timeout=600, cancel=ev))
+    t.start()
+    time.sleep(1.0)
+    ev.set()
+    t.join(10)
+    time.sleep(4.0)
+    assert not sentinel.exists(), "grandchild killed with the tree (no sentinel written)"
+
+
+def _cancel_work():
+    def work(progress, log, cancel):
+        rc, reason = Installer._stream([PY, "-c", "import time; time.sleep(30)"], log,
+                                       inactivity_timeout=600, cancel=cancel)
+        if reason == "cancelled":
+            return {"ok": False, "error": "Cancelled by user.", "local_path": None}
+        return {"ok": True, "local_path": "x", "venv_path": "x/.venv",
+                "python_path": "x/.venv/bin/python", "package_name": "p"}
+    return work
+
+
+def test_end_to_end_cancel_fresh_install():
+    init = InstallJob._launch(country_id="ETH", country_name="Ethiopia",
+                             source_type="catalog", work_fn=_cancel_work())
+    iid = init["install_id"]
+    time.sleep(1.0)
+    assert InstallJob.cancel(iid) is True, "cancel() signals the running job"
+    assert wait_done("ETH")
+    job = InstallJob.get_status(iid)
+    assert job["install_state"] == "failed" and job["error"] == "Cancelled by user."
+    assert CalibrationRegistry.get("ETH")["install_state"] == "failed"
+
+
+def test_end_to_end_cancel_update_preserved():
+    CalibrationRegistry.upsert({"country_id": "ZAF", "country_name": "South Africa",
+                                "source_type": "catalog", "install_state": "installed",
+                                "venv_path": "/models/OG-ZAF/.venv",
+                                "installed_at": "2026-01-01T00:00:00Z"})
+    init = InstallJob._launch(country_id="ZAF", country_name="South Africa",
+                             source_type="catalog", work_fn=_cancel_work())
+    time.sleep(1.0)
+    InstallJob.cancel(init["install_id"])
+    assert wait_done("ZAF")
+    rec = CalibrationRegistry.get("ZAF")
+    assert rec["install_state"] == "installed", "cancelled update keeps the working install"
+    assert rec.get("last_error") == "Cancelled by user."
+
+
+def test_cancel_unknown_id_returns_false():
+    assert InstallJob.cancel("install_2026_07_20_999") is False
+
+
+def test_run_installer_maps_cancel_timeout_and_real_exit(tmp_path, monkeypatch):
+    monkeypatch.setattr(Installer, "ensure_installer_script", staticmethod(lambda: "dummy_script"))
+    og_xx = tmp_path / "OG-XX"
+    og_xx.mkdir()
+    # A real install/update always has pyproject.toml; keep one here so the
+    # unusable-leftover cleanup does not fire and skew this message-mapping check.
+    (og_xx / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+
+    monkeypatch.setattr(Installer, "_stream", staticmethod(lambda *a, **k: (None, "cancelled")))
+    ev = threading.Event()
+    ev.set()
+    res = Installer.run_installer(source_type="catalog", repo_name="OG-XX",
+                                 dest_parent=str(tmp_path), catalog_key="og-xx", cancel=ev)
+    assert res["ok"] is False and res["error"] == "Cancelled by user."
+
+    monkeypatch.setattr(Installer, "_stream", staticmethod(lambda *a, **k: (None, "timeout")))
+    res = Installer.run_installer(source_type="catalog", repo_name="OG-XX",
+                                 dest_parent=str(tmp_path), catalog_key="og-xx", cancel=None)
+    assert res["ok"] is False and "timed out" in res["error"]
+
+    # A child that legitimately exits 124 must not be mislabeled as our timeout.
+    monkeypatch.setattr(Installer, "_stream", staticmethod(lambda *a, **k: (124, None)))
+    res = Installer.run_installer(source_type="catalog", repo_name="OG-XX",
+                                 dest_parent=str(tmp_path), catalog_key="og-xx", cancel=None)
+    assert res["ok"] is False and "124" in res["error"] and "timed out" not in res["error"]


### PR DESCRIPTION
Fixes #501.

## Summary

Earlier the installed-calibration registry only got a record when an install finished successfully. While a job was running, or after it failed, nothing was recorded (silent failure), and there was no way to find a job's `install_id` after a reload / other similar instances - in that case once it downloaded, it would show up as available after process finish, but the user wouldn't be able to see any states in between.

This records the job at the moment it starts and on failure, and with this it also closes two install-lifecycle gaps that sat alongside #501: install cancel/timeout (previously scoped out in #487), and restart recovery.

## What this adds

### 1. Registry tracking

- A record is written the moment an install starts (state `installing`, carrying its `install_id`), and updated on failure, not only on success.
- A failed or cancelled *update* over a calibration that is already installed and working is not knocked back to `failed`. The working install stays `installed`, and the failure is recorded in a `last_error` field. Only a country with no usable install is marked `failed`.
- The `install_id` is kept on the record on success too, and `getCalibrationCatalog` entries now carry `install_id`, so a reloaded page can reach `getInstallStatus` from one call. The frontend's `localStorage` workaround can be removed.
  

> **Note to frontend** ( @error9098x ) : **getInstalledCalibrations** is the authoritative 'what's happening on this machine' source. There are a couple of ways to retrieve the install state , the recommendation is the one stated above , as this contains states for the ones that have been installed through links and pth dir as well, which might not be highlighted , if we use other methods (by design  , like if the setup page polls only getCalibrationCatalog, an in-flight repo-URL/local-path install goes invisible on reload)

### 2. Install cancel and timeout

- New endpoint `POST /ogc/cancelInstall {install_id}`. Cancelling a running install stops it and marks it failed with "Cancelled by user." (a cancelled update keeps its working install).
- An install that produces no output for a while (a stalled clone or download) is stopped by an inactivity timeout ( 10 mins currently ), so a hung network transfer no longer locks a country; the inactivity timeout plus cancel are the guards.
-  There is no fixed overall time cap now : OG-Core installs can legitimately run for hours, and a healthy
  install keeps logging so it is never killed. Now that the logging guard is in place , the 1-hour cap now becomes stale & hence was removed for this reason.
- Cancel and the inactivity timeout kill the whole process tree (the installer spawns git and uv) so nothing is left running. A cancelled or stalled fresh install cleans up its half-clone; an update leaves the existing clone in place.
- Tunable with `MUIOGO_OG_INSTALL_INACTIVITY_TIMEOUT` (seconds, default 600). A bad value falls back to the default rather than failing startup.

### 3. Restart recovery

- On server start, any install left mid-flight by a previous run (state `installing` or `checking`) is marked failed, so it does not read as installing forever. A working install that was mid-update is preserved as installed. Idle records (installed, update available) are left untouched.

## Behaviour notes

- A record exists from the moment a job starts, so any client sees `installing` while it runs and `failed` after a failure. `installed_at` is preserved across updates; `last_updated_at` is set only on a real update; a stale `last_error` is dropped once an install succeeds.
- `refreshCalibration` refuses to run while an install or update for that country is in flight, so it cannot overwrite the running job's state.

## Testing

- Real subprocesses for the install supervisor: cancel and the inactivity timeout both stop promptly, and a real spawned grandchild process is confirmed killed with the tree.
- The real `InstallJob` thread path for start, success, failure, cancel, and update, against a temporary registry.
- The real routes through a Flask test client (the refresh guard and cancel input validation).
- Startup reconciliation over seeded on-disk state, including idempotency.

67 checks across three suites, all passing.

## New knobs

- **`POST /ogc/cancelInstall` with `{ "install_id": "..." }`**
- **`MUIOGO_OG_INSTALL_INACTIVITY_TIMEOUT` (seconds, default 600)**

## Checklist

- [x] Change is scoped, no unrelated refactors
- [x] Branched from `main`; PR targets `EAPD-DRB/MUIOGO:main`
- [x] Docs updated for any setup, workflow, or architecture change (behaviour, new endpoint,
  and env knob documented in this PR body)
