### PR TITLE
Remove leftover debug logging from the frontend

### DIFF
--- a/WebAPP/App/Controller/AddCase.js
+++ b/WebAPP/App/Controller/AddCase.js
@@ -58,7 +58,6 @@ export default class AddCase {
                 AddCase.initPage(model);
             })
             .catch(error => {
-                console.log(' error ', error)
                 Message.bigBoxDanger(error);
             })
     }
@@ -67,7 +66,6 @@ export default class AddCase {
         Message.clearMessages();
         //$('a[href="#tabComms"]').click();
         //Navbar.initPage(model.casename, model.pageId);
-        console.log('model ', model)
         
         Html.title(model.casename, model.title, "create & edit");
         Html.genData(model);
@@ -334,7 +332,6 @@ export default class AddCase {
                 //sortingn ne utice na rowid i id i index
                 var rowid = $divTech.jqxGrid('getrowid', id);
 
-                console.log('rowid id ', rowid,id)
                 //var rows = $divTech.jqxGrid('getboundrows');
                 // // console.log('rows[rowId].uid ', rows[rowid].uid);
                 // // console.log('rows[id]].uid ', rows[id].uid);
@@ -348,7 +345,6 @@ export default class AddCase {
                 //provjera da brisemo tacnu tehnologiju
                 //console.log('techIds ', model.techs[id].TechId,techId, htmltechId,    model.techNames[techId],   model.techNames[model.techs[id].TechId],    model.techNames[htmltechId])
                 if(model.techs[id].TechId != techId ||techId != htmltechId){
-                    console.log('delete tech')  
                     Message.bigBoxDanger('Technology deletion error', `Wrong index!! <b>${model.techs[id].Tech}</b>?`, 3000);
                 }
                 if(model.techs[id].TG.length>0){          
@@ -604,7 +600,6 @@ export default class AddCase {
             model.seasons[rowBoundIndex][column] = value;
             if (column == 'Se') {
                 var seId = $divSe.jqxGrid('getcellvalue', rowBoundIndex, 'SeId');
-                console.log('seId ', seId, value)
                 model.seNames[seId] = value;
             }
         });
@@ -761,7 +756,6 @@ export default class AddCase {
                 delete model.dtbNames[dtbId];
                 //ovdje trebamo izbaciti season iz timeslice definicije
                 $.each(model.timeslices, function (id, obj) {
-                    console.log('dtbCount ', id, obj, dtbId)
                     if(obj.DTB == dtbId){
                         obj.DTB='DTB_0';
                     }
@@ -918,7 +912,6 @@ export default class AddCase {
             let defaultStg = DefaultObj.defaultStg();
             model.stg.push(JSON.parse(JSON.stringify(defaultStg[0], ['StgId', 'Stg', 'Desc',"UnitId", "TTS","TFS", "Operation"])));
             //update stgames
-            console.log('defaultStg ',defaultStg)
             model.stgNames[defaultStg[0]['StgId']] = defaultStg[0]['Stg'];
             //add row
             $divStg.jqxGrid('addrow', null, defaultStg);
@@ -952,7 +945,6 @@ export default class AddCase {
             model.stg[rowBoundIndex][column] = value;
             if (column == 'Stg') {
                 var stgId = $divStg.jqxGrid('getcellvalue', rowBoundIndex, 'StgId');
-                console.log('stgId ', stgId, value)
                 model.stgNames[stgId] = value;
             }
         });
@@ -1087,7 +1079,6 @@ export default class AddCase {
             event.stopImmediatePropagation();
             let defaultIndicator = DefaultObj.defaultIndicator();
             model.indicators.push(JSON.parse(JSON.stringify(defaultIndicator[0], ['IndicatorId', 'Indicator', 'Desc', 'IndicatorTypeId', 'Techs', 'Comms'])));
-            console.log('model.defaultIndicator ',defaultIndicator)
 
             $divIndicator.jqxGrid('addrow', null, defaultIndicator);
             $divIndicator.jqxGrid('updatebounddata', 'data');
@@ -1122,8 +1113,6 @@ export default class AddCase {
             }else{
                 var value = args.newvalue;
             }
-            console.log('column ', column)
-            console.log('value ', value)
             if (column != 'Techs' && column != 'Comms' && column != 'IndicatorTypeId') {
                 model.indicators[rowBoundIndex][column] = value;
             } else if (column == 'Techs' || column == 'Comms') {
@@ -1137,7 +1126,6 @@ export default class AddCase {
                 }
                 model.indicators[rowBoundIndex][column] = array;
             } else if (column == 'IndicatorTypeId') {
-                console.log('IndicatorTypeId value received:', value);
                 model.indicators[rowBoundIndex][column] = value;
             }
         });

--- a/WebAPP/App/Controller/Config.js
+++ b/WebAPP/App/Controller/Config.js
@@ -107,7 +107,6 @@ export default class Config {
 
             /////////////// params
             let paramData = $('#osy-gridParam').jqxGrid('getrows');
-            console.log('   paramData', paramData   );
             let ParamData = {};
             $.each(paramData, function (id, obj) {
                 let tmp = {};
@@ -174,7 +173,6 @@ export default class Config {
                 IndicatorData[obj.groupId].push(tmp);
             });
 
-            console.log('   IndicatorData', IndicatorData );
             Osemosys.saveParamFile(ParamData, VarData, DualData, IndicatorData)
             .then(response =>{
                 Message.bigBoxSuccess('Model message', response.message, 3000);
@@ -315,7 +313,6 @@ export default class Config {
                 unitRule = model.gridDualData[id]['unitRule'];
             }
 
-            console.log('unitRule, model.unitsDef ', unitRule, model.unitsDef);
 
             $('#unitTitle').html(
                 `<h6 id="paramId" data-paramId ="${paramId}" style="display: inline-block;">
@@ -393,7 +390,6 @@ export default class Config {
                 });
                 model.srcIndicatorGrid.localdata = model.gridIndicatorData;
                 $divIndicatorGrid.jqxGrid('updatebounddata');
-                console.log('model.indicatorRuleData ', model.indicatorData);
                 Message.smallBoxInfo('Rule updated for ', model.indicatorData[groupId][paramId], 3000);
             }
 
@@ -424,7 +420,6 @@ export default class Config {
             $.each(rule, function (id, rule) {
                 arrayRule += UNITDEFINITION[rule]['name'];
             });
-            console.log('receive ', arrayRule)
             $('#ruleFormula').html(`<p>${arrayRule}</p>`);
             $('#ruleFormula').show();
          }); 
@@ -448,8 +443,6 @@ export default class Config {
             formulaRule = model.gridIndicatorData[id]['formulaRule'];
  
 
-            console.log('formulaRule ', formulaRule);
-            console.log('model.indicatorRuleData ', model.indicatorRuleData);
 
             $('#indTitle').html(
                 `<h6 id="paramId" data-paramId ="${paramId}" style="display: inline-block;">
@@ -472,7 +465,6 @@ export default class Config {
 
             let arrayRule = name +' = ';
             $.each(rule, function (id, r) {
-                console.log('rule ', id, r)
                 //arrayRule += UNITDEFINITION[r]['name'];
                 //console.log('arrayRule ',arrayRule);
                 arrayRule +=  model.indicatorDef[r]['name'];
@@ -487,8 +479,6 @@ export default class Config {
         $("#btnSaveFormula").on('click', function (event) {
             let rule = $("#osy-indFormulaSort2").jqxSortable("toArray")
 
-            console.log('rule ', rule   );
-            console.log('model.indicatorDef ', model.indicatorDef   )
 
             let paramId = $('#paramId').attr("data-paramId");
             let groupId = $('#groupId').attr("data-groupId") 
@@ -551,7 +541,6 @@ export default class Config {
                 $.each(rule, function (id, rule) {
                     arrayRule += model.indicatorDef[rule]['name'];
                 });
-                console.log('stop ', arrayRule)
                 $('#formulaView').html(`<p>${arrayRule}</p>`);
                 $('#formulaView').show();
         }); 
@@ -565,7 +554,6 @@ export default class Config {
                 $.each(rule, function (id, rule) {
                     arrayRule += model.indicatorDef[rule]['name'];
                 });
-                console.log('receive ', arrayRule)
                 $('#formulaView').html(`<p>${arrayRule}</p>`);
                 $('#formulaView').show();
         }); 

--- a/WebAPP/App/Controller/DataFile.js
+++ b/WebAPP/App/Controller/DataFile.js
@@ -567,7 +567,6 @@ export default class DataFile {
                 }
             })
             .catch(error => {
-                console.log('error ',error)
                 Message.loaderEnd();
                 Message.bigBoxDanger('Error message', error, null);
             })
@@ -580,7 +579,6 @@ export default class DataFile {
             e.stopImmediatePropagation();
             Html.renderScOrder( model.scBycs[model.cs]);
             Message.clearMessages();
-            console.log('select, ', model)
             var caserunanme = $(this).attr('data-ps');
             model.cs = caserunanme;
             Html.renderScOrder( model.scBycs[model.cs]);
@@ -614,7 +612,6 @@ export default class DataFile {
             })
             .then(data => {
                 let [DataFile, ResultCSV] = data;
-                console.log('data ', data)
                 if (ResultCSV.length != 0) {
                     $(".Results").show();
                     Html.renderCSV(ResultCSV, model.cs)
@@ -756,7 +753,6 @@ export default class DataFile {
 
                         })
                         .catch(error => {
-                            console.log(error)
                             Message.danger(error);
                         });
                 }
@@ -834,7 +830,6 @@ export default class DataFile {
 
                         })
                         .catch(error => {
-                            console.log(error)
                             Message.danger(error);
                         });
                 }
@@ -932,7 +927,6 @@ export default class DataFile {
                 $("#osy-lpOutput").empty();
                 $('.Cases').tab('show');
 
-                console.log('response clean up ', response) 
 
                 Sidebar.Reload(model.casename);
                 Message.clearMessages();

--- a/WebAPP/App/Controller/LegacyImport.js
+++ b/WebAPP/App/Controller/LegacyImport.js
@@ -110,7 +110,6 @@ export default class LegacyImport {
             var date = $("#osy-date").val();
             var currency = $("#osy-currency").val();
             var templateName = $("#osy-template").val();
-            console.log('templateName ', templateName)
             let data = false;
             if ($('#osy-data').is(":checked")){
                 data = true;
@@ -127,7 +126,6 @@ export default class LegacyImport {
             }
             Osemosys.importTemplate(POSTDATA)
             .then(response => {
-                console.log('response ', response)
                 if (response.status_code == "success") {
                     Message.loaderEnd();
                     //console.log('response ', response)
@@ -139,7 +137,6 @@ export default class LegacyImport {
                 }
             })
             .catch(error => {
-                console.log('error ', error)
                 Message.loaderEnd();
                 Message.bigBoxDanger('Error message', error, null);
             })

--- a/WebAPP/App/Controller/RESViewerMermaid.js
+++ b/WebAPP/App/Controller/RESViewerMermaid.js
@@ -30,7 +30,6 @@ export default class RESViewer {
                 this.initEvents(model);
             })
             .catch(error => {
-                console.log('error ', error)
                 Message.warning(error);
             });
     }

--- a/WebAPP/App/Controller/RTSM.js
+++ b/WebAPP/App/Controller/RTSM.js
@@ -211,7 +211,6 @@ export default class RTSM {
             e.stopImmediatePropagation();
             var sc = $("#osy-scenarios").val();
             Html.lblScenario(sc);
-            console.log('sc ', sc)
             Grid.applyRSTMFilter($divGrid, sc, model.param);
             Message.smallBoxInfo('Info', 'Scenario data opened!', 2000);
         });

--- a/WebAPP/App/Controller/RYDtb.js
+++ b/WebAPP/App/Controller/RYDtb.js
@@ -115,8 +115,6 @@ export default class RYDtb {
                 delete obj.ScId;
             });
 
-            console.log('param ', param)
-            console.log('savedata ', saveData)
 
             Osemosys.updateData(saveData, param, "RYDtb.json")
                 .then(response => {

--- a/WebAPP/App/Controller/RYS.js
+++ b/WebAPP/App/Controller/RYS.js
@@ -51,7 +51,6 @@ export default class RYS {
 
 
     static initPage(model) {
-        console.log('model ', model)
         Message.clearMessages();
         //Navbar.initPage(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);

--- a/WebAPP/App/Controller/RYT.js
+++ b/WebAPP/App/Controller/RYT.js
@@ -51,7 +51,6 @@ export default class RYT {
 
 
     static initPage(model) {
-        console.log('model ', model)
         Message.clearMessages();
         //Navbar.initPage(model.casename);
         Html.title(model.casename, model.PARAMNAMES[model.param], GROUPNAMES[model.group]);

--- a/WebAPP/App/Controller/RYTC.js
+++ b/WebAPP/App/Controller/RYTC.js
@@ -53,7 +53,6 @@ export default class RYTC {
                 }
             })
             .catch(error => {
-                console.log('error ', error)
                 if (error.status_code == 'CaseError') {
                     MessageSelect.init(RYTC.refreshPage.bind(RYTC));
                 }

--- a/WebAPP/App/Controller/RYTTs.js
+++ b/WebAPP/App/Controller/RYTTs.js
@@ -224,7 +224,6 @@ export default class RYTTs {
             }
         }).on('cellvaluechanged', function (event) {
             if (!pasteEvent) {
-                console.log('not paste')
                 //Pace.restart();
                 pasteEvent = false;
                 var args = event.args;

--- a/WebAPP/App/Controller/Settings.js
+++ b/WebAPP/App/Controller/Settings.js
@@ -136,10 +136,8 @@ export default class Settings {
                 })
                 .then((data) =>{
                     let [session, module] = data; 
-                    console.log(pageId, module, session);
                     const AddCase = module.default;
                     const casename = session['session'];
-                    console.log('units from strogae ',JSON.parse(localStorage.getItem("osy-units")))
                     // Call the onLoad method
                     AddCase.refreshPage(casename);
                 })

--- a/WebAPP/App/Controller/ViewData.js
+++ b/WebAPP/App/Controller/ViewData.js
@@ -54,7 +54,6 @@ export default class ViewData {
         let $divTEGrid = $('#osy-gridRT');
 
         var daRTGrid = new $.jqx.dataAdapter(model.srcRTGrid, { autoBind: true });
-        console.log('daRTGrid', daRTGrid.records);
         Grid.Grid($divTEGrid, daRTGrid, model.columnsRT, { height:200});
         Grid.applyTEviewDataFilter($divTEGrid);
 
@@ -395,7 +394,6 @@ export default class ViewData {
             let rytData = $divGrid.jqxGrid('getdisplayrows');
             let data = JSON.parse(JSON.stringify(rytData, ['Sc', 'paramName', 'UnitId', 'TechName', "CommName", "EmisName", "ConName", 'Ts', 'MoId'].concat(model.years)));
 
-            console.log('data', data);
             Base.prepareCSV(model.casename, data)
             .then(response =>{
                 Message.smallBoxInfo('Case study message', response.message, 3000);

--- a/WebAPP/App/Model/RESViewer.Model.js
+++ b/WebAPP/App/Model/RESViewer.Model.js
@@ -12,7 +12,6 @@ export class Model {
         let commData = DataModel.getCommData(genData);
         
 
-        console.log('resData ', resData)
 
         let index = 0;
         let labelIndex = {};
@@ -208,11 +207,6 @@ export class Model {
 
 
 
-        console.log('source ', source)  
-        console.log('target ', target)  
-        console.log('value ', value)  
-        console.log('labelLink ', labelLink)  
-        console.log('colorLink ', colorLink)  
 
         let labelCount = source.length;
         this.selectedTechs = selectedTechs;

--- a/WebAPP/App/Model/RS.Model.js
+++ b/WebAPP/App/Model/RS.Model.js
@@ -19,7 +19,6 @@ export class Model {
             let scenarios = genData['osy-scenarios'];
             this.param = param;
 
-            console.log(RSdata, group, PARAMETERS, param)
             let RSgrid = DataModel.RSgrid(genData, RSdata, PARAMETERS);
             let RSchart = DataModel.RSchart(genData, RSdata);
             let PARAMNAMES = DataModel.ParamName(PARAMETERS[group]);

--- a/WebAPP/App/Model/RT.Model.js
+++ b/WebAPP/App/Model/RT.Model.js
@@ -60,7 +60,6 @@ export class Model {
                 if (['TMPAL', 'TMPAU'].includes(this.param)){
                     return true;
                 }else{
-                    console.log('Number.isInteger(value) ', value,  Number.isInteger(value))
                     if (value < 0) {
                         return { result: false, message: 'Value must be positive!' };
                     } 

--- a/WebAPP/App/Model/RTSM.Model.js
+++ b/WebAPP/App/Model/RTSM.Model.js
@@ -18,7 +18,6 @@ export class Model {
 
             let RTSMgrid = DataModel.RTSMgrid(genData, RTSMdata, PARAMETERS);
 
-            console.log('RTSMgrid ', RTSMgrid)
 
             // let techIds = DataModel.TechId(genData);
             // let ActivityTechs = DataModel.activityTechs(techs);

--- a/WebAPP/App/Model/RYDtb.Model.js
+++ b/WebAPP/App/Model/RYDtb.Model.js
@@ -51,7 +51,6 @@ export class Model {
                 // if(columnfield = '2020')
                 // console.log('ROW, COLUMN, VALUE ', row, columnfield, value)
                 if(row == 4 && columnfield == '2020')
-                console.log('row renderer ', row,  'row renderer value ',  value)
                 if (value === null || value === '') {
                     return '<span style="margin: 4px; float:right; ">n/a</span>';
                 } else {

--- a/WebAPP/App/Model/RYSeDt.Model.js
+++ b/WebAPP/App/Model/RYSeDt.Model.js
@@ -13,7 +13,6 @@ export class Model {
             let PARAMNAMES = DataModel.ParamName(PARAMETERS[group]);
             let RYSeDtgrid = DataModel.RYSeDtgrid(genData, RYCTsdata, PARAMETERS);
 
-            console.log('RYSeDtgrid ',RYSeDtgrid)
 
             let years = genData['osy-years'];
             let seasons = genData['osy-se'];

--- a/WebAPP/App/Model/RYTSM.Model.js
+++ b/WebAPP/App/Model/RYTSM.Model.js
@@ -18,7 +18,6 @@ export class Model {
 
             let RYTSMgrid = DataModel.RYTSMgrid(genData, RYTSMdata, PARAMETERS);
 
-            console.log('RYTSMgrid ', RYTSMgrid)
             let techIds = DataModel.TechId(genData);
             let ActivityTechs = DataModel.activityTechs(techs);
             let ActivityComms = DataModel.activityComms(genData);

--- a/WebAPP/App/Model/RYTs.Model.js
+++ b/WebAPP/App/Model/RYTs.Model.js
@@ -53,7 +53,6 @@ export class Model {
                 // if(columnfield = '2020')
                 // console.log('ROW, COLUMN, VALUE ', row, columnfield, value)
                 if(row == 4 && columnfield == '2020')
-                console.log('row renderer ', row,  'row renderer value ',  value)
                 if (value === null || value === '') {
                     return '<span style="margin: 4px; float:right; ">n/a</span>';
                 } else {


### PR DESCRIPTION
Fixes #436.

Strictly deletion-only: 58 leftover debug print lines removed across 21 frontend files (only whole lines that are a single console.log statement — commented-out ones and everything else untouched).

Verified in the running app: loaded every page whose files changed (model configuration, run page, data views, and nine data-entry grids) with zero JavaScript errors.

Credit to @parthdagia05, who proposed this cleanup in #437 — that branch fell out of date with this week's merges, so it was redone fresh.