### PR TITLE
Use the model folder name for resData.json when restoring legacy backups

### DIFF
--- a/API/Routes/Upload/UploadRoute.py
+++ b/API/Routes/Upload/UploadRoute.py
@@ -557,7 +557,7 @@ def handle_full_zip(file, filepath=None):
 
                         resPath = Path(Config.DATA_STORAGE,casename,'res')
                         viewPath = Path(Config.DATA_STORAGE,casename,'view')
-                        resDataPath = Path(Config.DATA_STORAGE,case,'view','resData.json')
+                        resDataPath = Path(Config.DATA_STORAGE,casename,'view','resData.json')
                         
                         if os.path.exists(resPath):
                             shutil.rmtree(resPath)


### PR DESCRIPTION
Fixes #359.

When restoring an old-format model backup whose zip filename differs from the model folder inside it (renamed files, or chunked uploads with randomized names), one path was built from the zip filename while its four neighboring paths correctly used the folder name — so the restore wrote into a folder that doesn't exist and failed.

One-word fix, aligning the line with its siblings. Credit to @Vinay152003 for catching this in #361; the second line their PR fixed was already removed by the restore rework, and an identical line in the deprecated `uploadCaseUnchunked_old` route was left alone since nothing calls it.

Test suite passes (49 tests).