### PR TITLE
Fix shadow prices lost to a duplicated energy-balance constraint

### DIFF
--- a/WebAPP/SOLVERs/model.v.5.4.txt
+++ b/WebAPP/SOLVERs/model.v.5.4.txt
@@ -263,7 +263,6 @@ s.t. EBa11_EnergyBalanceEachTS5
 
 
 s.t. EBa9_EnergyBalanceEachTS3{r in REGION, l in TIMESLICE, f in COMMODITY, y in YEAR}: SpecifiedAnnualDemand[r,f,y]*SpecifiedDemandProfile[r,f,l,y] = Demand[r,l,f,y];
-s.t. EBb4_EnergyBalanceEachYear4{r in REGION, f in COMMODITY, y in YEAR}: sum{(m,t) in MODExTECHNOLOGYperFUELout[f], l in TIMESLICE} RateOfActivity[r,l,t,m,y]*OutputActivityRatio[r,t,f,m,y]*YearSplit[l,y] >= sum{(m,t) in MODExTECHNOLOGYperFUELin[f], l in TIMESLICE} RateOfActivity[r,l,t,m,y]*InputActivityRatio[r,t,f,m,y]*YearSplit[l,y] + sum{l in TIMESLICE, rr in REGION} Trade[r,rr,l,f,y]*TradeRoute[r,rr,f,y] + AccumulatedAnnualDemand[r,f,y];
 #20240611 VK commented, 3 params removed
 #s.t. RM3_ReserveMargin_Constraint{r in REGION, l in TIMESLICE, y in YEAR}: sum{f in COMMODITY, (m,t) in MODExTECHNOLOGYperFUELout[f]} RateOfActivity[r,l,t,m,y]*OutputActivityRatio[r,t,f,m,y] * ReserveMarginTagFuel[r,f,y] * ReserveMargin[r,y]<= sum {t in TECHNOLOGY} ((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y]) * ReserveMarginTagTechnology[r,t,y] * CapacityToActivityUnit[r,t];
 

--- a/tests/test_model_file.py
+++ b/tests/test_model_file.py
@@ -1,0 +1,20 @@
+"""Guards on the shared OSeMOSYS model file.
+
+The plain EBb4 energy-balance constraint duplicated the _ICR variant row for
+row (identically wherever no capacity-input terms apply, dominated otherwise),
+so the solver could attach the energy-balance shadow price to the copy the app
+never reads and the Duals view showed 0 instead of the real value. The twin was
+removed; this guards against it being reintroduced, e.g. by an upstream sync.
+"""
+
+from pathlib import Path
+
+MODEL = Path(__file__).resolve().parents[1] / "WebAPP" / "SOLVERs" / "model.v.5.4.txt"
+
+
+def test_model_file_has_no_redundant_ebb4_twin():
+    model = MODEL.read_text()
+    # The variant the app reads shadow prices from must exist...
+    assert "s.t. EBb4_EnergyBalanceEachYear4_ICR" in model
+    # ...and the redundant plain twin must not come back.
+    assert "\ns.t. EBb4_EnergyBalanceEachYear4{" not in model


### PR DESCRIPTION
The app was showing a shadow price of 0 for some energy-balance constraints when the real value was large. Cause: the model file contained two copies of the same energy-balance rule, and the solver can attach the shadow price to either copy — it usually picked the one the app never reads.

Fix: remove the duplicate. This cannot change model results, because the removed rule is fully covered by the one that stays. Verified on the demo and on two full Philippines calibrations (v12 and vIS1.2): identical total cost, and the shadow prices now land on the constraint the app reports. A small test keeps the duplicate from coming back.