### PR TITLE
Fix pandas chained fillna deprecations

### DIFF
--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -1399,7 +1399,7 @@ class DataFile(Osemosys):
 
             # df_merge7 = df_merge7.set_index(['r','y']).fillna(df_YStmp.set_index(['r','y'])).reset_index()
             df_merge7 = pd.merge(df_merge7, df_YStmp, on=['r','y'],  suffixes=("", "_y"), how="left")
-            df_merge7['Sum'].fillna(df_merge7['Sum_y'], inplace=True)
+            df_merge7['Sum'] = df_merge7['Sum'].fillna(df_merge7['Sum_y'])
 
             df_merge7.drop(columns=['Sum_y'],axis=1, inplace=True)
 
@@ -2439,7 +2439,7 @@ class DataFile(Osemosys):
                         df_prod = pd.merge(df_out_ys, df_activity, how='left', on=['t','m','l','y'])
                         region = [x for x in list(df_prod.r.unique()) if str(x) != 'nan']
                         df_prod['r'] = str(region[0])
-                        df_prod['RateOfActivity'].fillna(0, inplace=True)
+                        df_prod['RateOfActivity'] = df_prod['RateOfActivity'].fillna(0)
                         df_prod['ProductionByTechnologyByMode'] = df_prod['OutputActivityRatio']*df_prod['YearSplit']*df_prod['RateOfActivity']
                         df_prod = df_prod.drop(['OutputActivityRatio','YearSplit','RateOfActivity'], axis=1)
                         df_prod['ProductionByTechnologyByMode'] = df_prod['ProductionByTechnologyByMode'].astype(float).round(4)
@@ -2509,7 +2509,7 @@ class DataFile(Osemosys):
                         df_ropbt = pd.merge(df_out_ys, df_activity, how='left', on=['t','m','l','y'])
                         region = [x for x in list(df_ropbt.r.unique()) if str(x) != 'nan']
                         df_ropbt['r'] = str(region[0])
-                        df_ropbt['RateOfActivity'].fillna(0, inplace=True)
+                        df_ropbt['RateOfActivity'] = df_ropbt['RateOfActivity'].fillna(0)
 
                         df_ropbt['RateOfProductionByTechnologyByMode'] = df_ropbt['OutputActivityRatio']*df_ropbt['RateOfActivity']
                         df_ropbt = df_ropbt.drop(['OutputActivityRatio','YearSplit','RateOfActivity'], axis=1)
@@ -2524,7 +2524,7 @@ class DataFile(Osemosys):
                         df_use = pd.merge(df_in_ys, df_activity, how='left', on=['t','m','l','y'])
                         region = [x for x in list(df_use.r.unique()) if str(x) != 'nan']
                         df_use['r'] = str(region[0])
-                        df_use['RateOfActivity'].fillna(0, inplace=True)
+                        df_use['RateOfActivity'] = df_use['RateOfActivity'].fillna(0)
             
                         df_use['UseByTechnologyByMode'] = df_use['InputActivityRatio']*df_use['YearSplit']*df_use['RateOfActivity']
                         df_use = df_use.drop(['InputActivityRatio','YearSplit','RateOfActivity'], axis=1)
@@ -2537,7 +2537,7 @@ class DataFile(Osemosys):
                         df_roubt = pd.merge(df_in_ys, df_activity, how='left', on=['t','m','l','y'])
                         region = [x for x in list(df_roubt.r.unique()) if str(x) != 'nan']
                         df_roubt['r'] = str(region[0])
-                        df_roubt['RateOfActivity'].fillna(0, inplace=True)
+                        df_roubt['RateOfActivity'] = df_roubt['RateOfActivity'].fillna(0)
             
                         df_roubt['RateOfUseByTechnologyByMode'] = df_roubt['InputActivityRatio']*df_roubt['RateOfActivity']
                         df_roubt = df_roubt.drop(['InputActivityRatio','YearSplit','RateOfActivity'], axis=1)


### PR DESCRIPTION
## Summary
- replace chained inplace fillna calls with explicit column assignment
- preserve existing missing-value behavior
- avoid pandas 2.2 deprecation notices and remain compatible with pandas 3 semantics

## Validation
- full pytest suite: 49 passed, 10 subtests passed
- verified the replacements with pandas 2.2.2 under an always-on warnings filter
- compiled DataFileClass.py successfully
- ran git diff --check