### PR TITLE
Add a CLEWs install page: see and install country models from their repositories

### DIFF
--- a/API/Classes/Base/Config.py
+++ b/API/Classes/Base/Config.py
@@ -146,12 +146,16 @@ CLEWS_DOWNLOADS_DIR = CLEWS_DATA_STORAGE / "downloads"
 CLEWS_REGISTRY_BASENAME = ".clews_registry.json"
 
 # The CLEWs country register: the CLEWs mirror of the OG installer's repos.json,
-# listing country repos that ship portable MUIO cases. There is no public hub for
-# CLEWs country models yet, so this defaults to unset -- the catalogue endpoint
-# then reports source "none" and users install by Git URL or local path. Point it
-# at a raw JSON URL ({"schema_version": 1, "repos": [{key, owner, repo, iso3,
-# description}, ...]}) when a register exists.
-CLEWS_CATALOG_URL = os.environ.get("MUIOGO_CLEWS_CATALOG_URL", "").strip()
+# listing country repos that ship portable MUIO cases. MUIOGO ships it as
+# scripts/clews-repos.json and reads it from the main branch, so adding a country
+# there is enough for every installation to offer it (the same way OG-Core's
+# register is read from its repository). The env override points tests and
+# offline runs at another URL, a file:// one included; an empty override is
+# honoured as "no register" and the catalogue reports source "none".
+CLEWS_CATALOG_URL = os.environ.get(
+    "MUIOGO_CLEWS_CATALOG_URL",
+    "https://raw.githubusercontent.com/EAPD-DRB/MUIOGO/main/scripts/clews-repos.json",
+).strip()
 CLEWS_CATALOG_CACHE = CLEWS_DATA_STORAGE / "catalog_cache.json"
 
 # Where the installer's machine-readable catalogue and scripts are fetched from.

--- a/API/Classes/Clews/ClewsInstaller.py
+++ b/API/Classes/Clews/ClewsInstaller.py
@@ -81,6 +81,7 @@ class ClewsInstaller:
                 "dir": v["dir"],
                 "muio_min_version": v.get("muio_min_version"),
                 "version_gate": version_gate(v),
+                "last_changed": v.get("last_changed"),
                 "cases": [],
             }
             for c in v["cases"]:
@@ -98,6 +99,12 @@ class ClewsInstaller:
             "name": manifest["name"],
             "og": manifest.get("og"),
             "source": source.describe(),
+            # discovered: the repository has no clews-country.json and this
+            # menu was read from its layout; ordering says how the versions
+            # were put newest-first ("date" from the commit history, "name"
+            # when dates were not available)
+            "discovered": bool(manifest.get("discovered")),
+            "ordering": manifest.get("ordering", "manifest"),
             "muio_version": CURRENT_CASE_VERSION,
             "accepted_case_versions": list(ACCEPTED_CASE_VERSIONS),
             "vintages": vintages,

--- a/API/Classes/Clews/CountryCatalog.py
+++ b/API/Classes/Clews/CountryCatalog.py
@@ -1,10 +1,10 @@
-"""Reflect a CLEWs country register, when one is configured.
+"""Reflect the CLEWs country register.
 
-MUIOGO does not maintain its own list of CLEWs country models. If a register URL
-is configured (Config.CLEWS_CATALOG_URL), it is read live on every call and the
-last good copy cached as an offline fallback -- exactly the OG CalibrationCatalog
-pattern. With no register configured (the default: no public CLEWs hub exists
-yet), the catalogue is honestly empty and installs go by Git URL or local path.
+The register (Config.CLEWS_CATALOG_URL, by default MUIOGO's own
+scripts/clews-repos.json read from the main branch) is read live on every call
+and the last good copy cached as an offline fallback -- exactly the OG
+CalibrationCatalog pattern. With the URL emptied out, the catalogue is honestly
+empty and installs go by Git URL or local path.
 
 Register shape (schema_version 1):
     { "schema_version": 1,

--- a/API/Classes/Clews/CountryManifest.py
+++ b/API/Classes/Clews/CountryManifest.py
@@ -49,6 +49,10 @@ class ManifestError(ValueError):
     """The manifest is missing, unreadable, or does not validate."""
 
 
+class ManifestNotFound(ManifestError):
+    """A file the source was asked for does not exist (a 404, or no such file)."""
+
+
 def parse_github_url(repo_url):
     """(owner, repo) from a GitHub repo URL, or None if it is not one."""
     if not repo_url:
@@ -184,11 +188,16 @@ class CountrySource:
     source_type "local_path": reads the same layout from a directory on disk.
     """
 
-    def __init__(self, *, source_type, repo_url=None, ref=None, local_path=None):
+    def __init__(self, *, source_type, repo_url=None, ref=None, local_path=None,
+                 iso3=None, name=None):
         self.source_type = source_type
         self.repo_url = repo_url
         self.ref = ref or "main"
         self.local_path = local_path
+        # what the register says about this repository; used when the
+        # repository has no manifest and its models are discovered instead
+        self.hint_iso3 = iso3
+        self.hint_name = name
         if source_type == "repo_url":
             parsed = parse_github_url(repo_url)
             if not parsed:
@@ -208,13 +217,13 @@ class CountrySource:
         if self.source_type == "local_path":
             p = Path(self.local_path, relpath)
             if not p.is_file():
-                raise ManifestError(f"{relpath} not found under {self.local_path}.")
+                raise ManifestNotFound(f"{relpath} not found under {self.local_path}.")
             return p.read_text(encoding="utf-8-sig")
         try:
             return fetch_bytes(raw_url(self.owner, self.repo, self.ref, relpath)).decode("utf-8-sig")
         except urllib.error.HTTPError as exc:
             if exc.code == 404:
-                raise ManifestError(
+                raise ManifestNotFound(
                     f"{relpath} not found in {self.owner}/{self.repo}@{self.ref}. "
                     "If the repository is private, set GITHUB_TOKEN.") from exc
             raise ManifestError(f"Fetching {relpath} failed: HTTP {exc.code}.") from exc
@@ -255,15 +264,29 @@ class CountrySource:
 
     # ── the manifest itself ──────────────────────────────────────────────────
     def load_manifest(self):
+        """The repository's own manifest when it has one; otherwise a manifest
+        discovered from its layout (see RepoScan). Both go through the same
+        validation, so every caller sees one shape."""
         # Read first, parse second: a fetch failure is already a clean
         # ManifestError (which subclasses ValueError) and must not be rewrapped
         # as a JSON complaint.
-        text = self.read_text(MANIFEST_NAME)
+        try:
+            text = self.read_text(MANIFEST_NAME)
+        except ManifestNotFound:
+            return validate_manifest(self.discover_manifest())
         try:
             data = json.loads(text)
         except ValueError as exc:
             raise ManifestError(f"{MANIFEST_NAME} is not valid JSON: {exc}.") from exc
         return validate_manifest(data)
+
+    def discover_manifest(self):
+        # imported here: RepoScan builds on this module
+        from Classes.Clews import RepoScan
+        if self.source_type == "local_path":
+            return RepoScan.scan_local(self.local_path, iso3=self.hint_iso3, name=self.hint_name)
+        return RepoScan.scan_remote(self.owner, self.repo, self.ref,
+                                    iso3=self.hint_iso3, name=self.hint_name)
 
     def load_checksums(self, vintage):
         """{archive filename: declared sha256} for a vintage, or {} if undeclared."""

--- a/API/Classes/Clews/RepoScan.py
+++ b/API/Classes/Clews/RepoScan.py
@@ -1,0 +1,290 @@
+"""Discover a country repository's installable models from its contents.
+
+A repository is not required to describe itself in clews-country.json. When
+that file is missing, MUIOGO reads the repository's layout instead and builds
+the same manifest shape from it, so inspection, checksums, download and import
+work identically. What counts as an installable version is deliberately
+simple and convention-light:
+
+    a folder holding a SHA256SUMS file and at least one .zip archive
+
+Everything else is derived from names, with the rules written out so a
+surprising result can be traced:
+
+- The version label comes from the top-level folder: ``Philippines_v12_CLEWs_build``
+  drops the ``_CLEWs_<word>`` suffix and the country prefix shared by all
+  folders, giving ``v12``. A folder without a version token keeps its name.
+- A folder often also carries its predecessors' archives as evidence
+  (``Philippines_v24_CLEWs_build`` holds v15 through v24). Only archives whose
+  name starts with the folder's own model prefix (``Philippines_v24_``) belong
+  to the version; if none match that rule, every archive in the folder does.
+- The case name is the archive name without ``_MUIO.zip`` and without a
+  trailing version token (``Philippines_v12_ENV_LAND_v12.0.0_MUIO.zip`` is the
+  case ``Philippines_v12_ENV_LAND``; ``Philippines_vIS2_vIS2.0.0_MUIO.zip`` is
+  ``Philippines_vIS2``). Several archives for the same case in one folder
+  (patch releases) collapse to the highest.
+- Newest first means most recently changed in the repository, from the commit
+  history of each version folder. When that cannot be read (a plain folder
+  without git) the versions are ordered by name and the menu says so
+  (``ordering: "name"``). No version is marked recommended: the first one is
+  what Install picks, the same rule the manifest path uses.
+
+Remote repositories are read through git, not a hosting API: a blobless clone
+(``--filter=blob:none``: commits and trees, no file contents) is a few MB, needs
+no token, has no request limit, works for any git host, and gives both the file
+listing and per-folder dates locally. The clone is kept under the CLEWs state
+directory and refreshed with a fetch; the derived manifest is cached for an hour
+per repository and branch. Nothing here downloads an archive.
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from Classes.Base import Config
+from Classes.Clews.CountryManifest import ManifestError, MANIFEST_SCHEMA_VERSION
+
+SUMS_NAME = "SHA256SUMS"
+CACHE_TTL_SECONDS = 3600
+_GIT_TIMEOUT = 180
+
+_BUILD_SUFFIX_RE = re.compile(r"_CLEWs(_[A-Za-z0-9]+)?$", re.IGNORECASE)
+# a trailing token that reads as a version: v12.0.0, vIS2.0.0, 2.0.3, raw-v1.0.0
+_VERSION_TOKEN_RE = re.compile(r"(^v[A-Za-z]*\d|^\d|-v?\d)", re.IGNORECASE)
+_REPO_ISO3_RE = re.compile(r"^CLEWs-([A-Za-z]{3})$", re.IGNORECASE)
+
+
+def natural_key(text):
+    """Sort key that orders embedded numbers numerically (v2 < v2.9 < v12)."""
+    return [int(part) if part.isdigit() else part.lower()
+            for part in re.split(r"(\d+)", str(text))]
+
+
+def _case_name(archive):
+    name = archive[:-4] if archive.lower().endswith(".zip") else archive
+    if name.lower().endswith("_muio"):
+        name = name[:-5]
+    head, sep, last = name.rpartition("_")
+    if sep and head and _VERSION_TOKEN_RE.search(last):
+        return head
+    return name
+
+
+def _model_prefix(top_folder):
+    """``Philippines_v12_CLEWs_build`` -> ``Philippines_v12``; ``Fiji_CLEWs_Global`` -> ``Fiji``."""
+    return _BUILD_SUFFIX_RE.sub("", top_folder) or top_folder
+
+
+def _country_token(prefixes):
+    """The leading token every model prefix shares (``Philippines``), or ''.
+
+    A prefix may be the bare token itself (a folder without a version part)."""
+    tokens = {p.split("_", 1)[0] for p in prefixes}
+    if len(tokens) != 1:
+        return ""
+    return tokens.pop()
+
+
+def manifest_from_listing(paths, dates=None, *, repo_name=None, iso3=None, name=None):
+    """Build a manifest dict from repository paths.
+
+    paths: iterable of file paths relative to the repository root.
+    dates: {version dir: ISO date string} of each folder's last change, or None.
+    Raises ManifestError when nothing installable is found.
+    """
+    files = [p.replace("\\", "/").strip("/") for p in paths]
+    dirs_with_sums = {p.rsplit("/", 1)[0] for p in files
+                      if p.rsplit("/", 1)[-1] == SUMS_NAME and "/" in p}
+    zips_by_dir = {}
+    for p in files:
+        if p.lower().endswith(".zip") and "/" in p:
+            d, f = p.rsplit("/", 1)
+            zips_by_dir.setdefault(d, []).append(f)
+    candidates = sorted(d for d in dirs_with_sums if zips_by_dir.get(d))
+    if not candidates:
+        raise ManifestError(
+            "No installable models found: no folder with a SHA256SUMS file and "
+            "MUIO archives (.zip). A clews-country.json would also do.")
+
+    prefixes = {d: _model_prefix(d.split("/", 1)[0]) for d in candidates}
+    country = _country_token(prefixes.values())
+
+    vintages, seen_ids = [], {}
+    for d in candidates:
+        prefix = prefixes[d]
+        own = [z for z in zips_by_dir[d] if z.startswith(prefix + "_")] or list(zips_by_dir[d])
+        best_by_case = {}
+        for z in own:
+            case = _case_name(z)
+            if case not in best_by_case or natural_key(z) > natural_key(best_by_case[case]):
+                best_by_case[case] = z
+        cases = [{"case": c, "archive": a} for c, a in
+                 sorted(best_by_case.items(), key=lambda kv: natural_key(kv[0]))]
+        plain = [c for c in cases if c["case"] == prefix]
+        (plain[0] if plain else cases[0])["recommended"] = True
+
+        vid = prefix[len(country) + 1:] if country and prefix.startswith(country + "_") else prefix
+        vid = vid or prefix
+        if vid in seen_ids:
+            seen_ids[vid] += 1
+            vid = f"{vid}-{seen_ids[vid]}"
+        else:
+            seen_ids[vid] = 1
+        entry = {"id": vid, "dir": d, "sha256sums": SUMS_NAME, "cases": cases}
+        if dates and dates.get(d):
+            entry["last_changed"] = dates[d]
+        vintages.append(entry)
+
+    if dates and all(v.get("last_changed") for v in vintages):
+        vintages.sort(key=lambda v: (v["last_changed"], natural_key(v["id"])), reverse=True)
+        ordering = "date"
+    else:
+        vintages.sort(key=lambda v: natural_key(v["id"]), reverse=True)
+        ordering = "name"
+
+    if not iso3:
+        m = _REPO_ISO3_RE.match(repo_name or "")
+        iso3 = m.group(1).upper() if m else (country or repo_name or "UNKNOWN").upper()[:12]
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "iso3": iso3,
+        "name": name or country or repo_name or iso3,
+        "discovered": True,
+        "ordering": ordering,
+        "vintages": vintages,
+    }
+
+
+# ── the derived-manifest cache ────────────────────────────────────────────────
+
+def _cache_path():
+    return Path(Config.CLEWS_DATA_STORAGE) / "scan_cache.json"
+
+
+def _cache_read(key):
+    try:
+        data = json.loads(_cache_path().read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    entry = data.get(key)
+    if entry and time.time() - entry.get("fetched_at", 0) < CACHE_TTL_SECONDS:
+        return entry.get("manifest")
+    return None
+
+
+def _cache_write(key, manifest):
+    try:
+        path = _cache_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            data = {}
+        data[key] = {"fetched_at": time.time(), "manifest": manifest}
+        path.write_text(json.dumps(data, ensure_ascii=True, indent=2), encoding="utf-8")
+    except OSError:
+        pass  # a failed cache write must not fail the scan
+
+
+# ── git ───────────────────────────────────────────────────────────────────────
+
+def _git(args, cwd=None):
+    """Run git; returns stdout. Raises ManifestError with git's own words."""
+    try:
+        out = subprocess.run(["git"] + args, cwd=cwd, capture_output=True, text=True,
+                             timeout=_GIT_TIMEOUT)
+    except FileNotFoundError as exc:
+        raise ManifestError("git is needed to read a repository's contents and was "
+                            "not found on this machine.") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise ManifestError("Reading the repository took too long; try again.") from exc
+    if out.returncode != 0:
+        detail = (out.stderr or out.stdout or "").strip().splitlines()
+        raise ManifestError("Reading the repository failed: "
+                            + (detail[-1] if detail else f"git exit {out.returncode}"))
+    return out.stdout
+
+
+def _dates_from_git(repo_dir, ref, dirs):
+    dates = {}
+    for d in dirs:
+        stamp = _git(["log", "-1", "--format=%cI", ref, "--", d], cwd=repo_dir).strip()
+        if not stamp:
+            return {}
+        dates[d] = stamp
+    return dates
+
+
+def _mirror_dir(owner, repo):
+    return Path(Config.CLEWS_DATA_STORAGE) / "scan-cache" / f"{owner}__{repo}.git"
+
+
+def scan_remote(owner, repo, ref, *, iso3=None, name=None,
+                clone_url=None):
+    """Manifest discovered from a remote git repository at ref. Raises ManifestError.
+
+    Keeps a blobless bare clone per repository and refreshes it on each scan
+    that is older than the cache; the manifest itself is cached for an hour."""
+    key = f"{owner}/{repo}@{ref}"
+    cached = _cache_read(key)
+    if cached:
+        return cached
+    url = clone_url or f"https://github.com/{owner}/{repo}.git"
+    mirror = _mirror_dir(owner, repo)
+    refspec = f"+refs/heads/{ref}:refs/heads/{ref}"
+    if (mirror / "HEAD").exists():
+        try:
+            _git(["fetch", "-q", "--filter=blob:none", "--no-tags", "origin", refspec], cwd=mirror)
+        except ManifestError:
+            shutil.rmtree(mirror, ignore_errors=True)  # a broken mirror is rebuilt below
+    if not (mirror / "HEAD").exists():
+        mirror.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            _git(["clone", "-q", "--bare", "--filter=blob:none", "--no-tags",
+                  "--single-branch", "--branch", ref, url, str(mirror)])
+        except ManifestError as exc:
+            shutil.rmtree(mirror, ignore_errors=True)
+            raise ManifestError(
+                f"Could not read {owner}/{repo} (branch {ref}). {exc} "
+                "If the repository is private, sign in to GitHub with git first.") from exc
+
+    paths = _git(["ls-tree", "-r", "--name-only", ref], cwd=mirror).splitlines()
+    manifest = manifest_from_listing(paths, None, repo_name=repo, iso3=iso3, name=name)
+    dates = _dates_from_git(mirror, ref, [v["dir"] for v in manifest["vintages"]])
+    if dates:
+        manifest = manifest_from_listing(paths, dates, repo_name=repo, iso3=iso3, name=name)
+    _cache_write(key, manifest)
+    return manifest
+
+
+# ── local folder ──────────────────────────────────────────────────────────────
+
+def scan_local(root, *, iso3=None, name=None):
+    """Manifest discovered from a folder on disk (a checkout, or a copy)."""
+    root = Path(root)
+    paths, sums_dirs = [], []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d != ".git"]
+        rel = Path(dirpath).relative_to(root).as_posix()
+        for f in filenames:
+            paths.append(f if rel == "." else f"{rel}/{f}")
+        if SUMS_NAME in filenames and rel != ".":
+            sums_dirs.append(rel)
+    dates = {}
+    if (root / ".git").exists():
+        try:
+            dates = _dates_from_git(root, "HEAD", sums_dirs)
+        except ManifestError:
+            dates = {}
+    if not dates:
+        for d in sums_dirs:
+            try:
+                mtimes = [os.path.getmtime(p) for p in Path(root, d).iterdir() if p.is_file()]
+            except OSError:
+                mtimes = []
+            if mtimes:
+                dates[d] = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(max(mtimes)))
+    return manifest_from_listing(paths, dates or None, repo_name=root.name, iso3=iso3, name=name)

--- a/API/Routes/Clews/ClewsRoute.py
+++ b/API/Routes/Clews/ClewsRoute.py
@@ -68,7 +68,9 @@ def _source_from_request(data):
                 f"'{data.get('catalog_key')}' is not in the country catalogue. "
                 "Use a Git URL instead, or configure a catalogue register.")
         return CountrySource(source_type="repo_url", repo_url=entry["repo_url"],
-                             ref=data.get("ref"))
+                             ref=data.get("ref"),
+                             iso3=entry.get("iso3") or None,
+                             name=entry.get("country_name") or None)
     if source_type == "repo_url":
         return CountrySource(source_type="repo_url", repo_url=data.get("repo_url"),
                              ref=data.get("ref"))

--- a/WebAPP/App/Controller/ClewsInstall.js
+++ b/WebAPP/App/Controller/ClewsInstall.js
@@ -1,0 +1,520 @@
+import { Message } from "../../Classes/Message.Class.js";
+import { Base } from "../../Classes/Base.Class.js";
+import { Html } from "../../Classes/Html.Class.js";
+import { Clews } from "../../Classes/Clews.Class.js";
+import { Sidebar } from "./Sidebar.js";
+
+//register, manifest and case names render into markup, escape them
+const esc = s => String(s == null ? '' : s).replace(/[&<>"']/g,
+    ch => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[ch]));
+
+const POLL_MS = 2500;
+
+//incremented on every visit and route change; async work from an older visit
+//must not repaint or keep polling on the new page
+let PAGE_ID = 0;
+//one entry per country block on screen, by key: { key, source, menu, entry }
+let BLOCKS = {};
+//every case on this machine, from the last refresh
+let INSTALLED = [];
+//the one running install: { timer, key }, or null
+let POLL = null;
+
+export default class ClewsInstall {
+
+    static onLoad(){
+        ClewsInstall.stopPoll();
+        PAGE_ID++;
+        ClewsInstall.initEvents();
+        ClewsInstall.refresh(PAGE_ID);
+    }
+
+    static isCurrent(pageID){
+        return pageID == PAGE_ID;
+    }
+
+    static stopPoll(){
+        if (POLL){
+            clearInterval(POLL.timer);
+            POLL = null;
+        }
+    }
+
+    static initEvents(){
+        //a poll must not outlive the page
+        $(window).off('hashchange.clwPolls').on('hashchange.clwPolls', function () {
+            PAGE_ID++;
+            ClewsInstall.stopPoll();
+        });
+        $('.clw-page').off('click.clw').on('click.clw', '[data-act]', function (e) {
+            e.preventDefault();
+            e.stopPropagation();
+            let act = $(this).attr('data-act');
+            let block = $(this).closest('.clw-country');
+            let key = block.attr('data-key');
+            if (act == 'install-latest'){
+                ClewsInstall.install(key, block.attr('data-latest-vintage'), block.attr('data-latest-case'));
+            }else if (act == 'install'){
+                let row = $(this).closest('tr');
+                ClewsInstall.install(key, row.attr('data-vintage'), row.attr('data-case'));
+            }else if (act == 'toggle-all'){
+                block.find('.clw-all').toggle();
+                $(this).find('.fa').toggleClass('fa-caret-down fa-caret-up');
+            }else if (act == 'delete'){
+                ClewsInstall.confirmDelete($(this).closest('[data-case]').attr('data-case'));
+            }
+        });
+        $('#clwLookup').off('click.clw').on('click.clw', function (e) {
+            e.preventDefault();
+            ClewsInstall.lookup();
+        });
+        $('#clwSource').off('keydown.clw').on('keydown.clw', function (e) {
+            if (e.key == 'Enter'){
+                e.preventDefault();
+                ClewsInstall.lookup();
+            }
+        });
+    }
+
+    //── loading ──────────────────────────────────────────────────────────────
+
+    //the register and what is on this machine, then one block per repository;
+    //each block reads its repository (manifest or a scan of its contents)
+    static refresh(pageID){
+        $('#clwCountries').html('<div class="clw-note"><i class="fa fa-cog fa-spin"></i> Reading the list of country models...</div>');
+        Promise.all([Clews.getCountryCatalog(), Clews.getInstalledCountries()])
+        .then(data => {
+            if (!ClewsInstall.isCurrent(pageID)){
+                return;
+            }
+            let [catalog, installed] = data;
+            INSTALLED = installed.cases || [];
+            let entries = catalog.countries || [];
+            ClewsInstall.noteSource(catalog.catalog_source, entries.length);
+            BLOCKS = {};
+            let html = '';
+            $.each(entries, function (i, c) {
+                let key = 'reg-' + c.catalog_key;
+                BLOCKS[key] = { key: key, entry: c, source: { source_type: 'catalog', catalog_key: c.catalog_key }, menu: null };
+                html += ClewsInstall.blockHtml(BLOCKS[key]);
+            });
+            $('#clwCountries').html(html);
+            $.each(BLOCKS, function (key, b) {
+                ClewsInstall.loadBlock(b, pageID);
+            });
+            ClewsInstall.renderInstalled();
+            //an added repository stays on screen across refreshes
+            $('#clwAdded .clw-country').each(function () {
+                let key = $(this).attr('data-key');
+                if (BLOCKS[key]){
+                    ClewsInstall.loadBlock(BLOCKS[key], pageID);
+                }
+            });
+        })
+        .catch(error => {
+            if (!ClewsInstall.isCurrent(pageID)){
+                return;
+            }
+            Message.danger(error);
+            $('#clwCountries').html('<div class="clw-note clw-err">' + esc(error) + '</div>');
+        });
+    }
+
+    static noteSource(source, count){
+        let note = $('#clwSourceNote');
+        if (source == 'cache'){
+            note.text('No connection to the country list. Showing the last saved list; installing needs a connection.').show();
+        }else if (count == 0){
+            note.text('The list of country models could not be loaded. You can still add a repository below.').show();
+        }else{
+            note.hide();
+        }
+    }
+
+    static loadBlock(b, pageID){
+        Clews.inspectSource(b.source)
+        .then(menu => {
+            if (!ClewsInstall.isCurrent(pageID)){
+                return;
+            }
+            b.menu = menu;
+            ClewsInstall.rerender(b);
+            ClewsInstall.renderInstalled();
+        })
+        .catch(error => {
+            if (!ClewsInstall.isCurrent(pageID)){
+                return;
+            }
+            b.error = error;
+            ClewsInstall.rerender(b);
+        });
+    }
+
+    static rerender(b){
+        let open = ClewsInstall.block(b.key).find('.clw-all').is(':visible');
+        ClewsInstall.block(b.key).replaceWith(ClewsInstall.blockHtml(b));
+        if (open){
+            ClewsInstall.block(b.key).find('.clw-all').show().end().find('[data-act="toggle-all"] .fa').toggleClass('fa-caret-down fa-caret-up');
+        }
+    }
+
+    static block(key){
+        return $('.clw-country').filter(function () { return $(this).attr('data-key') == key; });
+    }
+
+    //── what belongs where ───────────────────────────────────────────────────
+
+    //a case on this machine belongs to the version whose case name it starts
+    //with (Philippines_v18_GOLD belongs to v18 through Philippines_v18); the
+    //longest match wins so Philippines_v12_ENV_LAND is not read as Philippines_v12
+    static attribute(menu, casename){
+        let best = null;
+        $.each(menu.vintages || [], function (i, v) {
+            $.each(v.cases || [], function (j, c) {
+                if (casename == c.case || casename.indexOf(c.case + '_') == 0){
+                    if (!best || c.case.length > best.caseName.length){
+                        best = { vintage: v, caseName: c.case };
+                    }
+                }
+            });
+        });
+        return best;
+    }
+
+    //installed cases grouped by version for one block: [{vintage, cases: [names]}]
+    static installedByVersion(menu){
+        let groups = {};
+        $.each(INSTALLED, function (i, rec) {
+            let hit = ClewsInstall.attribute(menu, rec.casename);
+            if (hit){
+                (groups[hit.vintage.id] = groups[hit.vintage.id] || { vintage: hit.vintage, cases: [] }).cases.push(rec.casename);
+            }
+        });
+        let out = [];
+        $.each(menu.vintages || [], function (i, v) {
+            if (groups[v.id]){
+                groups[v.id].cases.sort();
+                out.push(groups[v.id]);
+            }
+        });
+        return out;
+    }
+
+    static latestOf(menu){
+        let vintages = menu.vintages || [];
+        if (!vintages.length){
+            return null;
+        }
+        let v = vintages.find(x => x.recommended) || vintages[0];
+        let c = (v.cases || []).find(x => x.recommended) || (v.cases || [])[0];
+        return { vintage: v, caseName: c ? c.case : null };
+    }
+
+    //── rendering ────────────────────────────────────────────────────────────
+
+    //paint one repository block from a menu and a list of the machine's cases,
+    //replacing whatever is on screen; the browser test drives the page this way
+    static renderOne(menu, installed){
+        //a new visit as far as pending loads are concerned, so an initial
+        //refresh still in flight cannot repaint over what is drawn here
+        PAGE_ID++;
+        ClewsInstall.stopPoll();
+        INSTALLED = installed || [];
+        let source = menu.source && menu.source.repo_url
+            ? { source_type: 'repo_url', repo_url: menu.source.repo_url }
+            : { source_type: 'local_path', local_path: (menu.source || {}).local_path || '' };
+        BLOCKS = { test: { key: 'test', entry: null, source: source, menu: menu } };
+        $('#clwCountries').html(ClewsInstall.blockHtml(BLOCKS.test));
+        ClewsInstall.renderInstalled();
+    }
+
+    static repoLabel(b){
+        let url = (b.menu && b.menu.source && (b.menu.source.repo_url || b.menu.source.local_path))
+            || (b.entry && b.entry.repo_url) || b.source.repo_url || b.source.local_path || '';
+        return { url: url, text: url.replace(/^https?:\/\/(www\.)?/i, '') };
+    }
+
+    static blockHtml(b){
+        let repo = ClewsInstall.repoLabel(b);
+        let title = repo.url && /^https?:/i.test(repo.url)
+            ? '<a class="clw-url" href="' + esc(repo.url) + '" target="_blank" rel="noopener">' + esc(repo.text) + '</a>'
+            : '<span class="clw-url">' + esc(repo.text) + '</span>';
+        let name = (b.menu && b.menu.name) || (b.entry && b.entry.country_name) || '';
+        let head = '<div class="clw-block-head">' + title + (name ? ' <span class="clw-muted">' + esc(name) + '</span>' : '');
+
+        if (b.error){
+            return '<div class="clw-block clw-country" data-key="' + esc(b.key) + '">' + head + '</div>'
+                + '<div class="clw-note clw-err"><i class="fa fa-exclamation-triangle"></i> ' + esc(b.error) + '</div></div>';
+        }
+        if (!b.menu){
+            return '<div class="clw-block clw-country" data-key="' + esc(b.key) + '">' + head + '</div>'
+                + '<div class="clw-note"><i class="fa fa-cog fa-spin"></i> Reading the repository...</div></div>';
+        }
+
+        let menu = b.menu;
+        let latest = ClewsInstall.latestOf(menu);
+        let have = ClewsInstall.installedByVersion(menu);
+        let haveLatest = latest && have.some(g => g.vintage.id == latest.vintage.id);
+        let badge = haveLatest ? '<span class="clw-badge clw-b-ok">up to date</span>'
+            : have.length ? '<span class="clw-badge clw-b-upd">newer version available</span>'
+            : '<span class="clw-badge clw-b-mut">nothing installed</span>';
+        head += badge + '</div>';
+
+        let html = '<div class="clw-block clw-country" data-key="' + esc(b.key) + '"'
+            + (latest ? ' data-latest-vintage="' + esc(latest.vintage.id) + '" data-latest-case="' + esc(latest.caseName) + '"' : '') + '>' + head;
+
+        //newest version and what Install does
+        if (latest){
+            let latestExists = INSTALLED.some(r => r.casename == latest.caseName);
+            let when = latest.vintage.last_changed ? ' <span class="clw-muted">(' + esc(String(latest.vintage.last_changed).slice(0, 10)) + ')</span>' : '';
+            html += '<div class="clw-latest"><div class="clw-latest-text">Newest version <b>' + esc(latest.vintage.id) + '</b>' + when
+                + ' &mdash; Install adds the model <b>' + esc(latest.caseName) + '</b>'
+                + (latestExists ? ' <span class="clw-muted">(already here)</span>' : '') + '</div>'
+                + '<div class="clw-latest-actions">'
+                + '<button class="btn clw-btn clw-btn-main" data-act="install-latest"' + (latestExists || latest.vintage.version_gate ? ' disabled' : '')
+                + (latest.vintage.version_gate ? ' title="' + esc(latest.vintage.version_gate) + '"' : '') + '><i class="fa fa-download"></i> Install</button>'
+                + '<button class="btn clw-btn" data-act="toggle-all">All versions <span class="clw-muted">(' + esc((menu.vintages || []).length) + ')</span> <i class="fa fa-caret-down"></i></button>'
+                + '</div></div>';
+            html += '<div class="clw-status"></div>';
+            if (menu.discovered){
+                html += '<div class="clw-fine">Versions read from the repository\'s contents'
+                    + (menu.ordering == 'date' ? ', newest by last change.' : '; the repository\'s history could not be read, so they are ordered by name.') + '</div>';
+            }
+        }
+
+        //every version, newest first
+        html += '<div class="clw-all" style="display:none"><table class="table table-condensed clw-table"><tbody>';
+        $.each(menu.vintages || [], function (i, v) {
+            let isLatest = latest && v.id == latest.vintage.id;
+            let when = v.last_changed ? '<span class="clw-muted">' + esc(String(v.last_changed).slice(0, 10)) + '</span>' : '';
+            $.each(v.cases || [], function (j, c) {
+                let exists = INSTALLED.some(r => r.casename == c.case);
+                html += '<tr data-vintage="' + esc(v.id) + '" data-case="' + esc(c.case) + '">'
+                    + '<td class="clw-vcell">' + (j == 0 ? '<span class="clw-vid">' + esc(v.id) + '</span>' + (isLatest ? ' <span class="clw-badge clw-b-ok">newest</span>' : '') : '') + '</td>'
+                    + '<td class="clw-case">' + esc(c.case) + (c.role && (v.cases.length > 1) ? ' <span class="clw-muted">' + esc(c.role) + '</span>' : '') + '</td>'
+                    + '<td>' + (j == 0 ? when : '') + '</td>'
+                    + '<td class="clw-status">' + (exists ? 'installed here' : '') + '</td>'
+                    + '<td class="clw-act">' + (exists
+                        ? '<button class="btn btn-default btn-xs" disabled>Install</button>'
+                        : v.version_gate
+                            ? '<button class="btn btn-default btn-xs" disabled title="' + esc(v.version_gate) + '">Install</button>'
+                            : '<button class="btn btn-primary btn-xs" data-act="install">Install</button>') + '</td></tr>';
+            });
+        });
+        html += '</tbody></table></div></div>';
+        return html;
+    }
+
+    //every model on this machine: grouped under the repository it belongs to
+    //(by version), then the ones that belong to no repository on screen
+    static renderInstalled(){
+        let pending = Object.values(BLOCKS).some(b => !b.menu && !b.error);
+        if (pending){
+            $('#clwInstalled').html('<div class="clw-note"><i class="fa fa-cog fa-spin"></i> Reading the repositories...</div>');
+            return;
+        }
+        if (!INSTALLED.length){
+            $('#clwInstalled').html('<div class="clw-note">No model is installed yet.</div>');
+            return;
+        }
+        let claimed = {};
+        let html = '';
+        $.each(BLOCKS, function (key, b) {
+            if (!b.menu){
+                return;
+            }
+            let have = ClewsInstall.installedByVersion(b.menu);
+            if (!have.length){
+                return;
+            }
+            let repo = ClewsInstall.repoLabel(b);
+            html += '<div class="clw-have-title">' + esc(repo.text) + (b.menu.name ? ' <span class="clw-muted">' + esc(b.menu.name) + '</span>' : '') + '</div>';
+            html += '<table class="table table-condensed clw-table clw-havetable"><tbody>';
+            $.each(have, function (i, g) {
+                $.each(g.cases, function (j, name) {
+                    claimed[name] = true;
+                    html += ClewsInstall.installedRowHtml(j == 0 ? g.vintage.id : '', name);
+                });
+            });
+            html += '</tbody></table>';
+        });
+        let others = INSTALLED.filter(r => !claimed[r.casename]).map(r => r.casename).sort();
+        if (others.length){
+            html += '<div class="clw-have-title">Other models <span class="clw-muted">not from a listed repository: the demo, uploads, copies, imports</span></div>';
+            html += '<table class="table table-condensed clw-table clw-havetable"><tbody>';
+            $.each(others, function (i, name) {
+                html += ClewsInstall.installedRowHtml('', name);
+            });
+            html += '</tbody></table>';
+        }
+        $('#clwInstalled').html(html);
+    }
+
+    static installedRowHtml(versionLabel, name){
+        return '<tr data-case="' + esc(name) + '">'
+            + '<td class="clw-vcell">' + (versionLabel ? '<span class="clw-vid">' + esc(versionLabel) + '</span>' : '') + '</td>'
+            + '<td class="clw-case">' + esc(name) + '</td>'
+            + '<td class="clw-act"><button class="btn btn-default btn-xs clw-del" data-act="delete" title="Delete this model with all its scenarios and results"><i class="fa fa-trash-o"></i> Delete</button></td></tr>';
+    }
+
+    //── add a repository ─────────────────────────────────────────────────────
+
+    static lookup(){
+        let pageID = PAGE_ID;
+        let text = ($('#clwSource').val() || '').trim();
+        if (!text){
+            Message.warning('Enter a repository URL or a folder first.');
+            return;
+        }
+        let source = /^https?:\/\//i.test(text)
+            ? { source_type: 'repo_url', repo_url: text }
+            : { source_type: 'local_path', local_path: text };
+        let key = 'added-' + text.replace(/[^A-Za-z0-9]+/g, '-');
+        BLOCKS[key] = { key: key, entry: null, source: source, menu: null };
+        ClewsInstall.block(key).remove();
+        $('#clwAdded').prepend(ClewsInstall.blockHtml(BLOCKS[key]));
+        ClewsInstall.loadBlock(BLOCKS[key], pageID);
+    }
+
+    //── installing ───────────────────────────────────────────────────────────
+
+    static install(key, vintage, casename){
+        let pageID = PAGE_ID;
+        let b = BLOCKS[key];
+        if (!b || !vintage || !casename){
+            return;
+        }
+        if (POLL){
+            Message.warning('An install is already running. Wait for it to finish.');
+            return;
+        }
+        let payload = Object.assign({}, b.source, { vintage: vintage, cases: [casename] });
+        ClewsInstall.setStatus(key, 'Installing ' + casename + ': starting...', 'clw-run', true);
+        Clews.installCountry(payload)
+        .then(job => {
+            if (!ClewsInstall.isCurrent(pageID)){
+                return;
+            }
+            ClewsInstall.pollJob(job.install_id, key, casename, pageID);
+        })
+        .catch(error => {
+            if (!ClewsInstall.isCurrent(pageID)){
+                return;
+            }
+            ClewsInstall.setStatus(key, 'Installing ' + casename + ' failed: ' + error, 'clw-err', false);
+            Message.danger(error);
+        });
+    }
+
+    static setStatus(key, text, cls, busy){
+        let block = ClewsInstall.block(key);
+        block.find('.clw-status').attr('class', 'clw-status ' + cls).text(text);
+        block.find('[data-act="install-latest"], [data-act="install"]').prop('disabled', busy);
+    }
+
+    static pollJob(installId, key, casename, pageID){
+        ClewsInstall.stopPoll();
+        let tick = function () {
+            if (!ClewsInstall.isCurrent(pageID)){
+                ClewsInstall.stopPoll();
+                return;
+            }
+            Clews.getInstallStatus(installId)
+            .then(job => {
+                if (ClewsInstall.isCurrent(pageID)){
+                    ClewsInstall.applyJob(job, key, casename, pageID);
+                }
+            })
+            .catch(error => {
+                //a transient poll error keeps the timer; the job continues server side
+            });
+        };
+        POLL = { timer: setInterval(tick, POLL_MS), key: key };
+        tick();
+    }
+
+    static applyJob(job, key, casename, pageID){
+        let results = job.results || [];
+        if (job.install_state == 'installed'){
+            ClewsInstall.stopPoll();
+            let failed = results.filter(r => r.status == 'failed');
+            if (failed.length){
+                let why = failed[0].message || failed[0].error || 'see the server log';
+                ClewsInstall.setStatus(key, 'Installing ' + casename + ' failed: ' + why, 'clw-err', false);
+                Message.danger('Installing ' + casename + ' failed: ' + why);
+                return;
+            }
+            Message.success(casename + ' is installed and appears in the case list.');
+            ClewsInstall.refreshAfterChange(pageID, key, casename + ' installed.');
+            return;
+        }
+        if (job.install_state == 'failed'){
+            ClewsInstall.stopPoll();
+            let why = job.error || (results[0] && (results[0].message || results[0].error)) || 'see the server log';
+            ClewsInstall.setStatus(key, 'Installing ' + casename + ' failed: ' + why, 'clw-err', false);
+            Message.danger('Install failed: ' + why);
+            return;
+        }
+        ClewsInstall.setStatus(key, 'Installing ' + casename + ': ' + (job.progress_label || job.install_state) + '...', 'clw-run', true);
+    }
+
+    //after an install or a delete: re-read what is on the machine and repaint
+    //every block, keeping a short note on the block that changed
+    static refreshAfterChange(pageID, key, note){
+        Clews.getInstalledCountries()
+        .then(installed => {
+            if (!ClewsInstall.isCurrent(pageID)){
+                return;
+            }
+            INSTALLED = installed.cases || [];
+            $.each(BLOCKS, function (k, b) {
+                if (b.menu){
+                    //existence flags in the menu are stale now; the block repaints from INSTALLED
+                    ClewsInstall.rerender(b);
+                }
+            });
+            ClewsInstall.renderInstalled();
+            if (key && note){
+                ClewsInstall.setStatus(key, note, 'clw-ok', false);
+            }
+        })
+        .catch(error => {});
+    }
+
+    //── deleting ─────────────────────────────────────────────────────────────
+
+    //the same two steps the Home page uses: make the case the active one, then
+    //delete it; /deleteCase refuses anything but the active case
+    static confirmDelete(casename){
+        let pageID = PAGE_ID;
+        $.SmartMessageBox({
+            title: "Delete model",
+            content: "You are about to delete <b class='danger'>" + esc(casename) + "</b> with all its scenarios and results. This cannot be undone. Are you sure?",
+            buttons: '[No][Yes]'
+        }, function (ButtonPressed) {
+            if (ButtonPressed !== "Yes"){
+                return;
+            }
+            Base.setSession(casename)
+            .then(() => Base.deleteCaseStudy(casename))
+            .then(response => {
+                if (!ClewsInstall.isCurrent(pageID)){
+                    return;
+                }
+                if (response.status_code == 'success_session'){
+                    Message.success('Model ' + casename + ' deleted.');
+                    Html.removeCase(casename);
+                    Sidebar.Reload(null);
+                    ClewsInstall.refreshAfterChange(pageID, null, null);
+                }else{
+                    Message.warning(response.message);
+                }
+            })
+            .catch(error => {
+                if (ClewsInstall.isCurrent(pageID)){
+                    Message.danger(error);
+                }
+            });
+        });
+    }
+}

--- a/WebAPP/App/View/ClewsInstall.html
+++ b/WebAPP/App/View/ClewsInstall.html
@@ -1,0 +1,22 @@
+<div class="clw-page">
+  <h1 class="clw-title">CLEWs country models</h1>
+  <p class="clw-sub">Models are installed from their repositories. <b>Install</b> adds the newest version; <b>All versions</b> lists every version the repository holds. Nothing already on this machine is ever overwritten.</p>
+
+  <div class="clw-srcnote" id="clwSourceNote" style="display: none;"></div>
+
+  <div id="clwCountries"></div>
+
+  <div class="clw-block clw-addblock">
+    <div class="clw-block-head"><span class="clw-block-title">Add a repository</span><span class="clw-muted">a GitHub repository not on the list, or a local folder</span></div>
+    <div class="clw-source">
+      <input type="text" class="form-control" id="clwSource" placeholder="https://github.com/EAPD-DRB/CLEWs-FJI  (or a folder on this machine)" />
+      <button class="btn btn-primary" id="clwLookup"><i class="fa fa-search"></i> Look up</button>
+    </div>
+    <div id="clwAdded"></div>
+  </div>
+
+  <div class="clw-block" id="clwInstalledBlock">
+    <div class="clw-block-head"><span class="clw-block-title">Installed on this machine</span><span class="clw-muted">every model, by repository and version; Delete removes a model with all its scenarios and results</span></div>
+    <div id="clwInstalled"></div>
+  </div>
+</div>

--- a/WebAPP/App/View/Home.html
+++ b/WebAPP/App/View/Home.html
@@ -65,6 +65,9 @@
             </label>
           </div>
           <div class="widget-toolbar">
+            <a class="btn btn-default" href="#ClewsInstall" data-toggle="tooltip" data-placement="top" title="Install country model from its repository">
+              <i class="fa fa-download fa-lg fa-1.5x  osy"></i>
+            </a>
             <div class="btn btn-default" data-toggle="modal" data-target="#modalrestore" id="restoreCS" title="Restore model">
               <i class="fa fa-cloud-upload fa-lg fa-1.5x  osy"></i>
             </div>

--- a/WebAPP/Classes/Clews.Class.js
+++ b/WebAPP/Classes/Clews.Class.js
@@ -1,0 +1,57 @@
+import { Base } from "./Base.Class.js";
+
+//the /clews install layer: install a CLEWs country's cases from its repository
+export class Clews {
+
+    static _request(type, path, data) {
+        return new Promise((resolve, reject) => {
+            $.ajax({
+                url: Base.apiUrl() + path,
+                async: true,
+                type: type,
+                dataType: 'json',
+                contentType: data ? 'application/json' : undefined,
+                data: data ? JSON.stringify(data) : undefined,
+                credentials: 'include',
+                xhrFields: { withCredentials: true },
+                crossDomain: true,
+                success: function (result) {
+                    resolve(result);
+                },
+                error: function (xhr) {
+                    let msg = (xhr.responseJSON && xhr.responseJSON.message)
+                        || 'The CLEWs install service could not be reached.';
+                    reject(msg);
+                }
+            });
+        });
+    }
+
+    //countries from the register (scripts/clews-repos.json), tagged with this
+    //machine's install state; also carries catalog_source live | cache | none
+    static getCountryCatalog() {
+        return Clews._request('GET', 'clews/getCountryCatalog');
+    }
+
+    //every case on this machine with its provenance; hand-added ones are 'unmanaged'
+    static getInstalledCountries() {
+        return Clews._request('GET', 'clews/getInstalledCountries');
+    }
+
+    //read a repository's clews-country.json and return its vintages and cases,
+    //nothing downloaded; data is {source_type: 'repo_url', repo_url} or
+    //{source_type: 'local_path', local_path}
+    static inspectSource(data) {
+        return Clews._request('POST', 'clews/inspectSource', data);
+    }
+
+    //same source fields plus vintage and cases[], returns an install_id to poll
+    static installCountry(data) {
+        return Clews._request('POST', 'clews/installCountry', data);
+    }
+
+    //progress of a running install
+    static getInstallStatus(installId) {
+        return Clews._request('GET', 'clews/getInstallStatus?install_id=' + encodeURIComponent(installId));
+    }
+}

--- a/WebAPP/References/smartadmin/css/muiogo.css
+++ b/WebAPP/References/smartadmin/css/muiogo.css
@@ -80,6 +80,70 @@ body.osy-mode-clews.smart-style-4 nav>ul>li.active:not(.open)>a:before{border-le
 body.osy-mode-og .minifyme{background:var(--osy-og)!important;color:#fff!important}
 body.osy-mode-og .minifyme:hover{background:var(--osy-og-dark)!important}
 
+/* ===== CLEWs install page (#540): scoped under .clw-*, the CLEWs twin of the OG-Core page ===== */
+.clw-page{max-width:1400px;padding:6px 8px}
+.clw-title{font-size:26px;font-weight:400;color:#3a3f51;margin:0 0 4px}
+.clw-sub{color:#8a8f9c;font-size:13px;margin-bottom:18px;max-width:760px}
+.clw-h2{font-size:17px;font-weight:700;color:#3a3f51;margin:26px 0 8px}
+.clw-srcnote{background:#fcf3d7;border:1px solid #f0d9a8;color:#8a6d3b;font-size:12px;padding:6px 12px;border-radius:2px;margin-bottom:14px;max-width:560px}
+
+/* one block per country repository, then add-a-repository, then installed on this machine */
+.clw-block{background:#fff;border:1px solid #e4e4e4;border-radius:3px;padding:12px 16px 14px;margin-bottom:14px;border-top:3px solid #e4e4e4}
+.clw-country{border-top-color:var(--osy-clews)}
+.clw-block-head{display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:8px}
+.clw-block-title{font-size:15px;font-weight:700;color:#3a3f51}
+.clw-url{font-size:15px;font-weight:700;color:#3a3f51;font-family:monospace}
+a.clw-url:hover{color:var(--osy-clews-dark);text-decoration:underline}
+.clw-block-head .clw-badge{margin-left:auto}
+.clw-latest{display:flex;align-items:center;gap:12px;flex-wrap:wrap;padding:8px 0 4px}
+.clw-latest-text{flex:1 1 320px;font-size:13px;color:#3a3f51}
+.clw-latest-actions{display:flex;gap:6px;align-items:center}
+.clw-btn{font-size:12px;padding:5px 12px;border-radius:2px;border:1px solid #d5d8de;background:#fff;color:#3a3f51}
+.clw-btn .fa{margin-left:4px}
+.clw-btn:hover{background:#f6f7f9}
+.clw-btn-main{background:var(--osy-clews);border-color:var(--osy-clews-dark);color:#fff}
+.clw-btn-main .fa{margin:0 4px 0 0}
+.clw-btn-main:hover{background:var(--osy-clews-dark);color:#fff}
+.clw-btn-main[disabled]{opacity:.5}
+.clw-fine{font-size:11px;color:#8a8f9c;margin:2px 0 6px}
+.clw-status{font-size:12px;color:#6b7188;min-height:16px}
+.clw-status.clw-run{color:#31708f}
+.clw-status.clw-ok{color:#4b8a2a}
+.clw-status.clw-err{color:#a94442}
+
+/* installed on this machine: per repository, rows grouped by version, a labelled Delete per row */
+.clw-have-title{font-size:12px;font-weight:700;color:#3a3f51;margin:10px 0 4px;font-family:monospace}
+.clw-have-title .clw-muted{font-family:inherit}
+#clwInstalledBlock .clw-have-title:first-child{margin-top:2px}
+.clw-vid{font-family:monospace;font-size:13px;font-weight:700;color:#3a3f51;margin-right:6px}
+.clw-havetable td{padding-top:3px!important;padding-bottom:3px!important;border-top:1px solid #f1f2f5!important}
+.clw-havetable tr:first-child td{border-top:0!important}
+.clw-havetable .clw-case{font-weight:500}
+.clw-del{color:#6b7188}
+.clw-del:hover{color:#a94442;border-color:#e0b4b4}
+
+/* every version, newest first */
+.clw-all{margin-top:10px}
+.clw-table{margin:0}
+.clw-table td{vertical-align:middle!important}
+.clw-vcell{white-space:nowrap;width:1%}
+.clw-case{font-weight:600;color:#3a3f51}
+.clw-act{text-align:right;white-space:nowrap}
+.clw-muted{color:#8a8f9c;font-size:12px;font-weight:400}
+.clw-badge{font-size:10px;padding:2px 8px;border-radius:9px;white-space:nowrap}
+.clw-b-ok{background:#e3f3d6;color:#4b8a2a}
+.clw-b-upd{background:#fcf3d7;color:#8a6d3b}
+.clw-b-mut{background:#eceef2;color:#6b7188}
+.clw-b-warn{background:#fcf3d7;color:#8a6d3b}
+.clw-note{color:#6b7188;font-size:13px;padding:8px 0}
+.clw-note.clw-err{color:#a94442}
+
+/* add a repository */
+.clw-addblock{border-top-color:#c4c8d2}
+.clw-source{display:flex;gap:8px;max-width:820px;margin-top:6px}
+.clw-source input{flex:1 1 auto}
+#clwAdded .clw-block{margin-top:14px;margin-bottom:0}
+
 /* ===== OG-Core pages: scoped UI island, all styles under .ogc-* ===== */
 .ogc-page{max-width:1400px;padding:6px 8px}
 .ogc-title{font-size:26px;font-weight:400;color:#3a3f51;margin:0 0 4px}

--- a/WebAPP/Routes/Routes.Class.js
+++ b/WebAPP/Routes/Routes.Class.js
@@ -124,6 +124,17 @@ export class Routes {
                 });
             });
         });
+        crossroads.addRoute('/ClewsInstall', function() {
+            enterModel('clews');
+            $('#content').html('<h1 class="ajax-loading-animation"><i class="fa fa-cog fa-spin"></i> Loading...</h1>');
+            import('../App/Controller/ClewsInstall.js')
+            .then(ClewsInstall => {
+                $( ".osy-content" ).load( 'App/View/ClewsInstall.html', function() {
+                    localStorage.setItem("osy-pageId", "ClewsInstall");
+                    ClewsInstall.default.onLoad();
+                });
+            });
+        });
         crossroads.addRoute('/OGCore', function() {
             enterModel('og');
             $('#content').html('<h1 class="ajax-loading-animation"><i class="fa fa-cog fa-spin"></i> Loading...</h1>');

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -36,7 +36,9 @@ drives per-model navigation through a body class
 (`WebAPP/Classes/MuiogoShell.Class.js`, `muiogo.css`). Model-specific routes set
 that state explicitly; `localStorage` remembers the default used by `/`.
 OG-Core pages are scoped UI islands (`.ogc-*` styles) and call the `/ogc` API
-through `WebAPP/Classes/Ogc.Class.js`.
+through `WebAPP/Classes/Ogc.Class.js`. The CLEWs install page (`#/ClewsInstall`,
+reached from the Home page) follows the same pattern: `.clw-*` styles, and the
+`/clews` API through `WebAPP/Classes/Clews.Class.js`.
 
 ### Runtime data and outputs
 

--- a/scripts/clews-repos.json
+++ b/scripts/clews-repos.json
@@ -1,0 +1,19 @@
+{
+    "_readme": [
+        "The CLEWs country register: repositories that ship portable MUIO cases, the",
+        "CLEWs mirror of the OG-Core installer's repos.json. MUIOGO reads this file from",
+        "the main branch (Config.CLEWS_CATALOG_URL) to list the countries a user can",
+        "install from the CLEWs install page; each repository describes what it ships in",
+        "its own clews-country.json. Add a repository here once it carries that file."
+    ],
+    "schema_version": 1,
+    "repos": [
+        {
+            "key": "clews-phl",
+            "owner": "EAPD-DRB",
+            "repo": "CLEWs-PHL",
+            "iso3": "PHL",
+            "description": "Philippines"
+        }
+    ]
+}

--- a/tests/clews/test_catalog_and_update.py
+++ b/tests/clews/test_catalog_and_update.py
@@ -8,7 +8,9 @@ from Classes.Clews.CountryRegistry import CountryRegistry
 from .conftest import build_country_repo, wait_for_job
 
 
-def test_catalog_defaults_to_none(client):
+def test_catalog_is_none_without_a_register(client, monkeypatch):
+    # an empty MUIOGO_CLEWS_CATALOG_URL means "no register": nothing is fetched
+    monkeypatch.setattr(Config, "CLEWS_CATALOG_URL", "")
     resp = client.get("/clews/getCountryCatalog")
     assert resp.status_code == 200
     body = resp.get_json()

--- a/tests/clews/test_manifest.py
+++ b/tests/clews/test_manifest.py
@@ -118,21 +118,34 @@ def test_repo_url_source_fetches_raw(monkeypatch, tmp_path):
     assert calls == ["https://raw.githubusercontent.com/EAPD-DRB/CLEWs-PHL/main/clews-country.json"]
 
 
-def test_missing_remote_manifest_reports_not_found(monkeypatch):
-    """A 404 must surface as 'not found', not be rewrapped as a JSON complaint
-    (ManifestError subclasses ValueError, which load_manifest's parse guard
-    would otherwise swallow -- caught live against the real CLEWs-PHL repo)."""
+def test_missing_remote_manifest_falls_back_to_discovery(monkeypatch):
+    """A 404 on clews-country.json is not an error any more: the repository's
+    contents are read instead. The 404 must reach that fallback as 'not found',
+    not be rewrapped as a JSON complaint (ManifestError subclasses ValueError,
+    which load_manifest's parse guard would otherwise swallow -- caught live
+    against the real CLEWs-PHL repo)."""
     import urllib.error
+
+    from Classes.Clews import RepoScan
 
     def fake_fetch(url, timeout=20):
         raise urllib.error.HTTPError(url, 404, "Not Found", None, None)
 
+    seen = {}
+
+    def fake_scan(owner, repo, ref, iso3=None, name=None, clone_url=None):
+        seen.update(owner=owner, repo=repo, ref=ref)
+        raise cm.ManifestError("No installable models found in the repository.")
+
     monkeypatch.setattr(cm, "fetch_bytes", fake_fetch)
+    monkeypatch.setattr(RepoScan, "scan_remote", fake_scan)
     src = cm.CountrySource(source_type="repo_url",
                            repo_url="https://github.com/EAPD-DRB/CLEWs-PHL")
     with pytest.raises(cm.ManifestError) as exc:
         src.load_manifest()
-    assert "not found" in str(exc.value)
+    assert seen == {"owner": "EAPD-DRB", "repo": "CLEWs-PHL", "ref": "main"}
+    assert "No installable models" in str(exc.value)
+    assert "JSON" not in str(exc.value)
     assert "not valid JSON" not in str(exc.value)
 
 

--- a/tests/clews/test_repo_scan.py
+++ b/tests/clews/test_repo_scan.py
@@ -1,0 +1,184 @@
+"""Discovering a repository's installable models from its layout (no manifest)."""
+import json
+
+import pytest
+
+from Classes.Clews import RepoScan
+from Classes.Clews.CountryManifest import CountrySource, ManifestError, validate_manifest
+
+
+PHL_LISTING = [
+    "README.md",
+    "Philippines_v12_CLEWs_build/muio/SHA256SUMS",
+    "Philippines_v12_CLEWs_build/muio/Philippines_v12_v12.0.0_MUIO.zip",
+    "Philippines_v12_CLEWs_build/muio/Philippines_v12_ENV_LAND_v12.0.0_MUIO.zip",
+    "Philippines_v12_CLEWs_build/muio/Philippines_v12_ENV_LAND_WATER_DIAGNOSTIC_v12.0.0_MUIO.zip",
+    "Philippines_v16_CLEWs_build/muio/SHA256SUMS",
+    "Philippines_v16_CLEWs_build/muio/Philippines_v15_v15.0.0_MUIO.zip",   # predecessor copy
+    "Philippines_v16_CLEWs_build/muio/Philippines_v16_v16.0.0_MUIO.zip",
+    "Philippines_v16_CLEWs_build/notes.md",
+    "Philippines_vIS2_CLEWs_build/muio/SHA256SUMS",
+    "Philippines_vIS2_CLEWs_build/muio/Philippines_vIS2_vIS2.0.0_MUIO.zip",
+    "Philippines_v36_CLEWs_build/muio/SHA256SUMS",
+    "Philippines_v36_CLEWs_build/muio/Philippines_v36_v36.0.0_MUIO.zip",
+    "Philippines_v9_CLEWs_build/README.md",                                 # no sums, no zips
+]
+
+
+def test_versions_come_from_folders_with_checksums_and_archives():
+    m = manifest = RepoScan.manifest_from_listing(PHL_LISTING, None, repo_name="CLEWs-PHL")
+    validate_manifest(manifest)
+    assert m["discovered"] is True
+    assert m["iso3"] == "PHL"          # from the repository name CLEWs-PHL
+    assert m["name"] == "Philippines"  # the prefix every folder shares
+    assert [v["id"] for v in m["vintages"]] == ["vIS2", "v36", "v16", "v12"]  # by name, newest-looking first
+    assert m["ordering"] == "name"
+    assert not any(v.get("recommended") for v in m["vintages"])
+
+
+def test_only_the_folders_own_archives_count():
+    m = RepoScan.manifest_from_listing(PHL_LISTING, None, repo_name="CLEWs-PHL")
+    v16 = next(v for v in m["vintages"] if v["id"] == "v16")
+    assert [c["archive"] for c in v16["cases"]] == ["Philippines_v16_v16.0.0_MUIO.zip"]
+    assert v16["cases"][0]["case"] == "Philippines_v16"
+    assert v16["cases"][0]["recommended"] is True
+
+
+def test_case_names_and_the_plain_case_is_the_default():
+    m = RepoScan.manifest_from_listing(PHL_LISTING, None, repo_name="CLEWs-PHL")
+    v12 = next(v for v in m["vintages"] if v["id"] == "v12")
+    names = {c["case"]: c for c in v12["cases"]}
+    assert set(names) == {"Philippines_v12", "Philippines_v12_ENV_LAND",
+                          "Philippines_v12_ENV_LAND_WATER_DIAGNOSTIC"}
+    assert names["Philippines_v12"]["recommended"] is True
+    assert "recommended" not in names["Philippines_v12_ENV_LAND"]
+
+
+def test_dates_order_versions_and_win_over_names():
+    dates = {
+        "Philippines_v12_CLEWs_build/muio": "2026-01-01T00:00:00Z",
+        "Philippines_v16_CLEWs_build/muio": "2026-03-01T00:00:00Z",
+        "Philippines_v36_CLEWs_build/muio": "2026-08-01T00:00:00Z",
+        "Philippines_vIS2_CLEWs_build/muio": "2026-09-01T00:00:00Z",
+    }
+    m = RepoScan.manifest_from_listing(PHL_LISTING, dates, repo_name="CLEWs-PHL")
+    assert m["ordering"] == "date"
+    assert [v["id"] for v in m["vintages"]] == ["vIS2", "v36", "v16", "v12"]
+    assert m["vintages"][0]["last_changed"] == "2026-09-01T00:00:00Z"
+    # a missing date for any folder means the dates cannot be trusted for ordering
+    partial = dict(dates)
+    del partial["Philippines_v16_CLEWs_build/muio"]
+    assert RepoScan.manifest_from_listing(PHL_LISTING, partial, repo_name="CLEWs-PHL")["ordering"] == "name"
+
+
+def test_fiji_layout_patch_releases_collapse_to_the_highest():
+    listing = [
+        "Fiji_CLEWs_Global/muio/SHA256SUMS",
+        "Fiji_CLEWs_Global/muio/Fiji_CLEWs_Global_raw-v1.0.0_MUIO.zip",
+        "Fiji_v2.9_CLEWs_build/muio/SHA256SUMS",
+        "Fiji_v2.9_CLEWs_build/muio/Fiji_v2.9_v2.9.0_MUIO.zip",
+        "Fiji_v2_CLEWs_calibration/muio/SHA256SUMS",
+        "Fiji_v2_CLEWs_calibration/muio/Fiji_v2_v2.0.0_MUIO.zip",
+        "Fiji_v2_CLEWs_calibration/muio/Fiji_v2_v2.0.3_MUIO.zip",
+        "Fiji_v2_CLEWs_calibration/muio/Fiji_v2_v2.0.1_MUIO.zip",
+    ]
+    m = RepoScan.manifest_from_listing(listing, None, repo_name="CLEWs-FJI")
+    validate_manifest(m)
+    assert m["iso3"] == "FJI"
+    by_id = {v["id"]: v for v in m["vintages"]}
+    assert set(by_id) == {"v2.9", "v2", "Fiji"}      # Fiji_CLEWs_Global has no version token
+    assert [c["archive"] for c in by_id["v2"]["cases"]] == ["Fiji_v2_v2.0.3_MUIO.zip"]
+    assert by_id["v2"]["cases"][0]["case"] == "Fiji_v2"
+    assert by_id["Fiji"]["cases"][0]["case"] == "Fiji_CLEWs_Global"
+    # name ordering: v2.9 is newer than v2
+    assert m["vintages"].index(by_id["v2.9"]) < m["vintages"].index(by_id["v2"])
+
+
+def test_register_hints_win_over_derived_country_and_code():
+    m = RepoScan.manifest_from_listing(PHL_LISTING, None, repo_name="CLEWs-PHL",
+                                       iso3="PHL", name="Philippines (register)")
+    assert m["name"] == "Philippines (register)"
+
+
+def test_nothing_installable_is_a_clean_error():
+    with pytest.raises(ManifestError, match="No installable models"):
+        RepoScan.manifest_from_listing(["README.md", "docs/guide.pdf"], None, repo_name="Empty")
+
+
+def test_local_folder_without_manifest_is_scanned(tmp_path):
+    v1 = tmp_path / "Testland_v1_CLEWs_build" / "muio"
+    v2 = tmp_path / "Testland_v2_CLEWs_build" / "muio"
+    for d in (v1, v2):
+        d.mkdir(parents=True)
+        (d / "SHA256SUMS").write_text("")
+    (v1 / "Testland_v1_v1.0.0_MUIO.zip").write_bytes(b"zip")
+    (v2 / "Testland_v2_v2.0.0_MUIO.zip").write_bytes(b"zip")
+    (v2 / "Testland_v1_v1.0.0_MUIO.zip").write_bytes(b"zip")   # predecessor copy
+
+    source = CountrySource(source_type="local_path", local_path=str(tmp_path))
+    m = source.load_manifest()
+    assert m["discovered"] is True
+    assert m["name"] == "Testland"
+    assert [v["id"] for v in m["vintages"]] == ["v2", "v1"]
+    assert [c["case"] for c in m["vintages"][0]["cases"]] == ["Testland_v2"]
+
+
+def test_a_manifest_still_wins_when_present(tmp_path):
+    (tmp_path / "x" / "muio").mkdir(parents=True)
+    (tmp_path / "x" / "muio" / "SHA256SUMS").write_text("")
+    (tmp_path / "x" / "muio" / "Other.zip").write_bytes(b"zip")
+    (tmp_path / "clews-country.json").write_text(json.dumps({
+        "schema_version": 1, "iso3": "TST", "name": "Declared",
+        "vintages": [{"id": "d1", "dir": "x/muio", "cases": [{"case": "Declared", "archive": "Other.zip"}]}],
+    }))
+    m = CountrySource(source_type="local_path", local_path=str(tmp_path)).load_manifest()
+    assert m["name"] == "Declared"
+    assert "discovered" not in m
+
+
+def test_remote_scan_reads_a_git_repository_without_network(tmp_path, clews_state):
+    """A blobless clone of a local repository stands in for GitHub: the listing
+    and the per-folder dates come from git, newest version first."""
+    import os
+    import subprocess
+
+    def git(*args, cwd):
+        subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    git("init", "-q", "-b", "main", cwd=origin)
+    git("config", "user.email", "t@example.org", cwd=origin)
+    git("config", "user.name", "t", cwd=origin)
+    stamps = {"v1": "2026-01-01T00:00:00", "v3": "2026-03-01T00:00:00", "v2": "2026-02-01T00:00:00"}
+    for v, stamp in stamps.items():   # committed out of version order on purpose
+        d = origin / f"Testland_{v}_CLEWs_build" / "muio"
+        d.mkdir(parents=True)
+        (d / "SHA256SUMS").write_text("")
+        (d / f"Testland_{v}_{v}.0.0_MUIO.zip").write_bytes(b"zip")
+        git("add", ".", cwd=origin)
+        subprocess.run(["git", "commit", "-q", "-m", v], cwd=origin, check=True, capture_output=True,
+                       env={**os.environ, "GIT_AUTHOR_DATE": stamp, "GIT_COMMITTER_DATE": stamp})
+
+    m = RepoScan.scan_remote("Local", "Testland", "main", clone_url=str(origin))
+    assert m["discovered"] is True and m["ordering"] == "date"
+    assert [v["id"] for v in m["vintages"]] == ["v3", "v2", "v1"]
+    assert m["vintages"][0]["last_changed"].startswith("2026-03-01")
+    # the mirror is kept under the CLEWs state dir and the result is cached
+    assert (clews_state / "scan-cache" / "Local__Testland.git" / "HEAD").exists()
+    assert RepoScan._cache_read("Local/Testland@main")["vintages"][0]["id"] == "v3"
+
+
+def test_inspect_route_reports_a_detected_menu(client, tmp_path):
+    v = tmp_path / "Testland_v3_CLEWs_build" / "muio"
+    v.mkdir(parents=True)
+    (v / "SHA256SUMS").write_text("")
+    (v / "Testland_v3_v3.0.0_MUIO.zip").write_bytes(b"zip")
+    resp = client.post("/clews/inspectSource",
+                       json={"source_type": "local_path", "local_path": str(tmp_path)})
+    body = resp.get_json()
+    assert resp.status_code == 200, body
+    assert body["discovered"] is True
+    assert body["ordering"] in ("date", "name")
+    assert [v["id"] for v in body["vintages"]] == ["v3"]
+    assert body["vintages"][0]["cases"][0]["case"] == "Testland_v3"

--- a/tests/e2e/test_clews_install_page.py
+++ b/tests/e2e/test_clews_install_page.py
@@ -1,0 +1,124 @@
+"""
+Browser check for the CLEWs install page (#540): the route sets the shell mode,
+the Home page links to it, a country block renders from a repository's menu
+with installed models grouped by version, and adding a local repository without
+a manifest goes through the real discovery on the backend.
+
+Runs only when pytest-playwright is installed (the dedicated CI job); the plain
+pytest job skips this module.
+"""
+
+import pytest
+
+pytest.importorskip("pytest_playwright")
+from playwright.sync_api import expect
+
+from .test_shell_smoke import base_url  # noqa: F401  (session fixture: real server)
+
+expect.set_options(timeout=15_000)
+
+
+def test_route_sets_clews_mode_and_shows_page(page, base_url):
+    page.goto(f"{base_url}/#/ClewsInstall")
+    expect(page.locator("body.osy-mode-clews")).to_have_count(1)
+    expect(page.locator(".clw-page")).to_be_visible()
+    expect(page.locator(".clw-addblock")).to_be_visible()
+    expect(page.locator("#clwSource")).to_be_visible()
+
+
+def test_home_links_to_the_page(page, base_url):
+    page.goto(base_url)
+    page.locator("#osy-mb-clews").click()
+    expect(page.locator('a[href="#ClewsInstall"]')).to_be_visible()
+
+
+def test_country_block_shows_url_newest_and_installed_by_version(page, base_url):
+    page.goto(f"{base_url}/#/ClewsInstall")
+    expect(page.locator(".clw-page")).to_be_visible()
+    page.evaluate("""async () => {
+        const { default: ClewsInstall } = await import(new URL('App/Controller/ClewsInstall.js', location.href).href);
+        const menu = {
+            name: 'Philippines', iso3: 'PHL', discovered: true, ordering: 'date',
+            source: { type: 'repo_url', repo_url: 'https://github.com/EAPD-DRB/CLEWs-PHL' },
+            vintages: [
+                { id: 'vIS2', last_changed: '2026-09-01T00:00:00Z', cases: [{ case: 'Philippines_vIS2', recommended: true }] },
+                { id: 'v18', last_changed: '2026-07-01T00:00:00Z', cases: [{ case: 'Philippines_v18', recommended: true }] },
+                { id: 'v12', last_changed: '2026-01-01T00:00:00Z', cases: [
+                    { case: 'Philippines_v12', role: 'source', recommended: true },
+                    { case: 'Philippines_v12_ENV_LAND', role: 'env-land' }] },
+            ],
+        };
+        // what the machine holds: two v18 variants, one v12 layer, a stranger
+        const installed = ['Philippines_v18', 'Philippines_v18_GOLD', 'Philippines_v12_ENV_LAND', 'CLEWs Demo']
+            .map(n => ({ casename: n, source_type: 'unmanaged' }));
+        ClewsInstall.renderOne(menu, installed);
+    }""")
+    block = page.locator('.clw-country[data-key="test"]')
+    expect(block.locator(".clw-url")).to_have_text("github.com/EAPD-DRB/CLEWs-PHL")
+    expect(block.locator(".clw-badge").first).to_have_text("newer version available")
+    expect(block.locator(".clw-latest-text")).to_contain_text("vIS2")
+    expect(block.locator(".clw-latest-text")).to_contain_text("Philippines_vIS2")
+    expect(block.locator('[data-act="install-latest"]')).to_be_enabled()
+    # installed on this machine: under the repository, grouped by version, newest
+    # first -- v18 has two rows (the version named once), v12 one; every row has
+    # a labelled Delete; the stranger lands under other models at the end
+    installed = page.locator("#clwInstalled")
+    titles = installed.locator(".clw-have-title")
+    expect(titles).to_have_count(2)
+    expect(titles.nth(0)).to_contain_text("github.com/EAPD-DRB/CLEWs-PHL")
+    expect(titles.nth(1)).to_contain_text("Other models")
+    rows = installed.locator("tr[data-case]")
+    expect(rows).to_have_count(4)
+    expect(rows.nth(0).locator(".clw-vid")).to_have_text("v18")
+    expect(rows.nth(0)).to_contain_text("Philippines_v18")
+    expect(rows.nth(1).locator(".clw-vid")).to_have_count(0)
+    expect(rows.nth(1)).to_contain_text("Philippines_v18_GOLD")
+    expect(rows.nth(2).locator(".clw-vid")).to_have_text("v12")
+    expect(rows.nth(2)).to_contain_text("Philippines_v12_ENV_LAND")
+    expect(rows.nth(3)).to_contain_text("CLEWs Demo")
+    expect(installed.locator('[data-act="delete"]')).to_have_count(4)
+    expect(installed.locator('[data-act="delete"]').first).to_have_text("Delete")
+    # the page order: repositories, then add a repository, then installed
+    expect(page.locator(".clw-addblock")).to_be_visible()
+    order = page.evaluate("""() => {
+        const ids = ['clwCountries', 'clwAdded', 'clwInstalledBlock'].map(id => document.getElementById(id).getBoundingClientRect().top);
+        return ids[0] < ids[1] && ids[1] < ids[2];
+    }""")
+    assert order
+    # all versions is closed until asked, then lists every case newest first
+    expect(block.locator(".clw-all")).to_be_hidden()
+    block.locator('[data-act="toggle-all"]').click()
+    rows = block.locator(".clw-all tr[data-case]")
+    expect(rows).to_have_count(4)
+    expect(rows.nth(0)).to_contain_text("vIS2")
+    expect(rows.nth(0).locator(".clw-badge")).to_have_text("newest")
+    expect(rows.nth(1).locator(".clw-status")).to_have_text("installed here")
+    expect(rows.nth(1).locator("button")).to_be_disabled()
+
+
+def test_adding_a_local_repository_without_manifest_is_discovered(page, base_url, tmp_path):
+    for v in ("v1", "v2"):
+        d = tmp_path / f"Testland_{v}_CLEWs_build" / "muio"
+        d.mkdir(parents=True)
+        (d / "SHA256SUMS").write_text("")
+        (d / f"Testland_{v}_{v}.0.0_MUIO.zip").write_bytes(b"zip")
+
+    page.goto(f"{base_url}/#/ClewsInstall")
+    page.locator("#clwSource").fill(str(tmp_path))
+    page.locator("#clwLookup").click()
+
+    block = page.locator("#clwAdded .clw-country")
+    expect(block).to_have_count(1)
+    expect(block.locator(".clw-url")).to_contain_text(str(tmp_path))
+    expect(block.locator(".clw-latest-text")).to_contain_text("Testland_v2")
+    expect(block.locator(".clw-fine")).to_contain_text("read from the repository's contents")
+    expect(block.locator('[data-act="install-latest"]')).to_be_enabled()
+    block.locator('[data-act="toggle-all"]').click()
+    expect(block.locator(".clw-all tr[data-case]")).to_have_count(2)
+
+
+def test_folder_with_nothing_installable_reports_it(page, base_url, tmp_path):
+    page.goto(f"{base_url}/#/ClewsInstall")
+    page.locator("#clwSource").fill(str(tmp_path))
+    page.locator("#clwLookup").click()
+    expect(page.locator("#clwAdded .clw-err")).to_contain_text("No installable models")

--- a/tests/e2e/test_shell_smoke.py
+++ b/tests/e2e/test_shell_smoke.py
@@ -37,7 +37,9 @@ def _free_port():
 def base_url():
     """Real server on a free port, torn down after the session."""
     port = _free_port()
-    env = dict(os.environ, PORT=str(port))
+    # no country register: the CLEWs install page would otherwise fetch it from
+    # GitHub on every load, and a slow answer stalls the tests that follow
+    env = dict(os.environ, PORT=str(port), MUIOGO_CLEWS_CATALOG_URL="")
     proc = subprocess.Popen(
         [sys.executable, str(REPO_ROOT / "API" / "app.py")],
         cwd=REPO_ROOT, env=env,


### PR DESCRIPTION
Closes #540.

MUIOGO can install a CLEWs country model from its GitHub repository (#519), but only through the API. In the browser the only way to bring a model in is still to upload a zip by hand. This adds the page for it, reached from a new button on the Home page next to "Restore model".

**What the user sees**, organised by country, then version, then model:

- One block per country repository MUIOGO knows about. It shows the repository's address, the newest version and exactly which model **Install** adds, and whether this machine is up to date, behind, or has nothing from that repository yet. **All versions** lists every version the repository holds, newest first, for installing an older one on purpose. Progress shows on the block until the model is imported and appears with the others.
- **Add a repository**: paste the address of a repository not on the list (or a folder on this machine) and it appears as a block like the others.
- **Installed on this machine**: every model, grouped under the repository it came from and by version, each with a Delete button (asks first; removes the model the same way the Home page does). Models from no listed repository — the demo, uploads, copies — are listed at the end.

**Where the list of countries comes from.** MUIOGO now ships a short register, `scripts/clews-repos.json`, read from the main branch by default — the same arrangement OG-Core uses for its own register. Adding a country there is enough for every installation to offer it. The Philippines is the first entry.

**How MUIOGO knows what a repository ships.** It reads the repository itself, so a repository does not have to describe itself in a manifest (if it has one, that is used). A folder holding a checksum file and MUIO archives is a version; the version label, the folder's own archives and the model names are derived from the names, with the rules written down in one place (`RepoScan.py`). Newest means most recently changed in the repository's history. Remote repositories are read through a small git clone that carries history and file names but no file contents (a few hundred KB, no token, no request limit); it is kept under MUIOGO's state folder and refreshed on each visit.

**Tested.** Discovery rules against Philippines- and Fiji-shaped layouts, a git scan of a local repository, and the inspect endpoint on a folder without a manifest (all 343 tests pass). Five browser checks of the page alongside the shell's smoke test. Both real repositories, CLEWs-PHL and CLEWs-FJI, scanned correctly on a live installation; an install job runs, polls and fails cleanly when an archive is missing. One existing test changed meaning: a missing manifest now falls through to discovery instead of being an error.

**Not included on purpose:** update checks, cancelling an install, and renaming a model (the app has no rename endpoint).