### PR TITLE
Return clean errors instead of crashing when the model name is missing

### DIFF
--- a/API/Routes/DataFile/DataFileRoute.py
+++ b/API/Routes/DataFile/DataFileRoute.py
@@ -12,6 +12,9 @@ datafile_api = Blueprint('DataFileRoute', __name__)
 @datafile_api.route("/generateDataFile", methods=['POST'])
 def generateDataFile():
     try:
+        err, code = validate_json_fields('casename', 'caserunname')
+        if err:
+            return err, code
         casename = request.json['casename']
         caserunname = request.json['caserunname']
 
@@ -100,6 +103,9 @@ def deleteCaseRun():
 @datafile_api.route("/deleteScenarioCaseRuns", methods=['POST'])
 def deleteScenarioCaseRuns():
     try:
+        err, code = validate_json_fields('casename', 'scenarioId')
+        if err:
+            return err, code
         scenarioId = request.json['scenarioId']
         casename = request.json['casename']
 
@@ -114,6 +120,9 @@ def deleteScenarioCaseRuns():
 @datafile_api.route("/saveView", methods=['POST'])
 def saveView():
     try:
+        err, code = validate_json_fields('casename', 'param', 'data')
+        if err:
+            return err, code
         casename = request.json['casename']
         param = request.json['param']
         data = request.json['data']
@@ -129,6 +138,9 @@ def saveView():
 @datafile_api.route("/updateViews", methods=['POST'])
 def updateViews():
     try:
+        err, code = validate_json_fields('casename', 'param', 'data')
+        if err:
+            return err, code
         casename = request.json['casename']
         param = request.json['param']
         data = request.json['data']
@@ -328,6 +340,9 @@ def batchRun():
 @datafile_api.route("/cleanUp", methods=['POST'])
 def cleanUp():
     try:
+        err, code = validate_json_fields('modelname')
+        if err:
+            return err, code
         modelname = request.json['modelname']
 
         if modelname != None:

--- a/API/utils.py
+++ b/API/utils.py
@@ -14,4 +14,6 @@ def validate_json_fields(*fields):
     for field in fields:
         if field not in data:
             return jsonify({"error": f"Missing required field: {field}"}), 400
+        if data[field] is None:
+            return jsonify({"error": f"Required field cannot be null: {field}"}), 400
     return None, None


### PR DESCRIPTION
Fixes #438.

When a request arrives with a null model name — which the frontend can produce when no model is selected — seven endpoints crashed with a raw server error page instead of a clean message. This includes endpoints that already had validation, because the shared check only verified a field was present, not that it had a value.

Two-part fix: the shared validator now rejects null values (strictly null — legitimate `false` flags and empty lists still pass), and the five endpoints that had no validation at all now use it.

Verified: all seven null probes that crashed before now return a clean 400 message, a real data-file generation on the demo model still succeeds, and the suite passes (49 tests).

Credit to @parthdagia05, whose #439 mapped this out — this version fixes the shared validator too, which their probe pattern revealed was letting nulls through everywhere.