### PR TITLE
Use row UID for uniqueness validation after sorting

### DIFF
--- a/WebAPP/Classes/Grid.Class.js
+++ b/WebAPP/Classes/Grid.Class.js
@@ -32,7 +32,7 @@ export class Grid {
 
         var validation_1 = function (cell, value) {
             var validationResult = true;
-            var rows = $('#osy-gridSe').jqxGrid('getrows');
+            var rows = $('#osy-gridSe').jqxGrid('getboundrows');
             // compare row UIDs rather than bound indices to correctly identify the edited row
             var currentRowId = String($('#osy-gridSe').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
@@ -88,7 +88,7 @@ export class Grid {
 
         var validation_1 = function (cell, value) {
             var validationResult = true;
-            var rows = $('#osy-gridDt').jqxGrid('getrows');
+            var rows = $('#osy-gridDt').jqxGrid('getboundrows');
             var currentRowId = String($('#osy-gridDt').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
                 if (rows[i].Dt.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
@@ -143,7 +143,7 @@ export class Grid {
 
         var validation_1 = function (cell, value) {
             var validationResult = true;
-            var rows = $('#osy-gridDtb').jqxGrid('getrows');
+            var rows = $('#osy-gridDtb').jqxGrid('getboundrows');
             var currentRowId = String($('#osy-gridDtb').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
                 if (rows[i].Dtb.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
@@ -250,7 +250,7 @@ export class Grid {
 
         var validation_1 = function (cell, value) {
             var validationResult = true;
-            var rows = $('#osy-gridTs').jqxGrid('getrows');
+            var rows = $('#osy-gridTs').jqxGrid('getboundrows');
             var currentRowId = String($('#osy-gridTs').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
                 if (rows[i].Ts.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
@@ -436,7 +436,7 @@ export class Grid {
 
         var validation_1 = function (cell, value) {
             var validationResult = true;
-            var rows = $('#osy-gridTech').jqxGrid('getrows');
+            var rows = $('#osy-gridTech').jqxGrid('getboundrows');
             //console.log('rows ', rows)
             var currentRowId = String($('#osy-gridTech').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
@@ -566,7 +566,7 @@ export class Grid {
 
         var validation_1 = function (cell, value) {
             var validationResult = true;
-            var rows = $('#osy-gridTechGroup').jqxGrid('getrows');
+            var rows = $('#osy-gridTechGroup').jqxGrid('getboundrows');
             var currentRowId = String($('#osy-gridTechGroup').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
                 if (rows[i].TechGroup.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
@@ -636,7 +636,7 @@ export class Grid {
 
         var validation_1 = function (cell, value) {
             var validationResult = true;
-            var rows = $('#osy-gridComm').jqxGrid('getrows');
+            var rows = $('#osy-gridComm').jqxGrid('getboundrows');
             var currentRowId = String($('#osy-gridComm').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
                 if (rows[i].Comm.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
@@ -711,7 +711,7 @@ export class Grid {
 
         var validation_1 = function (cell, value) {
             var validationResult = true;
-            var rows = $('#osy-gridEmis').jqxGrid('getrows');
+            var rows = $('#osy-gridEmis').jqxGrid('getboundrows');
             var currentRowId = String($('#osy-gridEmis').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
                 if (rows[i].Emis.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
@@ -838,7 +838,7 @@ export class Grid {
 
         var validation_1 = function (cell, value) {
             var validationResult = true;
-            var rows = $('#osy-gridStg').jqxGrid('getrows');
+            var rows = $('#osy-gridStg').jqxGrid('getboundrows');
             var currentRowId = String($('#osy-gridStg').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
                 if (rows[i].Stg.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
@@ -895,7 +895,7 @@ export class Grid {
 
         var validation_1 = function (cell, value) {
             var validationResult = true;
-            var rows = $('#osy-gridScenario').jqxGrid('getrows');
+            var rows = $('#osy-gridScenario').jqxGrid('getboundrows');
             var currentRowId = String($('#osy-gridScenario').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
                 if (rows[i].Scenario.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
@@ -980,10 +980,10 @@ export class Grid {
 
         var validation_1 = function (cell, value) {
             var validationResult = true;
-            var rows = $('#osy-gridConstraint').jqxGrid('getrows');
+            var rows = $('#osy-gridConstraint').jqxGrid('getboundrows');
             var currentRowId = String($('#osy-gridConstraint').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Constraint.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
+                if (rows[i].Con.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
                     validationResult = false;
                     break;
                 }
@@ -1155,7 +1155,7 @@ export class Grid {
 
         var validation_1 = function (cell, value) {
             var validationResult = true;
-            var rows = $('#osy-gridIndicator').jqxGrid('getrows');
+            var rows = $('#osy-gridIndicator').jqxGrid('getboundrows');
             var currentRowId = String($('#osy-gridIndicator').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
                 if (rows[i].Indicator.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {

--- a/WebAPP/Classes/Grid.Class.js
+++ b/WebAPP/Classes/Grid.Class.js
@@ -33,9 +33,10 @@ export class Grid {
         var validation_1 = function (cell, value) {
             var validationResult = true;
             var rows = $('#osy-gridSe').jqxGrid('getrows');
-            // compare row UIDs instead of row indexes (i != cell.row), otherwise breaks whenever the grid is sorted
+            // compare row UIDs rather than bound indices to correctly identify the edited row
+            var currentRowId = String($('#osy-gridSe').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Se.trim() == value.trim() && rows[i].uid != cell.row) {
+                if (rows[i].Se.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
                     validationResult = false;
                     break;
                 }
@@ -88,8 +89,9 @@ export class Grid {
         var validation_1 = function (cell, value) {
             var validationResult = true;
             var rows = $('#osy-gridDt').jqxGrid('getrows');
+            var currentRowId = String($('#osy-gridDt').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Dt.trim() == value.trim() && rows[i].uid != cell.row) {
+                if (rows[i].Dt.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
                     validationResult = false;
                     break;
                 }
@@ -142,8 +144,9 @@ export class Grid {
         var validation_1 = function (cell, value) {
             var validationResult = true;
             var rows = $('#osy-gridDtb').jqxGrid('getrows');
+            var currentRowId = String($('#osy-gridDtb').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Dtb.trim() == value.trim() && rows[i].uid != cell.row) {
+                if (rows[i].Dtb.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
                     validationResult = false;
                     break;
                 }
@@ -248,8 +251,9 @@ export class Grid {
         var validation_1 = function (cell, value) {
             var validationResult = true;
             var rows = $('#osy-gridTs').jqxGrid('getrows');
+            var currentRowId = String($('#osy-gridTs').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Ts.trim() == value.trim() && rows[i].uid != cell.row) {
+                if (rows[i].Ts.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
                     validationResult = false;
                     break;
                 }
@@ -434,8 +438,9 @@ export class Grid {
             var validationResult = true;
             var rows = $('#osy-gridTech').jqxGrid('getrows');
             //console.log('rows ', rows)
+            var currentRowId = String($('#osy-gridTech').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Tech.trim() == value.trim() && rows[i].uid != cell.row) {
+                if (rows[i].Tech.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
                     validationResult = false;
                     break;
                 }
@@ -562,8 +567,9 @@ export class Grid {
         var validation_1 = function (cell, value) {
             var validationResult = true;
             var rows = $('#osy-gridTechGroup').jqxGrid('getrows');
+            var currentRowId = String($('#osy-gridTechGroup').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].TechGroup.trim() == value.trim() && rows[i].uid != cell.row) {
+                if (rows[i].TechGroup.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
                     validationResult = false;
                     break;
                 }
@@ -631,8 +637,9 @@ export class Grid {
         var validation_1 = function (cell, value) {
             var validationResult = true;
             var rows = $('#osy-gridComm').jqxGrid('getrows');
+            var currentRowId = String($('#osy-gridComm').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Comm.trim() == value.trim() && rows[i].uid != cell.row) {
+                if (rows[i].Comm.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
                     validationResult = false;
                     break;
                 }
@@ -705,8 +712,9 @@ export class Grid {
         var validation_1 = function (cell, value) {
             var validationResult = true;
             var rows = $('#osy-gridEmis').jqxGrid('getrows');
+            var currentRowId = String($('#osy-gridEmis').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Emis.trim() == value.trim() && rows[i].uid != cell.row) {
+                if (rows[i].Emis.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
                     validationResult = false;
                     break;
                 }
@@ -831,8 +839,9 @@ export class Grid {
         var validation_1 = function (cell, value) {
             var validationResult = true;
             var rows = $('#osy-gridStg').jqxGrid('getrows');
+            var currentRowId = String($('#osy-gridStg').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Stg.trim() == value.trim() && rows[i].uid != cell.row) {
+                if (rows[i].Stg.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
                     validationResult = false;
                     break;
                 }
@@ -887,8 +896,9 @@ export class Grid {
         var validation_1 = function (cell, value) {
             var validationResult = true;
             var rows = $('#osy-gridScenario').jqxGrid('getrows');
+            var currentRowId = String($('#osy-gridScenario').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Scenario.trim() == value.trim() && rows[i].uid != cell.row) {
+                if (rows[i].Scenario.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
                     validationResult = false;
                     break;
                 }
@@ -971,8 +981,9 @@ export class Grid {
         var validation_1 = function (cell, value) {
             var validationResult = true;
             var rows = $('#osy-gridConstraint').jqxGrid('getrows');
+            var currentRowId = String($('#osy-gridConstraint').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Constraint.trim() == value.trim() && rows[i].uid != cell.row) {
+                if (rows[i].Constraint.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
                     validationResult = false;
                     break;
                 }
@@ -1145,8 +1156,9 @@ export class Grid {
         var validation_1 = function (cell, value) {
             var validationResult = true;
             var rows = $('#osy-gridIndicator').jqxGrid('getrows');
+            var currentRowId = String($('#osy-gridIndicator').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Indicator.trim() == value.trim() && rows[i].uid != cell.row) {
+                if (rows[i].Indicator.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
                     validationResult = false;
                     break;
                 }

--- a/WebAPP/Classes/Grid.Class.js
+++ b/WebAPP/Classes/Grid.Class.js
@@ -33,8 +33,9 @@ export class Grid {
         var validation_1 = function (cell, value) {
             var validationResult = true;
             var rows = $('#osy-gridSe').jqxGrid('getrows');
+            // compare row UIDs instead of row indexes (i != cell.row), otherwise breaks whenever the grid is sorted
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Se.trim() == value.trim() && i != cell.row) {
+                if (rows[i].Se.trim() == value.trim() && rows[i].uid != cell.row) {
                     validationResult = false;
                     break;
                 }
@@ -88,7 +89,7 @@ export class Grid {
             var validationResult = true;
             var rows = $('#osy-gridDt').jqxGrid('getrows');
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Dt.trim() == value.trim() && i != cell.row) {
+                if (rows[i].Dt.trim() == value.trim() && rows[i].uid != cell.row) {
                     validationResult = false;
                     break;
                 }
@@ -142,7 +143,7 @@ export class Grid {
             var validationResult = true;
             var rows = $('#osy-gridDtb').jqxGrid('getrows');
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Dtb.trim() == value.trim() && i != cell.row) {
+                if (rows[i].Dtb.trim() == value.trim() && rows[i].uid != cell.row) {
                     validationResult = false;
                     break;
                 }
@@ -248,7 +249,7 @@ export class Grid {
             var validationResult = true;
             var rows = $('#osy-gridTs').jqxGrid('getrows');
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Ts.trim() == value.trim() && i != cell.row) {
+                if (rows[i].Ts.trim() == value.trim() && rows[i].uid != cell.row) {
                     validationResult = false;
                     break;
                 }
@@ -434,7 +435,7 @@ export class Grid {
             var rows = $('#osy-gridTech').jqxGrid('getrows');
             //console.log('rows ', rows)
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Tech.trim() == value.trim() && i != cell.row) {
+                if (rows[i].Tech.trim() == value.trim() && rows[i].uid != cell.row) {
                     validationResult = false;
                     break;
                 }
@@ -562,7 +563,7 @@ export class Grid {
             var validationResult = true;
             var rows = $('#osy-gridTechGroup').jqxGrid('getrows');
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].TechGroup.trim() == value.trim() && i != cell.row) {
+                if (rows[i].TechGroup.trim() == value.trim() && rows[i].uid != cell.row) {
                     validationResult = false;
                     break;
                 }
@@ -631,7 +632,7 @@ export class Grid {
             var validationResult = true;
             var rows = $('#osy-gridComm').jqxGrid('getrows');
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Comm.trim() == value.trim() && i != cell.row) {
+                if (rows[i].Comm.trim() == value.trim() && rows[i].uid != cell.row) {
                     validationResult = false;
                     break;
                 }
@@ -705,7 +706,7 @@ export class Grid {
             var validationResult = true;
             var rows = $('#osy-gridEmis').jqxGrid('getrows');
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Emis.trim() == value.trim() && i != cell.row) {
+                if (rows[i].Emis.trim() == value.trim() && rows[i].uid != cell.row) {
                     validationResult = false;
                     break;
                 }
@@ -831,7 +832,7 @@ export class Grid {
             var validationResult = true;
             var rows = $('#osy-gridStg').jqxGrid('getrows');
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Stg.trim() == value.trim() && i != cell.row) {
+                if (rows[i].Stg.trim() == value.trim() && rows[i].uid != cell.row) {
                     validationResult = false;
                     break;
                 }
@@ -887,7 +888,7 @@ export class Grid {
             var validationResult = true;
             var rows = $('#osy-gridScenario').jqxGrid('getrows');
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Scenario.trim() == value.trim() && i != cell.row) {
+                if (rows[i].Scenario.trim() == value.trim() && rows[i].uid != cell.row) {
                     validationResult = false;
                     break;
                 }
@@ -971,7 +972,7 @@ export class Grid {
             var validationResult = true;
             var rows = $('#osy-gridConstraint').jqxGrid('getrows');
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Constraint.trim() == value.trim() && i != cell.row) {
+                if (rows[i].Constraint.trim() == value.trim() && rows[i].uid != cell.row) {
                     validationResult = false;
                     break;
                 }
@@ -1145,7 +1146,7 @@ export class Grid {
             var validationResult = true;
             var rows = $('#osy-gridIndicator').jqxGrid('getrows');
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Indicator.trim() == value.trim() && i != cell.row) {
+                if (rows[i].Indicator.trim() == value.trim() && rows[i].uid != cell.row) {
                     validationResult = false;
                     break;
                 }

--- a/WebAPP/Classes/JqxSources.Class.js
+++ b/WebAPP/Classes/JqxSources.Class.js
@@ -299,8 +299,7 @@ export class JqxSources {
 
         var validation_1 = function (cell, value) {
             var validationResult = true;
-            var rows = $('#osy-gridTech').jqxGrid('getrows');
-            
+            var rows = $('#osy-gridTech').jqxGrid('getboundrows');
             var currentRowId = String($('#osy-gridTech').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
                 if (rows[i].Tech.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {

--- a/WebAPP/Classes/JqxSources.Class.js
+++ b/WebAPP/Classes/JqxSources.Class.js
@@ -300,8 +300,9 @@ export class JqxSources {
         var validation_1 = function (cell, value) {
             var validationResult = true;
             var rows = $('#osy-gridTech').jqxGrid('getrows');
+            // compare row UIDs instead of row indexes (i != cell.row), otherwise breaks whenever the grid is sorted
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Tech.trim() == value.trim() && i != cell.row) {
+                if (rows[i].Tech.trim() == value.trim() && rows[i].uid != cell.row) {
                     validationResult = false;
                     break;
                 }

--- a/WebAPP/Classes/JqxSources.Class.js
+++ b/WebAPP/Classes/JqxSources.Class.js
@@ -300,9 +300,10 @@ export class JqxSources {
         var validation_1 = function (cell, value) {
             var validationResult = true;
             var rows = $('#osy-gridTech').jqxGrid('getrows');
-            // compare row UIDs instead of row indexes (i != cell.row), otherwise breaks whenever the grid is sorted
+            
+            var currentRowId = String($('#osy-gridTech').jqxGrid('getrowid', cell.row));
             for (var i = 0; i < rows.length; i++) {
-                if (rows[i].Tech.trim() == value.trim() && rows[i].uid != cell.row) {
+                if (rows[i].Tech.trim() == value.trim() && String(rows[i].uid) !== currentRowId) {
                     validationResult = false;
                     break;
                 }


### PR DESCRIPTION
## Summary

- What changed:
Replaced row index comparisons `i != cell.row` with row UID comparisons `rows[i].uid != cell.row` in grid uniqueness validators.
Updated all affected occurrences in `Grid.Class.js` and `JqxSources.Class.js`.

- Why:
Fixes false "name should be unique" validation errors after sorting a grid. The validators were comparing the edited row against its displayed index instead of its row UID, causing the edited row to be treated as a duplicate of itself

## Linked issue (if applicable)

- Closes #499 

## Validation

- [x] Tests added/updated (or not applicable)
- [x] Manual verification steps documented, with evidence where relevant
To reproduce: (in the current version)
1. Goto `model configuration` > any of the `commodities`, `technologies`, `emissions`, or other
2. Sort the name column first (either ascending or descending)
3. Select one name from the list (for eg. COA), rename it to COA_TEST
4. Warning error message "`.... name should be unique!`" pops up

Verified the fix by repeating the same steps after the change.

## Checklist

- [x] Change is scoped — no unrelated refactors
- [x] Branched from `main`; PR targets `EAPD-DRB/MUIOGO:main`
- [x] Docs updated for any setup, workflow, or architecture change
