### PR TITLE
Fix the unit shown on the Energy Balance shadow price

### DIFF
--- a/WebAPP/DataStorage/Duals.json
+++ b/WebAPP/DataStorage/Duals.json
@@ -49,7 +49,7 @@
                         "var": "divide"
                     },
                     {
-                        "var": "EmiUnit"
+                        "var": "CommUnit"
                     }
                 ]
             }


### PR DESCRIPTION
Fixes #432.

The Energy Balance shadow price in the results view was labeled per emission unit (e.g. M$/Mt) when it's actually a price per unit of the commodity (e.g. M$/PJ) — a wrong unit on a number policymakers read. One-word fix in `Duals.json`; the emissions-limit shadow price keeps its (correct) per-emission unit.

Credit to @brightyorcerf, who caught this in #433 — the entry has since moved from Variables.json to Duals.json, and the wrong unit moved with it. This matters more once #489 (units on the pivot chart axis) lands, since the axis will print whatever unit is declared here.

Test suite passes (49 tests).