### PR TITLE
Make CLEWS runs repeatable

### DIFF
--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -1758,15 +1758,22 @@ class DataFile(Osemosys):
             data_itnc = data['InputToNewCapacityRatio']
             data_ittc = data['InputToTotalCapacityRatio']
                             
-            data_out = list(set(data_out))
-            data_inp = list(set(data_inp))
-            data_all = list(set(data_all))
-            data_emi = list(set(data_emi))
-            data_emichange = list(set(data_emichange))
-            data_tts = list(set(data_tts))
-            data_tfs = list(set(data_tfs))
-            data_itnc = list(set(data_itnc))
-            data_ittc = list(set(data_ittc))
+            # Deterministic de-duplication: preserve first-seen order (the order the
+            # rows were parsed from the data file) instead of hash-set order.
+            # list(set(...)) reorders by hash, which Python randomizes per process
+            # (PYTHONHASHSEED) -> a differently ordered LP -> the solver returns a
+            # different (equally optimal, same-cost) solution on each run. dict.fromkeys
+            # keeps insertion order, so the LP and results are stable no matter how the
+            # run is launched (web UI, direct python, MUIOGO-AI over HTTP).
+            data_out = list(dict.fromkeys(data_out))
+            data_inp = list(dict.fromkeys(data_inp))
+            data_all = list(dict.fromkeys(data_all))
+            data_emi = list(dict.fromkeys(data_emi))
+            data_emichange = list(dict.fromkeys(data_emichange))
+            data_tts = list(dict.fromkeys(data_tts))
+            data_tfs = list(dict.fromkeys(data_tfs))
+            data_itnc = list(dict.fromkeys(data_itnc))
+            data_ittc = list(dict.fromkeys(data_ittc))
 
             dict_out = defaultdict(list)
             dict_inp = defaultdict(list)


### PR DESCRIPTION
Running the same case twice used to give slightly different numbers. The model often has several equally good answers (all with the same total cost), and the code was handing the rows to the solver in a random order each run, so the solver picked a different one each time. This fixes the order, so the same inputs now give the same results every run — however the app is started, including over the web API.

This is the reproducibility half of #529, resubmitted on its own after the revert in #531. The review there agreed with this part; the objections were to the bundled speedup, which will come back as its own PR with the review's fixes built in.

One thing to know: because runs now repeat exactly, the first re-run of an old case can show a different detailed mix than a run saved under the old random order — the total cost is unchanged. Stored results that were never re-solved under the new ordering (the promoted Philippines v22 scenarios, for example) should be re-run once before their numbers are treated as reproducible.

Tested: all 82 tests pass, and solving the demo case twice across server restarts produces byte-identical results — it didn't before.