### PR TITLE
Let MUIOGO update a locally-registered calibration when the clone is safe to pull

### DIFF
--- a/API/Classes/OGCore/InstallJob.py
+++ b/API/Classes/OGCore/InstallJob.py
@@ -395,8 +395,14 @@ class InstallJob:
     @classmethod
     def start_install(cls, *, source_type, country_id, country_name, repo_name,
                       dest_parent, catalog_key=None, repo_url=None, branch=None,
-                      package_name=None):
-        """Start a catalog or repo_url install. Returns the initial job dict."""
+                      package_name=None, record_as=None):
+        """Start a catalog or repo_url install. Returns the initial job dict.
+
+        record_as: source_type to write on the registry record when it differs from
+        the install mechanism. An update of a locally-registered clone runs through
+        the repo_url installer but must stay a local_path record, so the same
+        safety checks apply to its next update.
+        """
         def work(progress, log, cancel):
             return Installer.run_installer(
                 source_type=source_type, repo_name=repo_name,
@@ -407,7 +413,7 @@ class InstallJob:
 
         return cls._launch(
             country_id=country_id, country_name=country_name,
-            source_type=source_type, work_fn=work,
+            source_type=record_as or source_type, work_fn=work,
         )
 
     @classmethod

--- a/API/Classes/OGCore/Installer.py
+++ b/API/Classes/OGCore/Installer.py
@@ -202,6 +202,33 @@ class Installer:
             ),
         }
 
+    @classmethod
+    def local_clone_update_status(cls, local_path):
+        """Say whether MUIOGO may pull over a locally-registered clone.
+
+        A local folder is someone's checkout, so an automatic update is only safe
+        when nothing of theirs can be lost: every tracked file is unmodified, the
+        checked-out branch tracks a remote branch, and origin is known. Untracked
+        files are fine, a fast-forward pull never touches them. Returns
+        {updatable, reason}; reason is a short user-facing sentence when blocked.
+        """
+        try:
+            if cls._git(["rev-parse", "--git-dir"], local_path).returncode != 0:
+                return {"updatable": False, "reason": "The folder is not a git clone."}
+            if not cls.git_remote_url(local_path):
+                return {"updatable": False,
+                        "reason": "The clone has no origin remote to pull from."}
+            dirty = cls._git(["status", "--porcelain", "--untracked-files=no"], local_path)
+            if dirty.returncode != 0 or dirty.stdout.strip():
+                return {"updatable": False,
+                        "reason": "The folder has local changes to tracked files."}
+            if cls._git(["rev-parse", "--abbrev-ref", "@{u}"], local_path).returncode != 0:
+                return {"updatable": False,
+                        "reason": "The checked-out branch does not track a remote branch."}
+        except (OSError, subprocess.SubprocessError) as exc:
+            return {"updatable": False, "reason": f"Could not inspect the clone: {exc}"}
+        return {"updatable": True, "reason": None}
+
     # ── import verification ──────────────────────────────────────────────────
     @staticmethod
     def verify_import(python_path, package_name):

--- a/API/Routes/OGCore/OGCoreInstallRoute.py
+++ b/API/Routes/OGCore/OGCoreInstallRoute.py
@@ -416,22 +416,33 @@ def refreshCalibration():
 
     check_only = data.get("check_only", True)
     local_path = record.get("local_path")
+    is_local = record.get("source_type") == "local_path"
 
-    # A locally-registered calibration is the user's own clone (possibly with
-    # uncommitted work). Never git pull / rebuild over it automatically; a check is
-    # fine, but applying an update must be the user's own action outside MUIOGO.
-    if not check_only and record.get("source_type") == "local_path":
+    # A locally-registered calibration is the user's own clone. MUIOGO pulls over
+    # it only when nothing of theirs can be lost: tracked files clean, branch
+    # tracking its remote, origin known (see Installer.local_clone_update_status).
+    # Anything else stays the user's own action outside MUIOGO. The verdict is
+    # stored on the record so the card can offer or withhold the Update button.
+    clone = Installer.local_clone_update_status(local_path) if is_local else None
+    if not check_only and is_local and not clone["updatable"]:
         return _err(
-            "This calibration was registered from a local folder, so MUIOGO will not "
-            "update it automatically. Update that clone yourself, then refresh."
+            "This calibration was registered from a local folder and MUIOGO will not "
+            f"update it automatically: {clone['reason']} Update that clone yourself, "
+            "then check again."
         )
 
     if check_only:
         result = Installer.check_update(local_path)
         state = "update_available" if result["update_available"] else "installed"
-        CalibrationRegistry.update_fields(
-            country_id, install_state=state, last_checked_at=_now_iso(),
-        )
+        fields = {"install_state": state, "last_checked_at": _now_iso()}
+        # The clone may have been pulled by hand since the last install; the record
+        # must say what is actually checked out, not what was installed back then.
+        if result["local_commit_sha"]:
+            fields["commit_sha"] = result["local_commit_sha"]
+        if clone is not None:
+            fields["updatable"] = clone["updatable"]
+            fields["update_blocked_reason"] = clone["reason"]
+        CalibrationRegistry.update_fields(country_id, **fields)
         message = (
             "A newer version is available."
             if result["update_available"]
@@ -443,10 +454,13 @@ def refreshCalibration():
             "install_state": state,
             "local_commit_sha": result["local_commit_sha"],
             "remote_commit_sha": result["remote_commit_sha"],
+            "updatable": clone["updatable"] if clone is not None else True,
+            "update_blocked_reason": clone["reason"] if clone is not None else None,
             "message": message,
         }), 200
 
     # Apply an update: re-run the installer over the existing clone (pull + uv sync).
+    # A local_path record keeps that source_type so its next update is checked again.
     repo_url = record.get("repo_url")
     if not repo_url:
         return _err(
@@ -467,6 +481,7 @@ def refreshCalibration():
         dest_parent=str(path.parent),
         repo_url=repo_url,
         package_name=record.get("package_name"),
+        record_as="local_path" if is_local else None,
     )
     if job is None:
         return _err("An update is already running for this country.")

--- a/WebAPP/App/Controller/OGCore.js
+++ b/WebAPP/App/Controller/OGCore.js
@@ -180,7 +180,9 @@ export default class OGCore {
     }
 
     //register calibrations (catalog_key, no record) and repo_url customs are
-    //updatable by MUIOGO; a local_path record is not, the user owns that folder
+    //updatable by MUIOGO; a local_path record is too when the server found the
+    //clone safe to pull (record.updatable, set by Check for updates), otherwise
+    //the user owns that folder and the card says why
     static actionsHtml(c, record){
         let state = c.install_state;
         if (state == 'not_installed'){
@@ -199,8 +201,11 @@ export default class OGCore {
                     <button class="btn ogc-btn ogc-btn-ico" data-act="remove" title="Remove from MUIOGO"><i class="fa fa-times"></i></button>`;
         }
         if (state == 'update_available'){
-            if (record && record.source_type == 'local_path'){
-                return `<div class="ogc-updatenote" title="This calibration comes from a local folder. Update the folder yourself, then check again.">Update the local folder to get this version</div>
+            if (record && record.source_type == 'local_path' && !record.updatable){
+                let why = record.update_blocked_reason
+                    ? esc(record.update_blocked_reason) + ' Update the folder yourself, then check again.'
+                    : 'This calibration comes from a local folder. Update the folder yourself, then check again.';
+                return `<div class="ogc-updatenote" title="${why}">Update the local folder to get this version</div>
                         <button class="btn ogc-btn ogc-btn-line" data-act="check"><i class="fa fa-refresh"></i> Check again</button>
                         <button class="btn ogc-btn ogc-btn-ico" data-act="remove" title="Remove from MUIOGO"><i class="fa fa-times"></i></button>`;
             }

--- a/tests/ogc/test_install_refresh_local.py
+++ b/tests/ogc/test_install_refresh_local.py
@@ -1,0 +1,179 @@
+"""Updating a calibration registered from a local folder (issue #543).
+
+MUIOGO used to refuse every automatic update of a local_path record, and a check
+left the stored commit at the installed version even after the clone had been
+pulled by hand. Now a check records what is actually checked out and whether the
+clone is safe to pull (tracked files clean, branch tracking its remote), and an
+update is allowed exactly in that case. Uses real git repositories in tmp_path.
+"""
+import subprocess
+import time
+
+from Classes.OGCore.CalibrationRegistry import CalibrationRegistry
+from Classes.OGCore.InstallJob import InstallJob
+from Classes.OGCore.Installer import Installer
+
+
+def _git(args, cwd):
+    return subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "-c", "commit.gpgsign=false",
+         *args],
+        cwd=str(cwd), check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+
+def _clone_behind_origin(tmp_path):
+    """A bare origin, a clone of it, then one more commit on origin only."""
+    origin = tmp_path / "origin.git"
+    origin.mkdir()
+    _git(["init", "--bare", "-q", "-b", "main"], origin)
+    seed = tmp_path / "seed"
+    _git(["clone", "-q", str(origin), str(seed)], tmp_path)
+    (seed / "pyproject.toml").write_text('[project]\nname = "ogeth"\nversion = "0.1.0"\n')
+    _git(["add", "-A"], seed)
+    _git(["commit", "-q", "-m", "one"], seed)
+    _git(["push", "-q", "origin", "HEAD:main"], seed)
+    clone = tmp_path / "OG-ETH"
+    _git(["clone", "-q", str(origin), str(clone)], tmp_path)
+    (seed / "pyproject.toml").write_text('[project]\nname = "ogeth"\nversion = "0.2.0"\n')
+    _git(["commit", "-q", "-am", "two"], seed)
+    _git(["push", "-q", "origin", "HEAD:main"], seed)
+    return clone
+
+
+def _register_local(clone):
+    CalibrationRegistry.upsert({
+        "country_id": "ETH", "country_name": "Ethiopia", "source_type": "local_path",
+        "local_path": str(clone), "venv_path": str(clone / ".venv"),
+        "python_path": str(clone / ".venv/bin/python"), "package_name": "ogeth",
+        "repo_url": Installer.git_remote_url(clone), "commit_sha": "stale",
+        "install_state": "installed", "installed_at": "2026-01-01T00:00:00Z",
+    })
+
+
+def _check(client):
+    resp = client.post("/ogc/refreshCalibration",
+                       json={"country_id": "ETH", "check_only": True})
+    assert resp.status_code == 200, resp.get_json()
+    return resp.get_json()
+
+
+def _apply(client):
+    return client.post("/ogc/refreshCalibration",
+                       json={"country_id": "ETH", "check_only": False})
+
+
+def test_check_records_checked_out_commit_and_updatable(client, tmp_path):
+    clone = _clone_behind_origin(tmp_path)
+    _register_local(clone)
+
+    body = _check(client)
+
+    assert body["install_state"] == "update_available"
+    assert body["updatable"] is True and body["update_blocked_reason"] is None
+    record = CalibrationRegistry.get("ETH")
+    assert record["commit_sha"] == Installer.git_head_sha(clone), \
+        "the record says what is checked out, not what was installed"
+    assert record["updatable"] is True
+
+
+def test_check_after_a_manual_pull_moves_the_recorded_commit(client, tmp_path):
+    clone = _clone_behind_origin(tmp_path)
+    _register_local(clone)
+    _git(["pull", "-q", "--ff-only"], clone)
+
+    body = _check(client)
+
+    assert body["install_state"] == "installed"
+    assert CalibrationRegistry.get("ETH")["commit_sha"] == Installer.git_head_sha(clone)
+
+
+def test_clean_tracking_clone_can_be_updated(client, tmp_path, monkeypatch):
+    clone = _clone_behind_origin(tmp_path)
+    _register_local(clone)
+    started = {}
+    monkeypatch.setattr(
+        InstallJob, "start_install",
+        classmethod(lambda cls, **kw: started.update(kw) or
+                    {"install_id": "install_2026_01_01_001", "install_state": "checking"}),
+    )
+
+    resp = _apply(client)
+
+    assert resp.status_code == 200, resp.get_json()
+    assert started["source_type"] == "repo_url", "runs through the repo installer"
+    assert started["record_as"] == "local_path", "but stays a local_path record"
+    assert started["repo_url"] == Installer.git_remote_url(clone)
+    assert started["dest_parent"] == str(clone.parent) and started["repo_name"] == "OG-ETH"
+
+
+def test_clone_with_local_changes_is_not_updated(client, tmp_path, monkeypatch):
+    clone = _clone_behind_origin(tmp_path)
+    _register_local(clone)
+    (clone / "pyproject.toml").write_text("# edited by hand\n")
+    monkeypatch.setattr(InstallJob, "start_install",
+                        classmethod(lambda cls, **kw: (_ for _ in ()).throw(AssertionError)))
+
+    body = _check(client)
+    assert body["updatable"] is False and "local changes" in body["update_blocked_reason"]
+    assert CalibrationRegistry.get("ETH")["updatable"] is False
+
+    resp = _apply(client)
+    assert resp.status_code == 400
+    assert "local changes" in resp.get_json()["message"]
+
+
+def test_untracked_files_do_not_block_an_update(client, tmp_path, monkeypatch):
+    clone = _clone_behind_origin(tmp_path)
+    _register_local(clone)
+    (clone / ".venv").mkdir()
+    (clone / "scratch.ipynb").write_text("{}")
+    monkeypatch.setattr(
+        InstallJob, "start_install",
+        classmethod(lambda cls, **kw: {"install_id": "install_2026_01_01_001",
+                                       "install_state": "checking"}),
+    )
+
+    assert _check(client)["updatable"] is True
+    assert _apply(client).status_code == 200
+
+
+def test_detached_clone_is_not_updated(client, tmp_path):
+    clone = _clone_behind_origin(tmp_path)
+    _register_local(clone)
+    _git(["checkout", "-q", "--detach"], clone)
+
+    body = _check(client)
+    assert body["updatable"] is False and "track" in body["update_blocked_reason"]
+
+    resp = _apply(client)
+    assert resp.status_code == 400
+    assert "track" in resp.get_json()["message"]
+
+
+def test_update_job_keeps_the_local_path_source_type(tmp_path, monkeypatch):
+    clone = _clone_behind_origin(tmp_path)
+    _register_local(clone)
+    monkeypatch.setattr(
+        Installer, "run_installer",
+        classmethod(lambda cls, **kw: {
+            "ok": True, "local_path": str(clone), "venv_path": str(clone / ".venv"),
+            "python_path": str(clone / ".venv/bin/python"), "package_name": "ogeth",
+            "repo_url": Installer.git_remote_url(clone), "commit_sha": "new",
+        }),
+    )
+
+    job = InstallJob.start_install(
+        source_type="repo_url", country_id="ETH", country_name="Ethiopia",
+        repo_name="OG-ETH", dest_parent=str(tmp_path), repo_url="x",
+        record_as="local_path",
+    )
+    assert job is not None
+    end = time.time() + 10
+    while InstallJob.is_country_active("ETH") and time.time() < end:
+        time.sleep(0.02)
+
+    record = CalibrationRegistry.get("ETH")
+    assert record["install_state"] == "installed"
+    assert record["source_type"] == "local_path", "next update is safety-checked again"
+    assert record["commit_sha"] == "new" and record.get("last_updated_at")


### PR DESCRIPTION
## Summary

- What changed: "Check for updates" on an OG-Core card now records the commit that is actually checked out, and whether a locally-registered clone is safe to pull (tracked files unmodified, branch tracking its remote, origin known). When it is, the card offers the Update button and the update runs through the usual installer path, with the record staying a local-folder record so the next update is checked the same way. When it is not, the card and the refusal message say why. Untracked files such as a `.venv` do not count as local changes.
- Why: models set up by an installer are registered from a local folder, and MUIOGO refused to update any local folder, so the card could only say "update the local folder" with no way to do it. A check also left the recorded commit at the installed version after the clone had been pulled by hand.

## Linked issue (if applicable)

- Closes #543

## Validation

- [x] Tests added/updated: `tests/ogc/test_install_refresh_local.py` (7 tests against real temporary git repositories: check records the checked-out commit; a manual pull moves it; a clean tracking clone can be updated and keeps its `local_path` source type; local changes and a detached checkout are refused with a reason; untracked files do not block). `pytest tests/ogc tests/ogcore`: 197 passed.
- [x] Manual verification: ran the server against a temporary registry holding a local clone one commit behind its origin. Check for updates returned `update_available`, `updatable: true`, and the registry's `commit_sha` moved to the clone's HEAD; the card showed the Update button. After editing a tracked file, the check returned `updatable: false` with "The folder has local changes to tracked files.", the apply call returned 400 with that reason, and the card showed the "Update the local folder" note with "Check again".

## Checklist

- [x] Change is scoped — no unrelated refactors
- [x] Branched from `main`; PR targets `EAPD-DRB/MUIOGO:main`
- [x] Docs updated for any setup, workflow, or architecture change (none needed: no user docs describe this page yet; the card text carries the guidance)
