### PR TITLE
Fix hidden model filtering and alphabetical ordering

### DIFF
--- a/API/Routes/Case/CaseRoute.py
+++ b/API/Routes/Case/CaseRoute.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, jsonify, request, session, send_file
 import os
+import stat
 from pathlib import Path
 import shutil
 import pandas as pd
@@ -13,6 +14,15 @@ from Classes.Clews.Provenance import Provenance
 from utils import validate_json_fields
 
 case_api = Blueprint('CaseRoute', __name__)
+
+# Helper to detect hidden directories using platform-specific flags and naming rules
+def _is_hidden_directory(entry):
+    metadata = entry.stat()
+    if os.name == 'nt':
+        return bool(metadata.st_file_attributes & stat.FILE_ATTRIBUTE_HIDDEN)
+    return entry.name.startswith('.') or bool(
+        getattr(metadata, 'st_flags', 0) & getattr(stat, 'UF_HIDDEN', 0)
+    )
 
 @case_api.route("/initSyncS3", methods=['GET'])
 def initSyncS3():
@@ -35,7 +45,9 @@ def initSyncS3():
 @case_api.route("/getCases", methods=['GET'])
 def getCases():
     try:
-        cases = [ f.name for f in os.scandir(Config.DATA_STORAGE) if f.is_dir() ]
+        with os.scandir(Config.DATA_STORAGE) as entries:
+            cases = [entry.name for entry in entries if entry.is_dir() and not _is_hidden_directory(entry)]
+        cases.sort(key=lambda name: (name.casefold(), name))
         return jsonify(cases), 200
     except(IOError):
         return jsonify('No existing cases!'), 404

--- a/WebAPP/App/Controller/Home.js
+++ b/WebAPP/App/Controller/Home.js
@@ -131,8 +131,7 @@ export default class Home {
                 if(response.status_code=="success"){
                     Message.bigBoxSuccess('Copy message', response.message, 3000);
                     //REFRESH
-                    Html.apendModel(casename+'_copy');
-                    Html.appendCasePicker(casename+'_copy', null)
+                    Base.refreshCaseLists();
                     if (Base.AWS_SYNC == 1){
                         SyncS3.deleteResultsPreSync(casename)
                         .then(response =>{
@@ -150,7 +149,7 @@ export default class Home {
             });
         });
 
-        //get descrition
+        //get description
         $("#cases").off('click.homeDescription', '.descriptionPS');
         $("#cases").on('click.homeDescription', '.descriptionPS', function(e){
             //e.stopImmediatePropagation();

--- a/WebAPP/Classes/Base.Class.js
+++ b/WebAPP/Classes/Base.Class.js
@@ -100,6 +100,19 @@ export class Base {
         });
     }
 
+    // Update the model list and dropdown after copying or uploading a model
+    static refreshCaseLists() {
+        return Promise.all([Base.getCaseStudies(), Base.getSession()])
+            .then(([cases, response]) => {
+                Html.renderCasePicker(cases, response.session);
+                if ($('#cases').length) {
+                    Html.renderModels(cases, response.session);
+                    $('#CaseSearch').trigger('keyup');
+                }
+            })
+            .catch(error => Message.danger(error));
+    }
+
     static getResultCSV(casename, caserunname) {
         return new Promise((resolve, reject) => {
             $.ajax({
@@ -235,7 +248,7 @@ export class Base {
         const handleCaseRestoreSuccess = function (result, showWarning = false) {
             let casename = result.casename;
             if (casename) {
-                Html.apendModel(casename);
+                Base.refreshCaseLists();
             }
 
             Message.bigBoxSuccess("Upload response", result.message, null);


### PR DESCRIPTION
## Summary
- What changed: Added a helper to exclude hidden folders using the Windows Hidden attribute `FILE_ATTRIBUTE_HIDDEN`, the macOS hidden flag `UF_HIDDEN` and dot-prefixed names `.`, or dot-prefixed names on Linux. Model names are sorted alphabetically, ignoring capitalization, and the list refreshes after copying or uploading a model.
- Why: Prevent hidden folders from appearing as models and make models easier to find.

## Linked issue (if applicable)
- Closes #541 

## Validation
- [x] Tests added/updated (or not applicable)
- [x] Manual verification steps documented, with evidence where relevant
-Verified alphabetical ordering on Windows.
-Marked a temporary model folder as Hidden and confirmed it disappeared after refreshing Home.
-Removed the Hidden attribute and confirmed the model reappeared.

## Checklist
- [x] Change is scoped — no unrelated refactors
- [x] Branched from `main`; PR targets `EAPD-DRB/MUIOGO:main`
- [x] Docs updated for any setup, workflow, or architecture change
