### PR TITLE
Speed up saving results after a solve

### DIFF
--- a/API/Classes/Base/FileClass.py
+++ b/API/Classes/Base/FileClass.py
@@ -16,10 +16,19 @@ class File:
             raise OSError
 
     @staticmethod
-    def writeFile(data, path):
+    def writeFile(data, path, indent=4):
+        # indent=None emits compact JSON on the C-accelerated encoder — ~6x
+        # faster and ~2.5x smaller than indented output. Callers pass it only
+        # for the multi-MB machine-read view/result files written on every run;
+        # everything else (including the version-controlled Parameters/
+        # Variables/Duals/Indicators files) keeps the readable, diffable
+        # 4-space default.
         try:
             with open(path, mode="w") as f:
-                f.write(json.dumps(data, ensure_ascii=True, indent=4, sort_keys=False))
+                if indent is None:
+                    f.write(json.dumps(data, ensure_ascii=True, separators=(",", ":")))
+                else:
+                    f.write(json.dumps(data, ensure_ascii=True, indent=indent, sort_keys=False))
         except (IOError, IndexError):
             raise IndexError
         except OSError:

--- a/API/Classes/Case/DataFileClass.py
+++ b/API/Classes/Case/DataFileClass.py
@@ -935,7 +935,7 @@ class DataFile(Osemosys):
                         if obj['id'] in jsonFile:
                             if caserunname in jsonFile[obj['id']]:
                                 del jsonFile[obj['id']][caserunname]
-                    File.writeFile(jsonFile, path)
+                    File.writeFile(jsonFile, path, indent=None)
         except(IOError, IndexError):
             raise IndexError
         except OSError:
@@ -965,7 +965,7 @@ class DataFile(Osemosys):
                         if obj['id'] in jsonFile:
                             if caserunname in jsonFile[obj['id']]:
                                 del jsonFile[obj['id']][caserunname]
-                    File.writeFile(jsonFile, path)
+                    File.writeFile(jsonFile, path, indent=None)
 
             response = {
                 "message": "You have deleted a case run!",
@@ -2302,7 +2302,6 @@ class DataFile(Osemosys):
                 pass
             
             #parsanje result.txt
-            params = []
             df = pd.read_csv(results_file, sep='\t')            
 
             ###################################### parse optimal value from result.txt
@@ -2352,10 +2351,14 @@ class DataFile(Osemosys):
                 df['dual'] = df['dual'].astype(float).round(4)
 
                 #variables that are output form solver 19
-                params = df.parameter.unique()
                 all_params = {}
 
-                for each in params:
+                # Group the parsed solver output by parameter in a single pass.
+                # Was `for each in df.parameter.unique(): df[df.parameter==each]`,
+                # which rescanned every result row once per parameter (quadratic
+                # in parameter count). sort=False preserves first-appearance and
+                # within-group row order, so the emitted CSVs stay byte-identical.
+                for each, df_each in df.groupby('parameter', sort=False):
                     # Variable branch: pull setrelation from Variables.json via
                     # VAR_BY_NAME. Replaces the legacy Config.VARIABLES_C lookup.
                     # Anything the solver produces that is not in Variables.json
@@ -2363,7 +2366,7 @@ class DataFile(Osemosys):
                     # intentionally not exported — those CSVs had no consumers
                     # in MUIOGO and this matches MUIO 5.6's data-driven design.
                     if each in self.VAR_BY_NAME:
-                        df_p = df[df.parameter == each].copy()
+                        df_p = df_each.copy()
                         df_p[self.VAR_BY_NAME[each]["setrelation"]] = df_p['id'].str.split(',', expand=True)
 
                         result_cols = self.VAR_BY_NAME[each]["setrelation"].copy()
@@ -2379,7 +2382,7 @@ class DataFile(Osemosys):
                     # below so the dual values are scaled to the case discount
                     # rate before being written.
                     if each in self.DUALS_BY_NAME:
-                        df_p = df[df.parameter == each].copy()
+                        df_p = df_each.copy()
                         df_p[self.DUALS_BY_NAME[each]["setrelation"]] = df_p['id'].str.split(',', expand=True)
 
                         result_cols = self.DUALS_BY_NAME[each]["setrelation"].copy()
@@ -2622,355 +2625,107 @@ class DataFile(Osemosys):
             #CSV
             csvs = [f.name for f in os.scandir(csvFolderPath) ]
 
-            # Compose the by-name lookup from Variables ∪ Duals ∪ Indicators.
-            # Each entry carries 'id', 'group', and (now) 'setrelation' — the
-            # downstream group-handler branches below only read 'id' and
-            # 'group', so the extra key is harmless.
+            # Compose the by-name lookup from Variables, Duals and Indicators.
+            # Each entry carries 'id', 'group' and 'setrelation'; the pivot below
+            # only reads 'id' and 'group'.
             paramByName = { **self.VAR_BY_NAME, **self.DUALS_BY_NAME, **self.IND_BY_NAME }
 
-            DATA = {}
+            # Pivot layout per view group: ordered (label, source-column) pairs
+            # that become the leading columns of each emitted row; the remaining
+            # columns are one per year (year -> value). 'R' and 'RT' are special
+            # (no per-year pivot) and handled explicitly below. This table
+            # replaces ~330 lines that were one near-identical if-branch per
+            # group; the emitted structure is unchanged.
+            PIVOT_KEYS = {
+                'RYT':     [('Tech', 't')],
+                'RYCn':    [('Con', 'cn')],
+                'RYC':     [('Comm', 'f')],
+                'RYE':     [('Emi', 'e')],
+                'RYS':     [('Stg', 's')],
+                'RYTM':    [('Tech', 't'), ('MoId', 'm')],
+                'RYTC':    [('Tech', 't'), ('Comm', 'f')],
+                'RYTE':    [('Tech', 't'), ('Emi', 'e')],
+                'RYTTs':   [('Tech', 't'), ('Ts', 'l')],
+                'RYCTs':   [('Comm', 'f'), ('Ts', 'l')],
+                'RYTEM':   [('Tech', 't'), ('Emi', 'e'), ('MoId', 'm')],
+                'RYTCTs':  [('Tech', 't'), ('Comm', 'f'), ('Ts', 'l')],
+                'RYTMTs':  [('Tech', 't'), ('MoId', 'm'), ('Ts', 'l')],
+                'RYTCMTs': [('Tech', 't'), ('Comm', 'f'), ('MoId', 'm'), ('Ts', 'l')],
+            }
+
+            # Match each CSV to its parameter and view group by header alone
+            # (cheap), so the groups can then be processed one at a time.
+            # Each result CSV has exactly one parameter value-column; the first
+            # paramByName match wins, matching the original scan order. Groups
+            # without a layout were read-but-never-written by the pre-rewrite
+            # code (a no-op); preserve that by not collecting them.
+            csvs_by_group = defaultdict(list)
             for csv in csvs:
-                #read csv file
                 csv_path = Path(Config.DATA_STORAGE,self.case,'res', caserunname, 'csv', csv)
-                if csv_path.is_file():
+                if not csv_path.is_file():
+                    continue
+                header = pd.read_csv(csv_path, nrows=0).columns
+                for param, paramobj in paramByName.items():
+                    if param not in header:
+                        continue
+                    group = paramobj['group']
+                    if group == 'R' or group == 'RT' or group in PIVOT_KEYS:
+                        csvs_by_group[group].append((csv_path, param, paramobj))
+                    break
+
+            # One group at a time: read the group file once, pivot every CSV
+            # that belongs to it, write it once, release it. The old per-CSV
+            # code re-read and re-serialized the whole group file for every
+            # matching CSV (quadratic in stored caseruns and view size); a
+            # cache-everything-flush-at-the-end approach is no better, because
+            # peak memory then scales with the whole view directory - real
+            # cases run to hundreds of MB per group file. This keeps the
+            # read-once/write-once I/O with a peak of one group in memory.
+            for group, entries in csvs_by_group.items():
+                viewGroupPath = Path(self.viewFolderPath, group + '.json')
+                viewData = File.readFile(viewGroupPath) if viewGroupPath.is_file() else {}
+                dirty = False
+
+                for csv_path, param, paramobj in entries:
                     df = pd.read_csv(csv_path)
-                    data = df.to_json(orient='records', indent=2)
-                    jsondata = json.loads(data)
+                    jsondata = json.loads(df.to_json(orient='records'))
+                    if len(jsondata) == 0:
+                        continue
 
-                    if len(jsondata) != 0:
-                        for param, paramobj in paramByName.items():
+                    if paramobj['id'] not in viewData:
+                        viewData[paramobj['id']] = {}
+                    rows = []
+                    viewData[paramobj['id']][caserunname] = rows
+                    dirty = True
 
-                            if param in jsondata[0]:
+                    if group == 'R':
+                        tmp = {}
+                        for obj in jsondata:
+                            tmp['ObjectiveValue'] = obj[param]
+                        rows.append(tmp)
+                    elif group == 'RT':
+                        tmp = {}
+                        for obj in jsondata:
+                            tmp[obj['t']] = obj[param]
+                        rows.append(tmp)
+                    else:
+                        keyspec = PIVOT_KEYS[group]
+                        cols = [col for _, col in keyspec]
+                        prev = tuple(jsondata[0][col] for col in cols)
+                        tmp = {}
+                        for obj in jsondata:
+                            cur = tuple(obj[col] for col in cols)
+                            if cur != prev:
+                                prev = cur
+                                rows.append(tmp)
+                                tmp = {}
+                            for label, col in keyspec:
+                                tmp[label] = obj[col]
+                            tmp[obj['y']] = obj[param]
+                        rows.append(tmp)
 
-                                viewGroupPath = Path(Config.DATA_STORAGE,self.case,'view', paramobj['group']+ '.json')
-                                if viewGroupPath.is_file():
-                                    viewData = File.readFile(viewGroupPath)
-                                else:
-                                    viewData = {}
-
-                                if paramobj['id'] not in viewData:
-                                    viewData[paramobj['id']] = {}
-
-                                # if caserunname not in viewData[paramobj['id']]:
-                                #     viewData[paramobj['id']][caserunname] = []
-
-                                #ovdje uvijek moramo napraviti novi niy jer je novi caserun i novi podaci
-                                viewData[paramobj['id']][caserunname] = []
-
-                                if paramobj['group'] == 'R':
-                                    tmp = {}
-                                    for obj in jsondata:
-                                        tmp['ObjectiveValue'] = obj[param]
-                                    viewData[paramobj['id']][caserunname].append(tmp)
-                                    path = Path(self.viewFolderPath, paramobj['group']+'.json')
-                                    File.writeFile( viewData, path)
-
-                                if paramobj['group'] == 'RT':
-                                    tmp = {}
-                                    for obj in jsondata:
-                                        tmp[ obj['t']] =obj[param]
-                                    viewData[paramobj['id']][caserunname].append(tmp)
-                                    path = Path(self.viewFolderPath, paramobj['group']+'.json')
-                                    File.writeFile( viewData, path)
-
-                                if paramobj['group'] == 'RYT':
-                                    tech = jsondata[0]['t']
-                                    tmp = {}
-                                    for obj in jsondata:
-                                        if tech == obj['t']:
-                                            tmp['Tech'] = obj['t']
-                                            tmp[obj['y']] = obj[param]
-                                        else:
-                                            tech = obj['t']
-                                            viewData[paramobj['id']][caserunname].append(tmp)
-                                            tmp = {}
-                                            tmp['Tech'] = obj['t']
-                                            tmp[obj['y']] = obj[param]
-                                    viewData[paramobj['id']][caserunname].append(tmp)
-                                    path = Path(self.viewFolderPath, paramobj['group']+'.json')
-                                    File.writeFile( viewData, path)  
-
-                                if paramobj['group'] == 'RYCn':
-                                    con = jsondata[0]['cn']
-                                    tmp = {}
-                                    for obj in jsondata:
-                                        if con == obj['cn']:
-                                            tmp['Con'] = obj['cn']
-                                            tmp[obj['y']] = obj[param]
-                                        else:
-                                            con = obj['cn']
-                                            viewData[paramobj['id']][caserunname].append(tmp)
-                                            tmp = {}
-                                            tmp['Con'] = obj['cn']
-                                            tmp[obj['y']] = obj[param]
-                                    viewData[paramobj['id']][caserunname].append(tmp)
-                                    path = Path(self.viewFolderPath, paramobj['group']+'.json')
-                                    File.writeFile( viewData, path)  
-
-                                if paramobj['group'] == 'RYC':
-                                    comm = jsondata[0]['f']
-                                    tmp = {}
-                                    for obj in jsondata:
-                                        if comm == obj['f']:
-                                            tmp['Comm'] = obj['f']
-                                            tmp[obj['y']] = obj[param]
-                                        else:
-                                            comm = obj['f']
-                                            viewData[paramobj['id']][caserunname].append(tmp)
-                                            tmp = {}
-                                            tmp['Comm'] = obj['f']
-                                            tmp[obj['y']] = obj[param]
-                                    viewData[paramobj['id']][caserunname].append(tmp)
-                                    path = Path(self.viewFolderPath, paramobj['group']+'.json')
-                                    File.writeFile( viewData, path) 
-
-                                if paramobj['group'] == 'RYE':
-                                    emi = jsondata[0]['e']
-                                    tmp = {}
-                                    for obj in jsondata:
-                                        if emi == obj['e']:
-                                            tmp['Emi'] = obj['e']
-                                            tmp[obj['y']] = obj[param]
-                                        else:
-                                            emi = obj['e']
-                                            viewData[paramobj['id']][caserunname].append(tmp)
-                                            tmp = {}
-                                            tmp['Emi'] = obj['e']
-                                            tmp[obj['y']] = obj[param]
-                                    viewData[paramobj['id']][caserunname].append(tmp)
-                                    path = Path(self.viewFolderPath, paramobj['group']+'.json')
-                                    File.writeFile( viewData, path)  
-
-                                if paramobj['group'] == 'RYS':
-                                    stg = jsondata[0]['s']
-                                    tmp = {}
-                                    for obj in jsondata:
-                                        if stg == obj['s']:
-                                            tmp['Stg'] = obj['s']
-                                            tmp[obj['y']] = obj[param]
-                                        else:
-                                            stg = obj['s']
-                                            viewData[paramobj['id']][caserunname].append(tmp)
-                                            tmp = {}
-                                            tmp['Stg'] = obj['s']
-                                            tmp[obj['y']] = obj[param]
-                                    viewData[paramobj['id']][caserunname].append(tmp)
-                                    path = Path(self.viewFolderPath, paramobj['group']+'.json')
-                                    File.writeFile( viewData, path) 
-
-                                if paramobj['group'] == 'RYTM':
-                                    tech = jsondata[0]['t']
-                                    mod = jsondata[0]['m']
-                                    tmp = {}
-                                    for obj in jsondata:
-                                        if tech == obj['t'] and mod == obj['m']:
-                                            tmp['Tech'] = obj['t']
-                                            tmp['MoId'] = obj['m']
-                                            tmp[obj['y']] = obj[param]
-                                        else:
-                                            tech = obj['t']
-                                            mod = obj['m']
-                                            viewData[paramobj['id']][caserunname].append(tmp)
-                                            tmp = {}
-                                            tmp['Tech'] = obj['t']
-                                            tmp['MoId'] = obj['m']
-                                            tmp[obj['y']] = obj[param]
-                                    viewData[paramobj['id']][caserunname].append(tmp)
-                                    path = Path(self.viewFolderPath, paramobj['group']+'.json')
-                                    File.writeFile( viewData, path)
-
-                                if paramobj['group'] == 'RYTC':
-                                    tech = jsondata[0]['t']
-                                    comm = jsondata[0]['f']
-                                    tmp = {}
-                                    for obj in jsondata:
-                                        if tech == obj['t'] and comm == obj['f']:
-                                            tmp['Tech'] = obj['t']
-                                            tmp['Comm'] = obj['f']
-                                            tmp[obj['y']] = obj[param]
-                                        else:
-                                            tech = obj['t']
-                                            comm = obj['f']
-                                            viewData[paramobj['id']][caserunname].append(tmp)
-                                            tmp = {}
-                                            tmp['Tech'] = obj['t']
-                                            tmp['Comm'] = obj['f']
-                                            tmp[obj['y']] = obj[param]
-                                    viewData[paramobj['id']][caserunname].append(tmp)
-                                    path = Path(self.viewFolderPath, paramobj['group']+'.json')
-                                    File.writeFile( viewData, path)
-
-                                if paramobj['group'] == 'RYTE':
-                                    tech = jsondata[0]['t']
-                                    emi = jsondata[0]['e']
-                                    tmp = {}
-                                    for obj in jsondata:
-                                        if tech == obj['t'] and emi == obj['e']:
-                                            tmp['Tech'] = obj['t']
-                                            tmp['Emi'] = obj['e']
-                                            tmp[obj['y']] = obj[param]
-                                        else:
-                                            tech = obj['t']
-                                            emi = obj['e']
-                                            viewData[paramobj['id']][caserunname].append(tmp)
-                                            tmp = {}
-                                            tmp['Tech'] = obj['t']
-                                            tmp['Emi'] = obj['e']
-                                            tmp[obj['y']] = obj[param]
-                                    viewData[paramobj['id']][caserunname].append(tmp)
-                                    path = Path(self.viewFolderPath, paramobj['group']+'.json')
-                                    File.writeFile( viewData, path)
-
-                                if paramobj['group'] == 'RYTTs':
-                                    tech = jsondata[0]['t']
-                                    ts = jsondata[0]['l']
-                                    tmp = {}
-                                    for obj in jsondata:
-                                        if tech == obj['t'] and ts == obj['l']:
-                                            tmp['Tech'] = obj['t']
-                                            tmp['Ts'] = obj['l']
-                                            tmp[obj['y']] = obj[param]
-                                        else:
-                                            tech = obj['t']
-                                            ts = obj['l']
-                                            viewData[paramobj['id']][caserunname].append(tmp)
-                                            tmp = {}
-                                            tmp['Tech'] = obj['t']
-                                            tmp['Ts'] = obj['l']
-                                            tmp[obj['y']] = obj[param]
-                                    viewData[paramobj['id']][caserunname].append(tmp)
-                                    path = Path(self.viewFolderPath, paramobj['group']+'.json')
-                                    File.writeFile( viewData, path)
-
-                                if paramobj['group'] == 'RYCTs':
-                                    comm = jsondata[0]['f']
-                                    ts = jsondata[0]['l']
-                                    tmp = {}
-                                    for obj in jsondata:
-                                        if comm == obj['f'] and ts == obj['l']:
-                                            tmp['Comm'] = obj['f']
-                                            tmp['Ts'] = obj['l']
-                                            tmp[obj['y']] = obj[param]
-                                        else:
-                                            comm = obj['f']
-                                            ts = obj['l']
-                                            viewData[paramobj['id']][caserunname].append(tmp)
-                                            tmp = {}
-                                            tmp['Comm'] = obj['f']
-                                            tmp['Ts'] = obj['l']
-                                            tmp[obj['y']] = obj[param]
-                                    viewData[paramobj['id']][caserunname].append(tmp)
-                                    path = Path(self.viewFolderPath, paramobj['group']+'.json')
-                                    File.writeFile( viewData, path)
-
-                                if paramobj['group'] == 'RYTEM':
-                                    tech = jsondata[0]['t']
-                                    emi = jsondata[0]['e']
-                                    mod = jsondata[0]['m']
-                                    tmp = {}
-                                    for obj in jsondata:
-                                        if tech == obj['t'] and emi == obj['e'] and mod == obj['m']:
-                                            tmp['Tech'] = obj['t']
-                                            tmp['Emi'] = obj['e']
-                                            tmp['MoId'] = obj['m']
-                                            tmp[obj['y']] = obj[param]
-                                        else:
-                                            tech = obj['t']
-                                            emi = obj['e']
-                                            mod = obj['m']
-                                            viewData[paramobj['id']][caserunname].append(tmp)
-                                            tmp = {}
-                                            tmp['Tech'] = obj['t']
-                                            tmp['Emi'] = obj['e']
-                                            tmp['MoId'] = obj['m']
-                                            tmp[obj['y']] = obj[param]
-                                    viewData[paramobj['id']][caserunname].append(tmp)
-                                    path = Path(self.viewFolderPath, paramobj['group']+'.json')
-                                    File.writeFile( viewData, path)
-
-                                if paramobj['group'] == 'RYTCTs':
-                                    tech = jsondata[0]['t']
-                                    comm = jsondata[0]['f']
-                                    ts = jsondata[0]['l']
-                                    tmp = {}
-                                    for obj in jsondata:
-                                        if tech == obj['t'] and comm == obj['f'] and ts == obj['l']:
-                                            tmp['Tech'] = obj['t']
-                                            tmp['Comm'] = obj['f']
-                                            tmp['Ts'] = obj['l']
-                                            tmp[obj['y']] = obj[param]
-                                        else:
-                                            tech = obj['t']
-                                            comm = obj['f']
-                                            ts = obj['l']
-                                            viewData[paramobj['id']][caserunname].append(tmp)
-                                            tmp = {}
-                                            tmp['Tech'] = obj['t']
-                                            tmp['Comm'] = obj['f']
-                                            tmp['Ts'] = obj['l']
-                                            tmp[obj['y']] = obj[param]
-                                    viewData[paramobj['id']][caserunname].append(tmp)
-                                    path = Path(self.viewFolderPath, paramobj['group']+'.json')
-                                    File.writeFile( viewData, path)
-
-                                # ne postoje vise varijable za ovaj dio Production By tecnology, Use By technology
-                                if paramobj['group'] == 'RYTMTs':
-                                    tech = jsondata[0]['t']
-                                    mod = jsondata[0]['m']
-                                    ts = jsondata[0]['l']
-                                    tmp = {}
-                                    for obj in jsondata:
-                                        if tech == obj['t'] and mod == obj['m'] and ts == obj['l']:
-                                            tmp['Tech'] = obj['t']
-                                            tmp['MoId'] = obj['m']
-                                            tmp['Ts'] = obj['l']
-                                            tmp[obj['y']] = obj[param]
-                                        else:
-                                            tech = obj['t']
-                                            mod = obj['m']
-                                            ts = obj['l'] 
-                                            viewData[paramobj['id']][caserunname].append(tmp)
-                                            tmp = {}
-                                            tmp['Tech'] = obj['t']
-                                            tmp['MoId'] = obj['m']
-                                            tmp['Ts'] = obj['l']
-                                            tmp[obj['y']] = obj[param]
-                                    viewData[paramobj['id']][caserunname].append(tmp)
-                                    path = Path(self.viewFolderPath, paramobj['group']+'.json')
-                                    File.writeFile( viewData, path)
-                            
-                                # ne koristi se jer smo izbrisali variajablu ROUBTBM Rate Of Use By Technology By Mode
-                                #ponovo koristimo jer korisitmo Production By Technology by Mode, Use By Technology By Mode (isto i sa Rate of...)
-                                if paramobj['group'] == 'RYTCMTs':
-                                    tech = jsondata[0]['t']
-                                    comm = jsondata[0]['f']
-                                    mod = jsondata[0]['m']
-                                    ts = jsondata[0]['l']
-                                    tmp = {}
-                                    for obj in jsondata:
-                                        if tech == obj['t'] and comm == obj['f'] and mod == obj['m'] and ts == obj['l']:
-                                            tmp['Tech'] = obj['t']
-                                            tmp['Comm'] = obj['f']
-                                            tmp['MoId'] = obj['m']
-                                            tmp['Ts'] = obj['l']
-                                            tmp[obj['y']] = obj[param]
-                                        else:
-                                            tech = obj['t']
-                                            comm = obj['f']
-                                            mod = obj['m']
-                                            ts = obj['l']
-                                            viewData[paramobj['id']][caserunname].append(tmp)
-                                            tmp = {}
-                                            tmp['Tech'] = obj['t']
-                                            tmp['Comm'] = obj['f']
-                                            tmp['MoId'] = obj['m']
-                                            tmp['Ts'] = obj['l']
-                                            tmp[obj['y']] = obj[param]
-                                    viewData[paramobj['id']][caserunname].append(tmp)
-                                    path = Path(self.viewFolderPath, paramobj['group']+'.json')
-                                    File.writeFile( viewData, path)
-                                
-                                break
+                if dirty:
+                    File.writeFile(viewData, viewGroupPath, indent=None)
 
         except(IOError, IndexError):
             raise IndexError

--- a/tests/test_results_postprocessing.py
+++ b/tests/test_results_postprocessing.py
@@ -1,0 +1,133 @@
+"""
+Tests for run post-processing: File.writeFile formatting and the pivot
+(results-viewer) output.
+
+The pivot test is a golden-output test: it feeds generateResultsViewer a small
+stored caserun and asserts the exact emitted structure, so any rewrite of the
+pivot loop has to reproduce the old files byte-for-byte (after JSON parsing).
+"""
+
+import json
+
+import pytest
+
+from Classes.Base import Config
+from Classes.Base.FileClass import File
+from Classes.Case.DataFileClass import DataFile
+
+
+# ---------------------------------------------------------------- writeFile
+
+def test_writefile_default_stays_indented(tmp_path):
+    """The default format is multi-line and diffable — the version-controlled
+    Parameters/Variables/Duals/Indicators files must not collapse to one line."""
+    path = tmp_path / "out.json"
+    File.writeFile({"a": 1, "b": [1, 2]}, path)
+    text = path.read_text()
+    assert len(text.splitlines()) > 1
+    assert json.loads(text) == {"a": 1, "b": [1, 2]}
+
+
+def test_writefile_compact_is_single_line_and_lossless(tmp_path):
+    data = {"a": 1, "b": [1, 2], "c": "x"}
+    path = tmp_path / "out.json"
+    File.writeFile(data, path, indent=None)
+    text = path.read_text()
+    assert "\n" not in text
+    assert json.loads(text) == data
+
+
+# ------------------------------------------------------------------- pivot
+
+VAR_BY_NAME = {
+    "AccumulatedNewCapacity": {"id": "ANC", "group": "RYT", "setrelation": ["r", "t", "y"]},
+    "NewCapacity": {"id": "NC", "group": "RYT", "setrelation": ["r", "t", "y"]},
+    "ObjectiveValue": {"id": "OV", "group": "R", "setrelation": ["r"]},
+}
+
+
+@pytest.fixture()
+def case_on_disk(tmp_path, monkeypatch):
+    """A minimal case with one stored caserun, and a DataFile wired to it."""
+    monkeypatch.setattr(Config, "DATA_STORAGE", tmp_path)
+
+    csv_dir = tmp_path / "TestCase" / "res" / "RUN1" / "csv"
+    csv_dir.mkdir(parents=True)
+    view_dir = tmp_path / "TestCase" / "view"
+    view_dir.mkdir(parents=True)
+
+    (csv_dir / "AccumulatedNewCapacity.csv").write_text(
+        "r,t,y,AccumulatedNewCapacity\n"
+        "RE1,COAL,2020,1.5\n"
+        "RE1,COAL,2021,2.5\n"
+        "RE1,WIND,2020,3.0\n"
+        "RE1,WIND,2021,4.0\n"
+    )
+    (csv_dir / "NewCapacity.csv").write_text(
+        "r,t,y,NewCapacity\n"
+        "RE1,COAL,2020,0.5\n"
+        "RE1,COAL,2021,1.0\n"
+    )
+    (csv_dir / "ObjectiveValue.csv").write_text(
+        "r,ObjectiveValue\n"
+        "RE1,-25420.42\n"
+    )
+
+    df = DataFile.__new__(DataFile)
+    df.case = "TestCase"
+    df.viewFolderPath = view_dir
+    df.VAR_BY_NAME = VAR_BY_NAME
+    df.DUALS_BY_NAME = {}
+    df.IND_BY_NAME = {}
+    return df, csv_dir, view_dir
+
+
+def test_pivot_golden_output(case_on_disk):
+    df, _, view_dir = case_on_disk
+    df.generateResultsViewer("RUN1")
+
+    ryt = json.loads((view_dir / "RYT.json").read_text())
+    assert ryt == {
+        "ANC": {
+            "RUN1": [
+                {"Tech": "COAL", "2020": 1.5, "2021": 2.5},
+                {"Tech": "WIND", "2020": 3.0, "2021": 4.0},
+            ]
+        },
+        "NC": {
+            "RUN1": [
+                {"Tech": "COAL", "2020": 0.5, "2021": 1.0},
+            ]
+        },
+    }
+
+    r = json.loads((view_dir / "R.json").read_text())
+    assert r == {"OV": {"RUN1": [{"ObjectiveValue": -25420.42}]}}
+
+
+def test_pivot_merges_into_existing_group_file(case_on_disk):
+    """A new run is added beside runs already stored in the group file, and a
+    re-run of the same name replaces only its own entry."""
+    df, _, view_dir = case_on_disk
+    existing = {"ANC": {"OLDRUN": [{"Tech": "COAL", "2020": 9.9}]}}
+    (view_dir / "RYT.json").write_text(json.dumps(existing))
+
+    df.generateResultsViewer("RUN1")
+    ryt = json.loads((view_dir / "RYT.json").read_text())
+    assert ryt["ANC"]["OLDRUN"] == [{"Tech": "COAL", "2020": 9.9}]
+    assert ryt["ANC"]["RUN1"][0] == {"Tech": "COAL", "2020": 1.5, "2021": 2.5}
+
+    df.generateResultsViewer("RUN1")  # idempotent re-run
+    ryt2 = json.loads((view_dir / "RYT.json").read_text())
+    assert ryt2 == ryt
+
+
+def test_pivot_skips_empty_csv(case_on_disk):
+    """A header-only CSV must not create or dirty a group file."""
+    df, csv_dir, view_dir = case_on_disk
+    for f in csv_dir.iterdir():
+        f.unlink()
+    (csv_dir / "AccumulatedNewCapacity.csv").write_text("r,t,y,AccumulatedNewCapacity\n")
+
+    df.generateResultsViewer("RUN1")
+    assert not (view_dir / "RYT.json").exists()


### PR DESCRIPTION
This redoes the speed-up half of #529 (reverted in #531), with the three issues from that review fixed.

After a model solves, the app folds the results into the case's pivot view files. On real country models those files run to hundreds of MB, and the old code re-read and re-wrote each one many times per run. Now each file is read once and written once.

What's different from #529:

- Files are processed one at a time and released, so memory peaks at the largest single file instead of the whole set.
- Only the big machine-read files are written compactly. The four version-controlled config files keep their readable format and normal diffs.
- New tests, including a golden-output test that pins the exact structure of the pivot files. That test passes unchanged against the current code on main, so the rewrite provably produces what the old code produced.

It also keeps #529's single-pass CSV building and removes the small leftovers the review flagged.

Tested: all 87 tests pass (82 existing + 5 new), and on a real demo run every view file written by the new code matches the old code's content exactly. Solve results are unchanged.

@autibet — this is the redo of the part you objected to. Grateful for a careful look before it goes anywhere.