### PR TITLE
Create case-run folder before writing data.txt in generateDatafile

### DIFF
--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -724,7 +724,8 @@ class DataFile(Osemosys):
             path = '"{}"'.format(self.resPath)
 
             dataFilePath = Path(Config.DATA_STORAGE, self.case, 'res',caserunname,'data.txt')
-
+            # restored backups may lack an empty res/<caserunname>/ folder
+            dataFilePath.parent.mkdir(parents=True, exist_ok=True)
 
             # self.f = open(self.dataFile, mode="w", encoding='utf-8')
             #self.f = open(dataFilePath, mode="w", encoding='utf-8')


### PR DESCRIPTION
Fixes #504.

When a model is restored from a backup, the folder that holds a run's results can be missing, because backups skip empty folders. Trying to create a data file for that run then failed with a server error and no file.

This change simply creates that folder right before writing the file, the same way other parts of the code already do it.

Credit to @parthdagia05 for catching this in #110.

Tested against the running app: saved a new model, registered a run, deleted its results folder to mimic a restore, then asked the app to generate the data file. Before the fix this fails with a server error; with the fix the file is created normally. The full test suite (49 tests) passes.